### PR TITLE
🐛 fix: 하위그룹 응답 dto수정 및 목록 조회 권한 수정

### DIFF
--- a/app-api/src/main/java/com/tasteam/domain/subgroup/dto/SubgroupListItem.java
+++ b/app-api/src/main/java/com/tasteam/domain/subgroup/dto/SubgroupListItem.java
@@ -2,6 +2,8 @@ package com.tasteam.domain.subgroup.dto;
 
 import java.time.Instant;
 
+import com.tasteam.domain.subgroup.type.SubgroupJoinType;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,5 +20,6 @@ public class SubgroupListItem {
 	private String description;
 	private Integer memberCount;
 	private String profileImageUrl;
+	private SubgroupJoinType joinType;
 	private Instant createdAt;
 }

--- a/app-api/src/main/java/com/tasteam/domain/subgroup/repository/SubgroupRepository.java
+++ b/app-api/src/main/java/com/tasteam/domain/subgroup/repository/SubgroupRepository.java
@@ -31,6 +31,7 @@ public interface SubgroupRepository extends JpaRepository<Subgroup, Long> {
 			s.description,
 			s.memberCount,
 			s.profileImageUrl,
+			s.joinType,
 			s.createdAt
 		)
 		from Subgroup s
@@ -65,6 +66,7 @@ public interface SubgroupRepository extends JpaRepository<Subgroup, Long> {
 			s.description,
 			s.memberCount,
 			s.profileImageUrl,
+			s.joinType,
 			s.createdAt
 		)
 		from SubgroupMember sm

--- a/app-api/src/main/java/com/tasteam/global/security/common/constants/ApiEndpointSecurityPolicy.java
+++ b/app-api/src/main/java/com/tasteam/global/security/common/constants/ApiEndpointSecurityPolicy.java
@@ -48,6 +48,8 @@ public final class ApiEndpointSecurityPolicy {
 			permit(GET, ApiEndpoints.GROUPS_REVIEWS),
 			permit(GET, ApiEndpoints.SUBGROUPS_REVIEWS),
 			permit(GET, ApiEndpoints.MEMBERS_REVIEWS),
+			permit(GET, ApiEndpoints.GROUPS_DETAIL),
+			permit(GET, ApiEndpoints.GROUPS_SUBGROUPS),
 
 			// 검색 (토큰 유무 무관)
 			permit(POST, ApiEndpoints.SEARCH),

--- a/app-api/src/main/java/com/tasteam/global/security/common/constants/ApiEndpoints.java
+++ b/app-api/src/main/java/com/tasteam/global/security/common/constants/ApiEndpoints.java
@@ -67,6 +67,7 @@ public final class ApiEndpoints {
 	public static final String GROUPS_ALL = GROUPS + ALL;
 	public static final String GROUPS_DETAIL = GROUPS + DETAIL;
 	public static final String GROUPS_REVIEWS = GROUPS_DETAIL + "/reviews";
+	public static final String GROUPS_SUBGROUPS = GROUPS + "/*/subgroups";
 
 	// Subgroup
 	public static final String SUBGROUPS = API_V1 + "/subgroups";


### PR DESCRIPTION

  ## 📌 PR 요약

  - 그룹 상세/하위그룹 조회를 공개 접근 가능하게 하고, 하위그룹 목록 응답에 joinType을 포함
  - 연관 이슈
      - 없음

  ———

  ## ➕ 추가된 기능

  - 하위그룹 목록 응답(SubgroupListItem)에 joinType 필드 추가.

  ———

  ## 🛠️ 수정/변경사항

  - 하위그룹 목록 조회 쿼리에서 joinType을 조회하도록 수정.
  - 하위그룹 멤버 조회 시 ACTIVE 상태 존재 여부로 검증 로직 변경.
  - 그룹 상세/하위그룹 목록 조회 API를 비로그인 접근 허용으로 변경.
  - 검색 키워드 처리 로직에서 공백/빈 문자열 처리 개선.

  ———

  ## 🧪 테스트

  - [ ] 로컬 테스트
  - [ ] API 호출 확인
  - [ ] 테스트 코드 추가/수정
  - [x] 테스트 생략 (사유: 변경 범위가 DTO/권한/간단 로직 변경이며 로컬 테스트 미수행)

  ———

  ## ✅ 남은 작업

  - [ ] 없음

  ———

  ## ⚠️ 리뷰 참고사항

  - 보안 정책 변경으로 그룹 상세/하위그룹 목록이 공개 API로 전환

