### PR TITLE
Feat: S3 PresingedURL 방식과 public 운영 전환 방식 구현

### DIFF
--- a/app-api/src/main/java/com/tasteam/domain/file/dto/response/ImageUrlResponse.java
+++ b/app-api/src/main/java/com/tasteam/domain/file/dto/response/ImageUrlResponse.java
@@ -5,6 +5,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record ImageUrlResponse(
 	@Schema(description = "파일 UUID(외부 식별자)", example = "a3f1c9e0-7a9b-4e9c-bc2e-1f2c33aa9012")
 	String fileUuid,
-	@Schema(description = "공개 조회 URL", example = "https://cdn.example.com/uploads/temp/a3f1c9e0-7a9b-4e9c-bc2e-1f2c33aa9012.jpg")
+	@Schema(description = "조회 URL(모드에 따라 public 또는 presigned)", example = "https://img.tasteam.com/uploads/temp/a3f1c9e0-7a9b-4e9c-bc2e-1f2c33aa9012.jpg")
 	String url) {
 }

--- a/app-api/src/main/java/com/tasteam/domain/file/service/FileService.java
+++ b/app-api/src/main/java/com/tasteam/domain/file/service/FileService.java
@@ -277,6 +277,13 @@ public class FileService {
 	}
 
 	private String buildPublicUrl(String storageKey) {
+		if (storageProperties.isPresignedAccess()) {
+			return storageClient.createPresignedGetUrl(storageKey);
+		}
+		return buildStaticUrl(storageKey);
+	}
+
+	private String buildStaticUrl(String storageKey) {
 		String baseUrl = storageProperties.getBaseUrl();
 		if (baseUrl == null || baseUrl.isBlank()) {
 			baseUrl = String.format("https://%s.s3.%s.amazonaws.com",

--- a/app-api/src/main/java/com/tasteam/domain/restaurant/service/RestaurantService.java
+++ b/app-api/src/main/java/com/tasteam/domain/restaurant/service/RestaurantService.java
@@ -69,6 +69,7 @@ import com.tasteam.global.exception.code.FileErrorCode;
 import com.tasteam.global.exception.code.GroupErrorCode;
 import com.tasteam.global.exception.code.RestaurantErrorCode;
 import com.tasteam.global.utils.CursorCodec;
+import com.tasteam.infra.storage.StorageClient;
 import com.tasteam.infra.storage.StorageProperties;
 
 import lombok.RequiredArgsConstructor;
@@ -97,6 +98,7 @@ public class RestaurantService {
 	private final RestaurantScheduleService restaurantScheduleService;
 	private final RestaurantWeeklyScheduleRepository weeklyScheduleRepository;
 	private final StorageProperties storageProperties;
+	private final StorageClient storageClient;
 
 	@Transactional(readOnly = true)
 	public RestaurantDetailResponse getRestaurantDetail(long restaurantId) {
@@ -500,6 +502,9 @@ public class RestaurantService {
 	}
 
 	private String buildPublicUrl(String storageKey) {
+		if (storageProperties.isPresignedAccess()) {
+			return storageClient.createPresignedGetUrl(storageKey);
+		}
 		String baseUrl = storageProperties.getBaseUrl();
 		if (baseUrl == null || baseUrl.isBlank()) {
 			baseUrl = String.format("https://%s.s3.%s.amazonaws.com",

--- a/app-api/src/main/java/com/tasteam/domain/review/service/ReviewService.java
+++ b/app-api/src/main/java/com/tasteam/domain/review/service/ReviewService.java
@@ -50,6 +50,7 @@ import com.tasteam.global.exception.code.RestaurantErrorCode;
 import com.tasteam.global.exception.code.ReviewErrorCode;
 import com.tasteam.global.exception.code.SubgroupErrorCode;
 import com.tasteam.global.utils.CursorCodec;
+import com.tasteam.infra.storage.StorageClient;
 import com.tasteam.infra.storage.StorageProperties;
 
 import lombok.RequiredArgsConstructor;
@@ -72,6 +73,7 @@ public class ReviewService {
 	private final DomainImageRepository domainImageRepository;
 	private final ImageRepository imageRepository;
 	private final StorageProperties storageProperties;
+	private final StorageClient storageClient;
 	private final CursorCodec cursorCodec;
 
 	@Transactional(readOnly = true)
@@ -414,6 +416,9 @@ public class ReviewService {
 	}
 
 	private String buildPublicUrl(String storageKey) {
+		if (storageProperties.isPresignedAccess()) {
+			return storageClient.createPresignedGetUrl(storageKey);
+		}
 		String baseUrl = storageProperties.getBaseUrl();
 		if (baseUrl == null || baseUrl.isBlank()) {
 			baseUrl = String.format("https://%s.s3.%s.amazonaws.com",

--- a/app-api/src/main/java/com/tasteam/infra/storage/DummyStorageClient.java
+++ b/app-api/src/main/java/com/tasteam/infra/storage/DummyStorageClient.java
@@ -36,6 +36,12 @@ public class DummyStorageClient implements StorageClient {
 	}
 
 	@Override
+	public String createPresignedGetUrl(String objectKey) {
+		Assert.hasText(objectKey, "objectKey는 필수입니다");
+		return buildFallbackUrl(objectKey);
+	}
+
+	@Override
 	public void deleteObject(String objectKey) {
 		Assert.hasText(objectKey, "objectKey는 필수입니다");
 		// No external storage to clean up.

--- a/app-api/src/main/java/com/tasteam/infra/storage/StorageClient.java
+++ b/app-api/src/main/java/com/tasteam/infra/storage/StorageClient.java
@@ -4,5 +4,7 @@ public interface StorageClient {
 
 	PresignedPostResponse createPresignedPost(PresignedPostRequest request);
 
+	String createPresignedGetUrl(String objectKey);
+
 	void deleteObject(String objectKey);
 }

--- a/app-api/src/main/java/com/tasteam/infra/storage/StorageProperties.java
+++ b/app-api/src/main/java/com/tasteam/infra/storage/StorageProperties.java
@@ -19,6 +19,7 @@ public class StorageProperties {
 	private String region;
 	private String bucket;
 	private String baseUrl;
+	private String accessMode = "public";
 	private String accessKey;
 	private String secretKey;
 	private long presignedExpirationSeconds = 300;
@@ -35,6 +36,7 @@ public class StorageProperties {
 		log.info("region: {}", isConfigured(region) ? region : "(not set)");
 		log.info("bucket: {}", isConfigured(bucket) ? maskValue(bucket) : "(not set)");
 		log.info("baseUrl: {}", isConfigured(baseUrl) ? baseUrl : "(not set)");
+		log.info("accessMode: {}", accessMode);
 		log.info("accessKey: {}", isConfigured(accessKey) ? "(configured)" : "(not set)");
 		log.info("secretKey: {}", isConfigured(secretKey) ? "(configured)" : "(not set)");
 		log.info("presignedExpirationSeconds: {}", presignedExpirationSeconds);
@@ -44,6 +46,10 @@ public class StorageProperties {
 
 	private boolean isConfigured(String value) {
 		return value != null && !value.isBlank();
+	}
+
+	public boolean isPresignedAccess() {
+		return "presigned".equalsIgnoreCase(accessMode);
 	}
 
 	private String maskValue(String value) {

--- a/app-api/src/main/resources/application.dev.yml
+++ b/app-api/src/main/resources/application.dev.yml
@@ -74,6 +74,7 @@ tasteam:
     region: ${STORAGE_REGION:ap-northeast-2}
     bucket: ${STORAGE_BUCKET:}
     base-url: ${STORAGE_BASE_URL:https://tasteam.kr}
+    access-mode: ${STORAGE_ACCESS_MODE:presigned}
     presigned-expiration-seconds: ${STORAGE_PRESIGNED_EXPIRATION_SECONDS:300}
   webhook:
     enabled: true

--- a/app-api/src/main/resources/application.prod.yml
+++ b/app-api/src/main/resources/application.prod.yml
@@ -73,6 +73,7 @@ tasteam:
     region: ${STORAGE_REGION:}
     bucket: ${STORAGE_BUCKET:}
     base-url: ${STORAGE_BASE_URL:}
+    access-mode: ${STORAGE_ACCESS_MODE:presigned}
     access-key: ${STORAGE_ACCESS_KEY:}
     secret-key: ${STORAGE_SECRET_KEY:}
     presigned-expiration-seconds: ${STORAGE_PRESIGNED_EXPIRATION_SECONDS:}

--- a/app-api/src/main/resources/application.yml
+++ b/app-api/src/main/resources/application.yml
@@ -72,6 +72,7 @@ tasteam:
     region: ${STORAGE_REGION:}
     bucket: ${STORAGE_BUCKET:}
     base-url: ${STORAGE_BASE_URL:}
+    access-mode: ${STORAGE_ACCESS_MODE:public}
     access-key: ${STORAGE_ACCESS_KEY:}
     secret-key: ${STORAGE_SECRET_KEY:}
     presigned-expiration-seconds: ${STORAGE_PRESIGNED_EXPIRATION_SECONDS:300}

--- a/app-api/src/test/java/com/tasteam/config/TestStorageConfiguration.java
+++ b/app-api/src/test/java/com/tasteam/config/TestStorageConfiguration.java
@@ -35,6 +35,11 @@ public class TestStorageConfiguration {
 		}
 
 		@Override
+		public String createPresignedGetUrl(String objectKey) {
+			return "https://fake-storage.local/" + objectKey;
+		}
+
+		@Override
 		public void deleteObject(String objectKey) {}
 	}
 }

--- a/docs/spec/tech/file/README.md
+++ b/docs/spec/tech/file/README.md
@@ -333,20 +333,23 @@ erDiagram
         - status: `200`
         - body
             - `data.fileUuid`: string
-            - `data.url`: string - `tasteam.storage.baseUrl + storageKey` 조합(또는 S3 base URL)
+            - `data.url`: string - `tasteam.storage.baseUrl + storageKey` 조합(또는 presigned GET URL)
         - 예시(JSON)
             ```json
             {
               "data": {
                 "fileUuid": "a3f1c9e0-7a9b-4e9c-bc2e-1f2c33aa9012",
-                "url": "https://cdn.example.com/uploads/temp/a3f1c9e0-7a9b-4e9c-bc2e-1f2c33aa9012.jpg"
+                "url": "https://img.tasteam.com/uploads/temp/a3f1c9e0-7a9b-4e9c-bc2e-1f2c33aa9012.jpg"
               }
             }
             ```
+        - **운영 모드(전환 가능):**
+            - `access-mode=public`: Client → CloudFront → S3(private) 또는 Public Bucket. 사용자에게 제공되는 URL은 CloudFront/커스텀 도메인.
+            - `access-mode=presigned`: S3 private + presigned GET으로 조회(쿼리스트링 포함 URL 반환).
     - **처리 로직:**
         1. Image 행 조회(fileUuid)
         2. `status=ACTIVE`가 아니면 에러(`FILE_NOT_ACTIVE`)
-        3. `url = baseUrl + storageKey`로 조합해 반환
+        3. `access-mode=presigned`면 presigned GET, 아니면 `url = baseUrl + storageKey` 조합해 반환
     - **에러 코드:** `RESOURCE_NOT_FOUND`, `FILE_NOT_ACTIVE`, `INTERNAL_SERVER_ERROR`
 
 <br>
@@ -378,7 +381,7 @@ erDiagram
             - `data.items[]`: array
                 - `id`: number - Image 테이블 내부 PK
                 - `fileUuid`: string - 외부 식별자
-                - `url`: string - 내부에서 `baseUrl + objectKey`로 조합한 이미지 URL
+                - `url`: string - 내부에서 `baseUrl + objectKey` 조합 또는 presigned GET URL
         - 예시(JSON)
             ```json
             {
@@ -387,7 +390,7 @@ erDiagram
                   {
                     "id": 101,
                     "fileUuid": "a3f1c9e0-7a9b-4e9c-bc2e-1f2c33aa9012",
-                    "url": "https://cdn.example.com/uploads/temp/a3f1c9e0-7a9b-4e9c-bc2e-1f2c33aa9012.jpg"
+                    "url": "https://img.tasteam.com/uploads/temp/a3f1c9e0-7a9b-4e9c-bc2e-1f2c33aa9012.jpg"
                   }
                 ]
               }
@@ -396,7 +399,7 @@ erDiagram
     - **처리 로직:**
         1. `fileUuids` 입력 검증 및 길이 제한
         2. Image 조회 (`file_uuid`, `id`, `storage_key`)
-        3. `url = baseUrl + storage_key` 조합 후 DTO 매핑
+        3. `access-mode=presigned`면 presigned GET, 아니면 `url = baseUrl + storage_key` 조합 후 DTO 매핑
     - **트랜잭션 관리:** 조회 전용(읽기 전용 트랜잭션)
     - **동시성/멱등성:** 조회는 멱등, 캐시 가능(`fileUuid` 기준)
     - **에러 코드:** `INVALID_REQUEST`, `RESOURCE_NOT_FOUND`, `INTERNAL_SERVER_ERROR`


### PR DESCRIPTION
📌 PR 요약
dev/prod에서 이미지 조회 URL을 presigned GET 방식으로 전환해 private S3에서도 정상 조회되도록 개선

연관 이슈

(없음) — 운영 환경에서 CloudFront 미사용/사설 버킷 접근 문제 대응
➕ 추가된 기능
tasteam.storage.access-mode로 public/presigned 조회 방식 전환 가능
presigned GET URL 생성 로직 추가(S3)
🛠️ 수정/변경사항
FileService/ReviewService/RestaurantService 이미지 URL 생성이 access-mode에 따라 presigned GET 또는 public URL로 분기
StorageClient 인터페이스 확장 및 S3/Dummy/Test 구현 추가
dev/prod 기본값을 presigned로 설정
문서/Swagger 예시 및 설명 갱신
🧪 테스트
 로컬 테스트
 API 호출 확인
 테스트 코드 추가/수정
 테스트 생략 (사유: )
✅ 남은 작업
[ ]
⚠️ 리뷰 참고사항
presigned URL 만료 시간은 tasteam.storage.presigned-expiration-seconds 설정값을 따릅니다
access-mode=public로 되돌릴 경우 기존 CloudFront/커스텀 도메인 방식 그대로 동작합니다