### PR TITLE
🐛 fix: 하위그룹 검색 권한 수정

### DIFF
--- a/app-api/src/main/java/com/tasteam/global/security/common/constants/ApiEndpointSecurityPolicy.java
+++ b/app-api/src/main/java/com/tasteam/global/security/common/constants/ApiEndpointSecurityPolicy.java
@@ -50,6 +50,7 @@ public final class ApiEndpointSecurityPolicy {
 			permit(GET, ApiEndpoints.MEMBERS_REVIEWS),
 			permit(GET, ApiEndpoints.GROUPS_DETAIL),
 			permit(GET, ApiEndpoints.GROUPS_SUBGROUPS),
+			permit(GET, ApiEndpoints.GROUPS_SUBGROUPS_SEARCH),
 
 			// 검색 (토큰 유무 무관)
 			permit(POST, ApiEndpoints.SEARCH),

--- a/app-api/src/main/java/com/tasteam/global/security/common/constants/ApiEndpoints.java
+++ b/app-api/src/main/java/com/tasteam/global/security/common/constants/ApiEndpoints.java
@@ -68,6 +68,7 @@ public final class ApiEndpoints {
 	public static final String GROUPS_DETAIL = GROUPS + DETAIL;
 	public static final String GROUPS_REVIEWS = GROUPS_DETAIL + "/reviews";
 	public static final String GROUPS_SUBGROUPS = GROUPS + "/*/subgroups";
+	public static final String GROUPS_SUBGROUPS_SEARCH = GROUPS + "/*/subgroups/search";
 
 	// Subgroup
 	public static final String SUBGROUPS = API_V1 + "/subgroups";


### PR DESCRIPTION

  ## 📌 PR 요약

  - 하위그룹 검색 API가 비인증 접근 가능하도록 보안 정책을 수정
  - 연관 이슈
  - 없음

  ———

  ## ➕ 추가된 기능

  - 없음 (정책 변경)

  ———

  ## 🛠️ 수정/변경사항

  - GET /api/v1/groups/*/subgroups/search 엔드포인트를 공개(permit) 목록에 추가
  - 보안 엔드포인트 상수 추가 (GROUPS_SUBGROUPS_SEARCH)

  ———

  ## 🧪 테스트

  - [ ] 로컬 테스트
  - [ ] API 호출 확인
  - [ ] 테스트 코드 추가/수정
  - [ ] 테스트 생략 

  ———

  ## ✅ 남은 작업

  - [ ]

  ———

  ## ⚠️ 리뷰 참고사항

  - 보안 정책 변경으로 비인증 접근 허용됨 (요구사항 확인 필요)
