### PR TITLE
Fix: 레스토랑 리스트 api 실제 데이터를 반환하도록 수정

### DIFF
--- a/app-api/src/main/java/com/tasteam/domain/restaurant/controller/RestaurantController.java
+++ b/app-api/src/main/java/com/tasteam/domain/restaurant/controller/RestaurantController.java
@@ -1,12 +1,12 @@
 package com.tasteam.domain.restaurant.controller;
 
-import java.util.List;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import com.tasteam.domain.restaurant.controller.docs.RestaurantControllerDocs;
+import com.tasteam.domain.restaurant.dto.request.NearbyRestaurantQueryParams;
 import com.tasteam.domain.restaurant.dto.request.RestaurantCreateRequest;
 import com.tasteam.domain.restaurant.dto.request.RestaurantReviewListRequest;
 import com.tasteam.domain.restaurant.dto.request.RestaurantUpdateRequest;
@@ -20,9 +20,11 @@ import com.tasteam.global.dto.api.SuccessResponse;
 import com.tasteam.global.security.jwt.annotation.CurrentUser;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
+@Validated
 @RestController
 @RequestMapping("/api/v1/restaurants")
 public class RestaurantController implements RestaurantControllerDocs {
@@ -30,125 +32,15 @@ public class RestaurantController implements RestaurantControllerDocs {
 	private final RestaurantService restaurantService;
 	private final ReviewService reviewService;
 
-	/**
-	 * 프론트 연동 테스트용 mock 목록 API.
-	 * 실제 쿼리 파라미터가 없어도 동작하도록 모두 optional로 받습니다.
-	 */
 	@ResponseStatus(HttpStatus.OK)
 	@GetMapping
-	public SuccessResponse<CursorPageResponse<RestaurantListItem>> getRestaurantsMock(
-		@RequestParam(required = false)
-		Double latitude,
-		@RequestParam(required = false)
-		Double longitude,
-		@RequestParam(required = false)
-		Double lat,
-		@RequestParam(required = false)
-		Double lng,
-		@RequestParam(required = false)
-		Integer size,
-		@RequestParam(required = false)
-		String cursor,
-		@RequestParam(required = false)
-		String category) {
+	public SuccessResponse<CursorPageResponse<RestaurantListItem>> getRestaurants(
+		@RequestParam @Positive
+		Long groupId,
+		@Valid @ModelAttribute
+		NearbyRestaurantQueryParams queryParams) {
 
-		List<RestaurantListItem> items = List.of(
-			new RestaurantListItem(
-				6001L,
-				"로컬 맛집",
-				"서울특별시 마포구 합정동 123-45",
-				120.0,
-				List.of("한식"),
-				List.of(new RestaurantImageDto(6001L, "https://picsum.photos/seed/tasteam-6001/640/480"))),
-			new RestaurantListItem(
-				6002L,
-				"로컬 카페",
-				"서울특별시 강남구 역삼동 222-11",
-				340.0,
-				List.of("카페"),
-				List.of(new RestaurantImageDto(6002L, "https://picsum.photos/seed/tasteam-6002/640/480"))),
-			new RestaurantListItem(
-				8001L,
-				"로컬 양식당",
-				"서울특별시 종로구 세종대로 1",
-				560.0,
-				List.of("양식"),
-				List.of(new RestaurantImageDto(8001L, "https://picsum.photos/seed/tasteam-8001/640/480"))),
-			new RestaurantListItem(
-				8002L,
-				"로컬 분식집",
-				"서울특별시 중구 명동 2",
-				780.0,
-				List.of("분식"),
-				List.of(new RestaurantImageDto(8002L, "https://picsum.photos/seed/tasteam-8002/640/480"))),
-			new RestaurantListItem(
-				8003L,
-				"로컬 베이커리",
-				"서울특별시 용산구 이태원 3",
-				910.0,
-				List.of("베이커리"),
-				List.of(new RestaurantImageDto(8003L, "https://picsum.photos/seed/tasteam-8003/640/480"))),
-			new RestaurantListItem(
-				8004L,
-				"로컬 치킨",
-				"서울특별시 성동구 왕십리 4",
-				1040.0,
-				List.of("치킨"),
-				List.of(new RestaurantImageDto(8004L, "https://picsum.photos/seed/tasteam-8004/640/480"))),
-			new RestaurantListItem(
-				8005L,
-				"로컬 피자",
-				"서울특별시 광진구 건대입구 5",
-				1270.0,
-				List.of("피자"),
-				List.of(new RestaurantImageDto(8005L, "https://picsum.photos/seed/tasteam-8005/640/480"))),
-			new RestaurantListItem(
-				8006L,
-				"로컬 아시아",
-				"서울특별시 마포구 홍대입구 6",
-				1490.0,
-				List.of("아시아"),
-				List.of(new RestaurantImageDto(8006L, "https://picsum.photos/seed/tasteam-8006/640/480"))),
-			new RestaurantListItem(
-				8007L,
-				"로컬 한식",
-				"서울특별시 영등포구 여의도 7",
-				1720.0,
-				List.of("한식"),
-				List.of(new RestaurantImageDto(8007L, "https://picsum.photos/seed/tasteam-8007/640/480"))),
-			new RestaurantListItem(
-				8008L,
-				"로컬 일식",
-				"서울특별시 서초구 서초동 8",
-				1960.0,
-				List.of("일식"),
-				List.of(new RestaurantImageDto(8008L, "https://picsum.photos/seed/tasteam-8008/640/480"))),
-			new RestaurantListItem(
-				8009L,
-				"로컬 중식",
-				"서울특별시 강서구 마곡 9",
-				2210.0,
-				List.of("중식"),
-				List.of(new RestaurantImageDto(8009L, "https://picsum.photos/seed/tasteam-8009/640/480"))),
-			new RestaurantListItem(
-				8010L,
-				"로컬 카페 2",
-				"서울특별시 송파구 잠실 10",
-				2480.0,
-				List.of("카페"),
-				List.of(new RestaurantImageDto(8010L, "https://picsum.photos/seed/tasteam-8010/640/480"))));
-
-		int pageSize = (size == null || size < 1) ? items.size() : Math.min(size, items.size());
-		List<RestaurantListItem> pageItems = items.subList(0, pageSize);
-
-		CursorPageResponse<RestaurantListItem> response = new CursorPageResponse<>(
-			pageItems,
-			new CursorPageResponse.Pagination(
-				null,
-				pageSize < items.size(),
-				pageSize));
-
-		return SuccessResponse.success(response);
+		return SuccessResponse.success(restaurantService.getGroupRestaurants(groupId, queryParams));
 	}
 
 	@ResponseStatus(HttpStatus.OK)

--- a/app-api/src/main/java/com/tasteam/domain/restaurant/controller/docs/RestaurantControllerDocs.java
+++ b/app-api/src/main/java/com/tasteam/domain/restaurant/controller/docs/RestaurantControllerDocs.java
@@ -4,6 +4,7 @@ import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import com.tasteam.domain.restaurant.dto.request.NearbyRestaurantQueryParams;
 import com.tasteam.domain.restaurant.dto.request.RestaurantCreateRequest;
 import com.tasteam.domain.restaurant.dto.request.RestaurantReviewListRequest;
 import com.tasteam.domain.restaurant.dto.request.RestaurantUpdateRequest;
@@ -25,27 +26,18 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Positive;
 
 @Tag(name = "Restaurant", description = "음식점 조회/관리 API")
 public interface RestaurantControllerDocs {
 
-	@Operation(summary = "음식점 목록 조회 (Mock)", description = "프론트 연동 테스트용 Mock 음식점 목록을 조회합니다.")
+	@Operation(summary = "그룹 음식점 목록 조회", description = "지정한 그룹과 위치 조건으로 주변 음식점을 커서 기반으로 조회합니다.")
 	@ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(schema = @Schema(implementation = CursorPageResponse.class)))
-	SuccessResponse<CursorPageResponse<RestaurantListItem>> getRestaurantsMock(
-		@Parameter(description = "위도", example = "37.5665") @RequestParam(required = false)
-		Double latitude,
-		@Parameter(description = "경도", example = "126.9780") @RequestParam(required = false)
-		Double longitude,
-		@Parameter(description = "위도 (축약)", example = "37.5665") @RequestParam(required = false)
-		Double lat,
-		@Parameter(description = "경도 (축약)", example = "126.9780") @RequestParam(required = false)
-		Double lng,
-		@Parameter(description = "페이지 크기", example = "20") @RequestParam(required = false)
-		Integer size,
-		@Parameter(description = "커서", example = "cursor") @RequestParam(required = false)
-		String cursor,
-		@Parameter(description = "카테고리", example = "한식") @RequestParam(required = false)
-		String category);
+	SuccessResponse<CursorPageResponse<RestaurantListItem>> getRestaurants(
+		@Parameter(description = "그룹 ID", example = "2001") @RequestParam @Positive
+		Long groupId,
+		@ParameterObject
+		NearbyRestaurantQueryParams queryParams);
 
 	@Operation(summary = "음식점 상세 조회", description = "음식점 상세 정보를 조회합니다.")
 	@ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(schema = @Schema(implementation = RestaurantDetailResponse.class)))


### PR DESCRIPTION
## 📌 PR 요약

<!--
  한 줄 요약에는 이 PR이 어떤 문제를 해결하는지, 어떤 개선을 하는지를 담아주세요.
  예: "예약 완료 모달에서 실패 시에도 재시도 버튼을 보여줘 고객이 다시 시도하게 합니다."
-->
* 레스토랑 리스트 api 실제 데이터를 반환 하도록 수정

<!--
  연관 이슈에는 closes/#123 또는 관련 문서를 적고, 왜 연결되는지를 짧게 덧붙이세요.
  예: "closes #123 (오류 로그가 계속 누락되는 현상)"
-->
* close #

---

## ➕ 추가된 기능

<!--
  새로운 기능을 소개하세요. 무엇이 새롭게 생기는지, 어떤 화면/API가 추가되는지를 기술하고 예시를 덧붙이면 좋습니다.
  예: "관리자 설정에서 `예약 알림` 토글을 추가하여 알림을 켜고 끌 수 있게 함."
-->
* 

---

## 🛠️ 수정/변경사항

<!--
  기존 기능 변경, 버그 수정, 리팩토링 등을 나열하세요. 영향 범위도 함께 쓰면 리뷰어가 이해하기 쉽습니다.
  예: "- 예약 API 응답에 `status` 필드를 추가함", "- 기존 실패율 경고 문구 변경"
-->
* 

---

## 🧪 테스트

<!--
  직접 수행한 테스트와 확인한 결과를 적어주세요. 명시하면 재현/검증이 쉬워집니다.
  예: "- [x] 로컬에서 예약 생성 확인", "- [ ] 로컬 테스트 미수행 (사유: 외부 서비스 필요)"
-->
* [ ] 로컬 테스트
* [ ] API 호출 확인
* [ ] 테스트 코드 추가/수정
* [ ] 테스트 생략 (사유: )

---

## ✅ 남은 작업

<!--
  아직 완료되지 않은 작업이나 사후에 처리해야 할 항목을 정리하세요. 검토자/다음 작업자에게 힌트가 됩니다.
-->
* [ ] 

---

## ⚠️ 리뷰 참고사항

<!--
  리뷰할 때 특히 봐야 하는 부분이나 위험도가 있는 변경 내용, 세부 조율점 등을 적어주세요.
  예: "동시성 문제로 race condition이 생길 수 있어 lock을 건 위치를 봐 주세요."
-->
* 
