### PR TITLE
🐛 fix:그룹/하위그룹에서 presigned 이미지 URL DB 저장을 제거하고 DomainImage(fileUuid/st…

### DIFF
--- a/app-api/src/main/java/com/tasteam/domain/member/service/MemberService.java
+++ b/app-api/src/main/java/com/tasteam/domain/member/service/MemberService.java
@@ -104,6 +104,14 @@ public class MemberService {
 			memberId,
 			SubgroupStatus.ACTIVE,
 			GroupStatus.ACTIVE);
+
+		Map<Long, String> groupImageUrlById = resolveDomainImageUrlMap(
+			DomainType.GROUP,
+			groupRows.stream().map(MemberGroupDetailSummaryRow::groupId).toList());
+		Map<Long, String> subgroupImageUrlById = resolveDomainImageUrlMap(
+			DomainType.SUBGROUP,
+			subgroupRows.stream().map(MemberSubgroupDetailSummaryRow::subGroupId).toList());
+
 		Map<Long, MemberGroupDetailSummaryResponse> grouped = new LinkedHashMap<>();
 		for (MemberGroupDetailSummaryRow row : groupRows) {
 			MemberGroupDetailSummaryResponse summary = new MemberGroupDetailSummaryResponse(
@@ -111,7 +119,7 @@ public class MemberService {
 				row.groupName(),
 				row.groupAddress(),
 				row.groupDetailAddress(),
-				row.groupLogoImageUrl(),
+				groupImageUrlById.get(row.groupId()),
 				row.groupMemberCount(),
 				new ArrayList<>());
 			grouped.put(row.groupId(), summary);
@@ -123,7 +131,7 @@ public class MemberService {
 					row.subGroupId(),
 					row.subGroupName(),
 					row.memberCount(),
-					row.logoImageUrl()));
+					subgroupImageUrlById.get(row.subGroupId())));
 			}
 		}
 		return new ArrayList<>(grouped.values());
@@ -211,5 +219,17 @@ public class MemberService {
 			return null;
 		}
 		return buildPublicUrl(images.getFirst().getImage().getStorageKey());
+	}
+
+	private Map<Long, String> resolveDomainImageUrlMap(DomainType domainType, List<Long> domainIds) {
+		if (domainIds.isEmpty()) {
+			return Map.of();
+		}
+		return domainImageRepository.findAllByDomainTypeAndDomainIdIn(domainType, domainIds)
+			.stream()
+			.collect(java.util.stream.Collectors.toMap(
+				DomainImage::getDomainId,
+				domainImage -> buildPublicUrl(domainImage.getImage().getStorageKey()),
+				(existing, ignored) -> existing));
 	}
 }


### PR DESCRIPTION
## 📌 PR 요약

  #### Summary

  - 그룹/하위그룹 이미지 처리에서 presigned URL(DB 컬럼 저장) 의존을 제거하고, DomainImage -> storageKey -> URL 변환 기반으로 조회 응답을 통일했습니다.
  - 하위그룹 이미지 등록 시 URL 길이 초과로 발생하던 DataIntegrityViolationException(500) 원인을 제거했습니다.

  ### Issue

  - close : #

  ———

  ## ➕ 추가된 기능

  1. 하위그룹 목록/검색/내 소모임 조회 응답에서 이미지 URL을 DomainImage 링크 기반으로 재매핑하는 로직 추가
  2. 멤버 그룹 상세 요약 응답(groupLogoImageUrl, subgroup logoImageUrl)을 링크 기반 URL 계산으로 통일

  ## 🛠️ 수정/변경사항

  1. Group/Subgroup 생성·수정 시 logo_image_url/profile_image_url 컬럼에 presigned URL을 저장하지 않도록 로직 변경
  2. Subgroup 상세 조회 fallback(엔티티 URL 컬럼 사용) 제거 및 링크 기반 URL만 사용하도록 정리

  ———

  ## ✅ 남은 작업

  - [ ] 운영 DB domain_image.domain_type에 SUBGROUP 반영 여부 최종 확인 (enum/check 제약)
  - [ ] 이미지 포함 하위그룹 생성/수정 및 목록/상세 응답 E2E 확인
  - [ ] Issue 번호 확정 후 close : # 반영
