### PR TITLE
Fix: dev서버 및 local 환경의 swagger 경고가 출력되지 않도록 수정

### DIFF
--- a/app-api/src/main/resources/application.dev.yml
+++ b/app-api/src/main/resources/application.dev.yml
@@ -66,6 +66,10 @@ spring:
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
 
+logging:
+  level:
+    org.springdoc: ERROR
+
 naver:
   maps:
     base-url: https://maps.apigw.ntruss.com

--- a/app-api/src/main/resources/application.local.yml
+++ b/app-api/src/main/resources/application.local.yml
@@ -43,6 +43,7 @@ logging:
     org.hibernate.SQL: debug
     org.hibernate.tool.schema: debug
     org.springframework.security: DEBUG
+    org.springdoc: ERROR
 
 naver:
   maps:


### PR DESCRIPTION
## 📌 PR 요약

#### Summary
- dev서버 및 local 환경의 swagger 경고가 출력되지 않도록 수정

### Issue
- (없음)

---

## 🛠️ 수정/변경사항
<!--
  기존 기능 변경, 버그 수정, 리팩토링 등을 나열하세요. 영향 범위도 함께 쓰면 리뷰어가 이해하기 쉽습니다.
  예: "- 예약 API 응답에 `status` 필드를 추가함", "- 기존 실패율 경고 문구 변경"
-->

1. dev서버 및 local 환경의 swagger 경고가 출력되지 않도록 수정

---

## ✅ 남은 작업

<!--
  아직 완료되지 않은 작업이나 사후에 처리해야 할 항목을 정리하세요. 검토자/다음 작업자에게 힌트가 됩니다.
-->
* [ ] 
