### PR TITLE
🐛 fix: 하위그룹목록 권한 수정, 하위그룹 목록 응답 필드 추가

### DIFF
--- a/app-api/src/main/java/com/tasteam/domain/subgroup/dto/SubgroupListItem.java
+++ b/app-api/src/main/java/com/tasteam/domain/subgroup/dto/SubgroupListItem.java
@@ -2,6 +2,8 @@ package com.tasteam.domain.subgroup.dto;
 
 import java.time.Instant;
 
+import com.tasteam.domain.subgroup.type.SubgroupJoinType;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,5 +20,6 @@ public class SubgroupListItem {
 	private String description;
 	private Integer memberCount;
 	private String profileImageUrl;
+	private SubgroupJoinType joinType;
 	private Instant createdAt;
 }

--- a/app-api/src/main/java/com/tasteam/domain/subgroup/repository/SubgroupRepository.java
+++ b/app-api/src/main/java/com/tasteam/domain/subgroup/repository/SubgroupRepository.java
@@ -31,6 +31,7 @@ public interface SubgroupRepository extends JpaRepository<Subgroup, Long> {
 			s.description,
 			s.memberCount,
 			s.profileImageUrl,
+			s.joinType,
 			s.createdAt
 		)
 		from Subgroup s
@@ -62,6 +63,7 @@ public interface SubgroupRepository extends JpaRepository<Subgroup, Long> {
 			s.description,
 			s.memberCount,
 			s.profileImageUrl,
+			s.joinType,
 			s.createdAt
 		)
 		from SubgroupMember sm

--- a/app-api/src/main/java/com/tasteam/domain/subgroup/service/SubgroupService.java
+++ b/app-api/src/main/java/com/tasteam/domain/subgroup/service/SubgroupService.java
@@ -76,7 +76,6 @@ public class SubgroupService {
 
 	@Transactional(readOnly = true)
 	public SubgroupListResponse getGroupSubgroups(Long groupId, Long memberId, String cursor, Integer size) {
-		validateAuthenticated(memberId);
 		getGroup(groupId);
 
 		int resolvedSize = resolveSize(size);

--- a/app-api/src/main/java/com/tasteam/global/security/common/constants/ApiEndpointSecurityPolicy.java
+++ b/app-api/src/main/java/com/tasteam/global/security/common/constants/ApiEndpointSecurityPolicy.java
@@ -44,6 +44,8 @@ public final class ApiEndpointSecurityPolicy {
 			permit(GET, ApiEndpoints.GROUPS_REVIEWS),
 			permit(GET, ApiEndpoints.SUBGROUPS_REVIEWS),
 			permit(GET, ApiEndpoints.MEMBERS_REVIEWS),
+			permit(GET, ApiEndpoints.GROUPS_DETAIL),
+			permit(GET, ApiEndpoints.GROUPS_SUBGROUPS),
 
 			// Swagger
 			permit(GET, ApiEndpoints.SWAGGER_UI),

--- a/app-api/src/main/java/com/tasteam/global/security/common/constants/ApiEndpoints.java
+++ b/app-api/src/main/java/com/tasteam/global/security/common/constants/ApiEndpoints.java
@@ -63,6 +63,7 @@ public final class ApiEndpoints {
 	public static final String GROUPS_ALL = GROUPS + ALL;
 	public static final String GROUPS_DETAIL = GROUPS + DETAIL;
 	public static final String GROUPS_REVIEWS = GROUPS_DETAIL + "/reviews";
+	public static final String GROUPS_SUBGROUPS = GROUPS + "/*/subgroups";
 
 	// Subgroup
 	public static final String SUBGROUPS = API_V1 + "/subgroups";


### PR DESCRIPTION

  ## 📌 PR 요약

  - 한 줄 요약: 하위그룹 목록 API에서 권한 검증을 제거하고 응답에 joinType 필드를 추가하며, 그룹 상세/하위그룹
    목록 엔드포인트를 공개 접근으로 변경
  - 연관 이슈
      - 없음

  ———

  ## ➕ 추가된 기능

  - 하위그룹 목록 응답에 joinType 필드가 포함됩니다.

  ———

  ## 🛠️ 수정/변경사항

  - 하위그룹 목록 조회에서 인증 검증 제거(비로그인 접근 허용).
  - 그룹 상세(GROUPS_DETAIL) 및 하위그룹 목록(GROUPS_SUBGROUPS) 엔드포인트 공개 접근 허용.
  - GROUPS_SUBGROUPS 엔드포인트 상수 추가.

  ———

  ## 🧪 테스트

  - [ ] 로컬 테스트
  - [ ] API 호출 확인
  - [ ] 테스트 코드 추가/수정
  - [x] 테스트 생략 (사유: 로컬/호출 테스트 미수행)

  ———

  ## ✅ 남은 작업

  - [ ] 없음

  ———

  ## ⚠️ 리뷰 참고사항

  - 하위그룹 목록이 비로그인에도 조회 가능

