### PR TITLE
🐛 fix: 비로그인시 그룹 리뷰 목록, 하위그룹 목록 권한 수정

### DIFF
--- a/app-api/src/main/java/com/tasteam/domain/subgroup/service/SubgroupService.java
+++ b/app-api/src/main/java/com/tasteam/domain/subgroup/service/SubgroupService.java
@@ -98,7 +98,6 @@ public class SubgroupService {
 	@Transactional(readOnly = true)
 	public CursorPageResponse<SubgroupListItem> getGroupSubgroups(Long groupId, Long memberId, String cursor,
 		Integer size) {
-		validateAuthenticated(memberId);
 		getGroup(groupId);
 
 		int resolvedSize = resolveSize(size);

--- a/app-api/src/main/java/com/tasteam/global/security/common/constants/ApiEndpointSecurityPolicy.java
+++ b/app-api/src/main/java/com/tasteam/global/security/common/constants/ApiEndpointSecurityPolicy.java
@@ -47,6 +47,7 @@ public final class ApiEndpointSecurityPolicy {
 			permit(GET, ApiEndpoints.REVIEWS),
 			permit(GET, ApiEndpoints.REVIEWS_DETAIL),
 			permit(GET, ApiEndpoints.GROUPS_REVIEWS),
+			permit(GET, ApiEndpoints.GROUPS_REVIEWS_RESTAURANTS),
 			permit(GET, ApiEndpoints.SUBGROUPS_REVIEWS),
 			permit(GET, ApiEndpoints.MEMBERS_REVIEWS),
 			permit(GET, ApiEndpoints.GROUPS_DETAIL),

--- a/app-api/src/main/java/com/tasteam/global/security/common/constants/ApiEndpoints.java
+++ b/app-api/src/main/java/com/tasteam/global/security/common/constants/ApiEndpoints.java
@@ -73,6 +73,7 @@ public final class ApiEndpoints {
 	public static final String GROUPS_ALL = GROUPS + ALL;
 	public static final String GROUPS_DETAIL = GROUPS + DETAIL;
 	public static final String GROUPS_REVIEWS = GROUPS_DETAIL + "/reviews";
+	public static final String GROUPS_REVIEWS_RESTAURANTS = GROUPS_REVIEWS + "/restaurants";
 	public static final String GROUPS_SUBGROUPS = GROUPS + "/*/subgroups";
 	public static final String GROUPS_SUBGROUPS_SEARCH = GROUPS + "/*/subgroups/search";
 

--- a/app-api/src/main/resources/application.yml
+++ b/app-api/src/main/resources/application.yml
@@ -65,8 +65,8 @@ springdoc:
 ## ====== 커스텀 설정 ======
 tasteam:
   admin:
-    username: ${ADMIN_USERNAME}
-    password: ${ADMIN_PASSWORD}
+    username: ${ADMIN_USERNAME:}
+    password: ${ADMIN_PASSWORD:}
   domain:
     service: ${SERVICE_DOMAIN:https://tasteam.kr}
     api: ${API_DOMAIN:https://api.tasteam.kr}


### PR DESCRIPTION
• ## 📌 PR 요약

  #### Summary

  - 그룹 리뷰 식당 목록 API의 비로그인 접근(401) 이슈를 해결하고, 하위그룹 목록 조회도 동일한 PUBLIC 접근 정책으로 정렬했습니다.
  - 운영 환경 변수 미설정 시 발생하던 ADMIN_USERNAME placeholder 예외를 방지했습니다.

  ### Issue

  - close : #166

  ———

  ## ➕ 추가된 기능

  1. GET /api/v1/groups/{groupId}/reviews/restaurants 경로를 permitAll 대상에 추가
  2. 하위그룹 목록 조회(getGroupSubgroups)에서 비로그인 요청도 처리 가능하도록 인증 강제 제거

  ## 🛠️ 수정/변경사항

  1. Security endpoint 상수/정책 수정
      - ApiEndpoints.GROUPS_REVIEWS_RESTAURANTS 추가
      - ApiEndpointSecurityPolicy.publicEndpoints()에 GET permitAll 등록
  2. 앱 기동 안정성 개선
      - application.yml의 tasteam.admin.username/password를 ${...:} 기본값 형태로 변경해 env 미설정 시 부팅 실패 방지

  ———

  ## ✅ 남은 작업
