### PR TITLE
✨ feat: 내 그룹 (+하위그룹) 목록 조회

### DIFF
--- a/app-api/src/main/java/com/tasteam/domain/group/repository/GroupMemberRepository.java
+++ b/app-api/src/main/java/com/tasteam/domain/group/repository/GroupMemberRepository.java
@@ -12,6 +12,7 @@ import com.tasteam.domain.group.dto.GroupMemberListItem;
 import com.tasteam.domain.group.entity.GroupMember;
 import com.tasteam.domain.group.repository.projection.GroupMemberCountProjection;
 import com.tasteam.domain.group.type.GroupStatus;
+import com.tasteam.domain.member.dto.response.MemberGroupDetailSummaryRow;
 import com.tasteam.domain.member.dto.response.MemberGroupSummaryRow;
 
 public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> {
@@ -71,6 +72,32 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
 		order by gm.id desc
 		""")
 	List<MemberGroupSummaryRow> findMemberGroupSummaries(
+		@Param("memberId")
+		Long memberId,
+		@Param("activeStatus")
+		GroupStatus activeStatus);
+
+	@Query("""
+		select distinct new com.tasteam.domain.member.dto.response.MemberGroupDetailSummaryRow(
+			g.id,
+			g.name,
+			g.address,
+			g.detailAddress,
+			g.logoImageUrl,
+			(select count(gmCount.id)
+				from GroupMember gmCount
+				where gmCount.groupId = g.id
+					and gmCount.deletedAt is null)
+		)
+		from GroupMember gm
+		join com.tasteam.domain.group.entity.Group g on g.id = gm.groupId
+		where gm.member.id = :memberId
+			and gm.deletedAt is null
+			and g.deletedAt is null
+			and g.status = :activeStatus
+		order by g.name asc
+		""")
+	List<MemberGroupDetailSummaryRow> findMemberGroupDetailSummaries(
 		@Param("memberId")
 		Long memberId,
 		@Param("activeStatus")

--- a/app-api/src/main/java/com/tasteam/domain/member/controller/MemberController.java
+++ b/app-api/src/main/java/com/tasteam/domain/member/controller/MemberController.java
@@ -18,6 +18,7 @@ import com.tasteam.domain.favorite.dto.response.FavoriteRestaurantItem;
 import com.tasteam.domain.favorite.service.FavoriteService;
 import com.tasteam.domain.member.controller.docs.MemberControllerDocs;
 import com.tasteam.domain.member.dto.request.MemberProfileUpdateRequest;
+import com.tasteam.domain.member.dto.response.MemberGroupDetailSummaryResponse;
 import com.tasteam.domain.member.dto.response.MemberGroupSummaryResponse;
 import com.tasteam.domain.member.dto.response.MemberMeResponse;
 import com.tasteam.domain.member.dto.response.ReviewSummaryResponse;
@@ -56,6 +57,13 @@ public class MemberController implements MemberControllerDocs {
 		@CurrentUser
 		Long memberId) {
 		return SuccessResponse.success(memberService.getMyGroupSummaries(memberId));
+	}
+
+	@GetMapping("/groups")
+	public SuccessResponse<List<MemberGroupDetailSummaryResponse>> getMyGroups(
+		@CurrentUser
+		Long memberId) {
+		return SuccessResponse.success(memberService.getMyGroupDetails(memberId));
 	}
 
 	@GetMapping("/groups/{groupId}/subgroups")

--- a/app-api/src/main/java/com/tasteam/domain/member/controller/docs/MemberControllerDocs.java
+++ b/app-api/src/main/java/com/tasteam/domain/member/controller/docs/MemberControllerDocs.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import com.tasteam.domain.member.dto.request.MemberProfileUpdateRequest;
+import com.tasteam.domain.member.dto.response.MemberGroupDetailSummaryResponse;
 import com.tasteam.domain.member.dto.response.MemberGroupSummaryResponse;
 import com.tasteam.domain.member.dto.response.MemberMeResponse;
 import com.tasteam.domain.subgroup.dto.SubgroupListResponse;
@@ -56,6 +57,13 @@ public interface MemberControllerDocs {
 	@ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = MemberGroupSummaryResponse.class)))
 	@CustomErrorResponseDescription(value = MemberSwaggerErrorResponseDescription.class, group = "MEMBER_GROUP_SUMMARIES")
 	SuccessResponse<List<MemberGroupSummaryResponse>> getMyGroupSummaries(
+		@CurrentUser
+		Long memberId);
+
+	@Operation(summary = "내 그룹 상세 목록 조회", description = "현재 로그인 사용자의 그룹 상세 정보와 가입한 하위 그룹 목록을 조회합니다.")
+	@ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = MemberGroupDetailSummaryResponse.class)))
+	@CustomErrorResponseDescription(value = MemberSwaggerErrorResponseDescription.class, group = "MEMBER_GROUP_SUMMARIES")
+	SuccessResponse<List<MemberGroupDetailSummaryResponse>> getMyGroups(
 		@CurrentUser
 		Long memberId);
 

--- a/app-api/src/main/java/com/tasteam/domain/member/dto/response/MemberGroupDetailSummaryResponse.java
+++ b/app-api/src/main/java/com/tasteam/domain/member/dto/response/MemberGroupDetailSummaryResponse.java
@@ -1,0 +1,13 @@
+package com.tasteam.domain.member.dto.response;
+
+import java.util.List;
+
+public record MemberGroupDetailSummaryResponse(
+	Long groupId,
+	String groupName,
+	String groupAddress,
+	String groupDetailAddress,
+	String groupLogoImageUrl,
+	long groupMemberCount,
+	List<MemberSubgroupDetailSummaryResponse> subGroups) {
+}

--- a/app-api/src/main/java/com/tasteam/domain/member/dto/response/MemberGroupDetailSummaryRow.java
+++ b/app-api/src/main/java/com/tasteam/domain/member/dto/response/MemberGroupDetailSummaryRow.java
@@ -1,0 +1,10 @@
+package com.tasteam.domain.member.dto.response;
+
+public record MemberGroupDetailSummaryRow(
+	Long groupId,
+	String groupName,
+	String groupAddress,
+	String groupDetailAddress,
+	String groupLogoImageUrl,
+	long groupMemberCount) {
+}

--- a/app-api/src/main/java/com/tasteam/domain/member/dto/response/MemberSubgroupDetailSummaryResponse.java
+++ b/app-api/src/main/java/com/tasteam/domain/member/dto/response/MemberSubgroupDetailSummaryResponse.java
@@ -1,0 +1,8 @@
+package com.tasteam.domain.member.dto.response;
+
+public record MemberSubgroupDetailSummaryResponse(
+	Long subGroupId,
+	String subGroupName,
+	Integer memberCount,
+	String logoImageUrl) {
+}

--- a/app-api/src/main/java/com/tasteam/domain/member/dto/response/MemberSubgroupDetailSummaryRow.java
+++ b/app-api/src/main/java/com/tasteam/domain/member/dto/response/MemberSubgroupDetailSummaryRow.java
@@ -1,0 +1,9 @@
+package com.tasteam.domain.member.dto.response;
+
+public record MemberSubgroupDetailSummaryRow(
+	Long groupId,
+	Long subGroupId,
+	String subGroupName,
+	Integer memberCount,
+	String logoImageUrl) {
+}

--- a/app-api/src/main/java/com/tasteam/domain/subgroup/repository/SubgroupMemberRepository.java
+++ b/app-api/src/main/java/com/tasteam/domain/subgroup/repository/SubgroupMemberRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.tasteam.domain.group.type.GroupStatus;
+import com.tasteam.domain.member.dto.response.MemberSubgroupDetailSummaryRow;
 import com.tasteam.domain.member.dto.response.MemberSubgroupSummaryRow;
 import com.tasteam.domain.subgroup.dto.SubgroupMemberListItem;
 import com.tasteam.domain.subgroup.entity.SubgroupMember;
@@ -52,6 +53,33 @@ public interface SubgroupMemberRepository extends JpaRepository<SubgroupMember, 
 		order by g.id asc, s.id asc
 		""")
 	List<MemberSubgroupSummaryRow> findMemberSubgroupSummaries(
+		@Param("memberId")
+		Long memberId,
+		@Param("activeSubgroupStatus")
+		SubgroupStatus activeSubgroupStatus,
+		@Param("activeGroupStatus")
+		GroupStatus activeGroupStatus);
+
+	@Query("""
+		select new com.tasteam.domain.member.dto.response.MemberSubgroupDetailSummaryRow(
+			g.id,
+			s.id,
+			s.name,
+			s.memberCount,
+			s.profileImageUrl
+		)
+		from SubgroupMember sm
+		join Subgroup s on s.id = sm.subgroupId
+		join s.group g
+		where sm.member.id = :memberId
+			and sm.deletedAt is null
+			and s.deletedAt is null
+			and s.status = :activeSubgroupStatus
+			and g.deletedAt is null
+			and g.status = :activeGroupStatus
+		order by g.name asc, s.name asc
+		""")
+	List<MemberSubgroupDetailSummaryRow> findMemberSubgroupDetailSummaries(
 		@Param("memberId")
 		Long memberId,
 		@Param("activeSubgroupStatus")


### PR DESCRIPTION

• ## 📌 PR 요약

  - 내 그룹 상세 목록 조회 API(/api/v1/members/me/groups)를 추가
  - 연관 이슈

  ———

  ## ➕ 추가된 기능

  - GET /api/v1/members/me/groups 엔드포인트 추가
  - 그룹 상세 + 하위그룹 상세 응답 DTO/Row 추가

  ———

  ## 🛠️ 수정/변경사항

  - MemberService#getMyGroupDetails 구현 및 연동
  - GroupMemberRepository, SubgroupMemberRepository에 상세 조회용 JPQL 추가
  - MemberController/Swagger Docs에 신규 API 등록

  ———

  ## 🧪 테스트

  - [ ] 로컬 테스트
  - [ ] API 호출 확인
  - [ ] 테스트 코드 추가/수정
  - [ ] 테스트 생략 (사유: )

  ———

  ## ✅ 남은 작업

  - [ ]

  ———

  ## ⚠️ 리뷰 참고사항
