### PR TITLE
Feat: 이미지 매핑 방식 변경

### DIFF
--- a/app-api/src/main/java/com/tasteam/domain/file/repository/DomainImageRepository.java
+++ b/app-api/src/main/java/com/tasteam/domain/file/repository/DomainImageRepository.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.tasteam.domain.file.entity.DomainImage;
 import com.tasteam.domain.file.entity.DomainType;
@@ -14,4 +16,22 @@ public interface DomainImageRepository extends JpaRepository<DomainImage, Long> 
 	Optional<DomainImage> findByDomainTypeAndDomainIdAndImage(DomainType domainType, Long domainId, Image image);
 
 	List<DomainImage> findAllByImage(Image image);
+
+	@Query("""
+		select di from DomainImage di
+		join fetch di.image i
+		where di.domainType = :domainType
+		  and di.domainId in :domainIds
+		  and i.status = 'ACTIVE'
+		order by di.domainId asc, di.sortOrder asc
+		""")
+	List<DomainImage> findAllByDomainTypeAndDomainIdIn(
+		@Param("domainType")
+		DomainType domainType,
+		@Param("domainIds")
+		List<Long> domainIds);
+
+	List<DomainImage> findAllByDomainTypeAndDomainId(DomainType domainType, Long domainId);
+
+	void deleteAllByDomainTypeAndDomainId(DomainType domainType, Long domainId);
 }

--- a/app-api/src/main/java/com/tasteam/domain/restaurant/entity/RestaurantImage.java
+++ b/app-api/src/main/java/com/tasteam/domain/restaurant/entity/RestaurantImage.java
@@ -21,13 +21,14 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Deprecated
 @Entity
 @Getter
 @Builder(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "restaurant_image")
-@Comment("음식점 대표 이미지 정보를 저장하는 테이블")
+@Comment("음식점 대표 이미지 - DomainImage 사용으로 대체됨")
 public class RestaurantImage extends BaseCreatedAtEntity {
 
 	@Id

--- a/app-api/src/main/java/com/tasteam/domain/restaurant/repository/RestaurantImageRepository.java
+++ b/app-api/src/main/java/com/tasteam/domain/restaurant/repository/RestaurantImageRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 import com.tasteam.domain.restaurant.entity.RestaurantImage;
 import com.tasteam.domain.restaurant.repository.projection.RestaurantImageProjection;
 
+@Deprecated
 public interface RestaurantImageRepository extends JpaRepository<RestaurantImage, Long> {
 
 	List<RestaurantImage> findByRestaurantIdAndDeletedAtIsNullOrderBySortOrderAsc(Long restaurantId);

--- a/app-api/src/main/java/com/tasteam/domain/restaurant/repository/projection/RestaurantImageProjection.java
+++ b/app-api/src/main/java/com/tasteam/domain/restaurant/repository/projection/RestaurantImageProjection.java
@@ -1,5 +1,6 @@
 package com.tasteam.domain.restaurant.repository.projection;
 
+@Deprecated
 public interface RestaurantImageProjection {
 	Long getRestaurantId();
 

--- a/app-api/src/main/java/com/tasteam/domain/review/entity/ReviewImage.java
+++ b/app-api/src/main/java/com/tasteam/domain/review/entity/ReviewImage.java
@@ -21,13 +21,14 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Deprecated
 @Entity
 @Getter
 @Builder(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "review_image")
-@Comment("리뷰 이미지")
+@Comment("리뷰 이미지 - DomainImage 사용으로 대체됨")
 public class ReviewImage extends BaseCreatedAtEntity {
 
 	@Id

--- a/app-api/src/main/java/com/tasteam/domain/review/repository/ReviewImageRepository.java
+++ b/app-api/src/main/java/com/tasteam/domain/review/repository/ReviewImageRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 import com.tasteam.domain.review.entity.ReviewImage;
 import com.tasteam.domain.review.repository.projection.ReviewImageProjection;
 
+@Deprecated
 public interface ReviewImageRepository extends JpaRepository<ReviewImage, Long> {
 
 	@Query("""

--- a/app-api/src/main/java/com/tasteam/domain/review/repository/projection/ReviewImageProjection.java
+++ b/app-api/src/main/java/com/tasteam/domain/review/repository/projection/ReviewImageProjection.java
@@ -1,5 +1,6 @@
 package com.tasteam.domain.review.repository.projection;
 
+@Deprecated
 public interface ReviewImageProjection {
 
 	Long getReviewId();


### PR DESCRIPTION
## 📌 PR 요약

* 이미지 URL 반환 시 storageKey만 반환되던 문제를 수정하고, ReviewImage/RestaurantImage를 DomainImage로 통합하여 이미지 관리 구조를 일원화합니다.

* 연관 이슈: S3 presigned POST 업로드 후 이미지 URL이 `uploads/temp/xxx.png` 형태로만 반환되어 프론트엔드에서 이미지를 불러올 수 없던 문제

---

## ➕ 추가된 기능

* `DomainImageRepository`에 도메인별 이미지 조회/삭제 메서드 추가
  - `findAllByDomainTypeAndDomainIdIn`: 여러 도메인 ID에 대한 이미지 일괄 조회
  - `deleteAllByDomainTypeAndDomainId`: 도메인별 이미지 삭제

* `buildPublicUrl` 메서드 추가 (`ReviewService`, `RestaurantService`)
  - storageKey를 baseUrl과 조합하여 완전한 이미지 URL 반환
  - baseUrl 미설정 시 S3 기본 URL로 fallback

---

## 🛠️ 수정/변경사항

* **이미지 매핑 구조 변경**
  - `ReviewImage`, `RestaurantImage` → `DomainImage` 테이블로 통합
  - 기존 엔티티/리포지토리에 `@Deprecated` 추가 (하위 호환성 유지)

* **ReviewService 수정**
  - `ReviewImageRepository` → `DomainImageRepository` 사용
  - 리뷰 생성 시 `DomainImage.create(DomainType.REVIEW, ...)` 사용
  - 리뷰 조회 시 이미지 URL에 baseUrl 조합

* **RestaurantService 수정**
  - `RestaurantImageRepository` → `DomainImageRepository` 사용
  - 음식점 생성/수정/삭제 시 `DomainImage` 사용
  - 음식점 조회 시 이미지 URL에 baseUrl 조합

* **@Deprecated 추가 대상**
  - `ReviewImage`, `ReviewImageRepository`, `ReviewImageProjection`
  - `RestaurantImage`, `RestaurantImageRepository`, `RestaurantImageProjection`

---

## 🧪 테스트

* [ ] 로컬 테스트
* [ ] API 호출 확인
* [ ] 테스트 코드 추가/수정
* [x] 테스트 생략 (사유: 기존 테스트 코드 수정 필요, 실제 S3 연동 테스트는 dev 환경에서 확인 필요)

---

## ✅ 남은 작업

* [ ] 기존 `review_image`, `restaurant_image` 테이블 데이터를 `domain_image`로 마이그레이션 (필요시)
* [ ] `@Deprecated` 처리된 엔티티/리포지토리 추후 제거

---

## ⚠️ 리뷰 참고사항

* 기존 `ReviewImage`, `RestaurantImage` 엔티티는 `@Deprecated` 처리만 하고 삭제하지 않음
  - DB 테이블은 그대로 유지되므로 기존 데이터에 영향 없음
  - 신규 이미지는 `domain_image` 테이블에 저장됨

* `buildPublicUrl` 로직이 `FileService`, `ReviewService`, `RestaurantService`에 중복 존재
  - 추후 공통 유틸로 분리 검토 필요
