### PR TITLE
🐛 fix: 그룹/하위그룹 이미지 링크 시 PENDING 상태가 ACTIVE로 반영되지 않는 문제 수정

### DIFF
--- a/app-api/src/main/java/com/tasteam/domain/file/repository/DomainImageRepository.java
+++ b/app-api/src/main/java/com/tasteam/domain/file/repository/DomainImageRepository.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -34,9 +33,5 @@ public interface DomainImageRepository extends JpaRepository<DomainImage, Long> 
 
 	List<DomainImage> findAllByDomainTypeAndDomainId(DomainType domainType, Long domainId);
 
-	@Modifying(clearAutomatically = true, flushAutomatically = true)
-	@Query("delete from DomainImage di where di.domainType = :domainType and di.domainId = :domainId")
-	void deleteAllByDomainTypeAndDomainId(@Param("domainType")
-	DomainType domainType, @Param("domainId")
-	Long domainId);
+	void deleteAllByDomainTypeAndDomainId(DomainType domainType, Long domainId);
 }

--- a/app-api/src/main/java/com/tasteam/domain/group/service/GroupService.java
+++ b/app-api/src/main/java/com/tasteam/domain/group/service/GroupService.java
@@ -465,6 +465,7 @@ public class GroupService {
 
 		if (image.getStatus() == ImageStatus.PENDING) {
 			image.activate();
+			imageRepository.save(image);
 		}
 	}
 

--- a/app-api/src/main/java/com/tasteam/domain/subgroup/service/SubgroupService.java
+++ b/app-api/src/main/java/com/tasteam/domain/subgroup/service/SubgroupService.java
@@ -521,6 +521,7 @@ public class SubgroupService {
 
 		if (image.getStatus() == ImageStatus.PENDING) {
 			image.activate();
+			imageRepository.save(image);
 		}
 	}
 

--- a/app-api/src/test/java/com/tasteam/domain/file/service/GroupSubgroupImageActivationIntegrationTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/file/service/GroupSubgroupImageActivationIntegrationTest.java
@@ -1,0 +1,221 @@
+package com.tasteam.domain.file.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.tasteam.config.annotation.ServiceIntegrationTest;
+import com.tasteam.domain.file.entity.DomainImage;
+import com.tasteam.domain.file.entity.DomainType;
+import com.tasteam.domain.file.entity.FilePurpose;
+import com.tasteam.domain.file.entity.Image;
+import com.tasteam.domain.file.entity.ImageStatus;
+import com.tasteam.domain.file.repository.DomainImageRepository;
+import com.tasteam.domain.file.repository.ImageRepository;
+import com.tasteam.domain.group.dto.GroupCreateRequest;
+import com.tasteam.domain.group.dto.GroupCreateResponse;
+import com.tasteam.domain.group.dto.GroupUpdateRequest;
+import com.tasteam.domain.group.entity.Group;
+import com.tasteam.domain.group.entity.GroupMember;
+import com.tasteam.domain.group.repository.GroupMemberRepository;
+import com.tasteam.domain.group.repository.GroupRepository;
+import com.tasteam.domain.group.service.GroupService;
+import com.tasteam.domain.group.type.GroupJoinType;
+import com.tasteam.domain.group.type.GroupType;
+import com.tasteam.domain.member.entity.Member;
+import com.tasteam.domain.member.repository.MemberRepository;
+import com.tasteam.domain.subgroup.dto.SubgroupCreateRequest;
+import com.tasteam.domain.subgroup.dto.SubgroupCreateResponse;
+import com.tasteam.domain.subgroup.dto.SubgroupUpdateRequest;
+import com.tasteam.domain.subgroup.entity.Subgroup;
+import com.tasteam.domain.subgroup.repository.SubgroupRepository;
+import com.tasteam.domain.subgroup.service.SubgroupService;
+import com.tasteam.domain.subgroup.type.SubgroupJoinType;
+import com.tasteam.fixture.GroupFixture;
+import com.tasteam.fixture.MemberFixture;
+
+@ServiceIntegrationTest
+@Transactional
+class GroupSubgroupImageActivationIntegrationTest {
+
+	@Autowired
+	private GroupService groupService;
+
+	@Autowired
+	private SubgroupService subgroupService;
+
+	@Autowired
+	private GroupRepository groupRepository;
+
+	@Autowired
+	private GroupMemberRepository groupMemberRepository;
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@Autowired
+	private SubgroupRepository subgroupRepository;
+
+	@Autowired
+	private ImageRepository imageRepository;
+
+	@Autowired
+	private DomainImageRepository domainImageRepository;
+
+	@Nested
+	@DisplayName("Group 이미지 상태 전환")
+	class GroupImageActivation {
+
+		@Test
+		@DisplayName("그룹 생성에서 PENDING 이미지를 연결하면 ACTIVE로 전환된다")
+		void createGroupActivatesPendingImage() {
+			UUID fileUuid = UUID.randomUUID();
+			imageRepository.save(Image.create(
+				FilePurpose.GROUP_IMAGE,
+				"group-create.png",
+				1024L,
+				"image/png",
+				"uploads/group/image/group-create.png",
+				fileUuid));
+
+			GroupCreateRequest request = new GroupCreateRequest(
+				"group-" + System.nanoTime(),
+				fileUuid.toString(),
+				GroupType.UNOFFICIAL,
+				"서울특별시 강남구",
+				null,
+				new GroupCreateRequest.Location(37.5, 127.0),
+				GroupJoinType.PASSWORD,
+				null,
+				"123456");
+
+			GroupCreateResponse response = groupService.createGroup(request);
+
+			Image updatedImage = imageRepository.findByFileUuid(fileUuid).orElseThrow();
+			assertThat(updatedImage.getStatus()).isEqualTo(ImageStatus.ACTIVE);
+
+			List<DomainImage> links = domainImageRepository.findAllByDomainTypeAndDomainIdIn(
+				DomainType.GROUP,
+				List.of(response.id()));
+			assertThat(links).hasSize(1);
+		}
+
+		@Test
+		@DisplayName("그룹 수정에서 PENDING 이미지를 연결하면 ACTIVE로 전환된다")
+		void updateGroupActivatesPendingImage() {
+			Group group = groupRepository.save(GroupFixture.create("update-group-" + System.nanoTime(), "서울시 강남구"));
+			UUID fileUuid = UUID.randomUUID();
+			imageRepository.save(Image.create(
+				FilePurpose.GROUP_IMAGE,
+				"group-update.png",
+				1024L,
+				"image/png",
+				"uploads/group/image/group-update.png",
+				fileUuid));
+
+			groupService.updateGroup(
+				group.getId(),
+				new GroupUpdateRequest(null, null, null, null, null, TextNode.valueOf(fileUuid.toString())));
+
+			Image updatedImage = imageRepository.findByFileUuid(fileUuid).orElseThrow();
+			assertThat(updatedImage.getStatus()).isEqualTo(ImageStatus.ACTIVE);
+
+			List<DomainImage> links = domainImageRepository.findAllByDomainTypeAndDomainIdIn(
+				DomainType.GROUP,
+				List.of(group.getId()));
+			assertThat(links).hasSize(1);
+		}
+	}
+
+	@Nested
+	@DisplayName("Subgroup 이미지 상태 전환")
+	class SubgroupImageActivation {
+
+		@Test
+		@DisplayName("하위그룹 생성에서 PENDING 이미지를 연결하면 ACTIVE로 전환된다")
+		void createSubgroupActivatesPendingImage() {
+			Member member = memberRepository
+				.save(MemberFixture.create("subgroup-create@example.com", "subgroup-create"));
+			Group group = groupRepository.save(GroupFixture.create("subgroup-group-" + System.nanoTime(), "서울시 강남구"));
+			groupMemberRepository.save(GroupMember.create(group.getId(), member));
+
+			UUID fileUuid = UUID.randomUUID();
+			imageRepository.save(Image.create(
+				FilePurpose.PROFILE_IMAGE,
+				"subgroup-create.png",
+				1024L,
+				"image/png",
+				"uploads/profile/image/subgroup-create.png",
+				fileUuid));
+
+			SubgroupCreateRequest request = new SubgroupCreateRequest(
+				"subgroup-" + System.nanoTime(),
+				null,
+				fileUuid.toString(),
+				SubgroupJoinType.OPEN,
+				null);
+
+			SubgroupCreateResponse response = subgroupService.createSubgroup(group.getId(), member.getId(), request);
+
+			Image updatedImage = imageRepository.findByFileUuid(fileUuid).orElseThrow();
+			assertThat(updatedImage.getStatus()).isEqualTo(ImageStatus.ACTIVE);
+
+			List<DomainImage> links = domainImageRepository.findAllByDomainTypeAndDomainIdIn(
+				DomainType.SUBGROUP,
+				List.of(response.data().id()));
+			assertThat(links).hasSize(1);
+		}
+
+		@Test
+		@DisplayName("하위그룹 수정에서 PENDING 이미지를 연결하면 ACTIVE로 전환된다")
+		void updateSubgroupActivatesPendingImage() {
+			Member member = memberRepository
+				.save(MemberFixture.create("subgroup-update@example.com", "subgroup-update"));
+			Group group = groupRepository
+				.save(GroupFixture.create("subgroup-update-group-" + System.nanoTime(), "서울시 강남구"));
+			groupMemberRepository.save(GroupMember.create(group.getId(), member));
+
+			SubgroupCreateResponse created = subgroupService.createSubgroup(
+				group.getId(),
+				member.getId(),
+				new SubgroupCreateRequest(
+					"subgroup-update-" + System.nanoTime(),
+					null,
+					null,
+					SubgroupJoinType.OPEN,
+					null));
+			Subgroup subgroup = subgroupRepository.findById(created.data().id()).orElseThrow();
+
+			UUID fileUuid = UUID.randomUUID();
+			imageRepository.save(Image.create(
+				FilePurpose.PROFILE_IMAGE,
+				"subgroup-update.png",
+				1024L,
+				"image/png",
+				"uploads/profile/image/subgroup-update.png",
+				fileUuid));
+
+			subgroupService.updateSubgroup(
+				group.getId(),
+				subgroup.getId(),
+				member.getId(),
+				new SubgroupUpdateRequest(null, null, TextNode.valueOf(fileUuid.toString())));
+
+			Image updatedImage = imageRepository.findByFileUuid(fileUuid).orElseThrow();
+			assertThat(updatedImage.getStatus()).isEqualTo(ImageStatus.ACTIVE);
+
+			List<DomainImage> links = domainImageRepository.findAllByDomainTypeAndDomainIdIn(
+				DomainType.SUBGROUP,
+				List.of(subgroup.getId()));
+			assertThat(links).hasSize(1);
+		}
+	}
+}


### PR DESCRIPTION
• ## 📌 PR 요약

  #### Summary

  - 그룹/하위그룹 이미지 연결 시 Image.status가 PENDING에서 ACTIVE로 반영되지 않던 문제를 수정했습니다.
  - 영속성 컨텍스트 clear 부작용으로 인한 상태 반영 누락을 제거하고, 상태 저장을 명시적으로 보장했습니다.
  - 관련 회귀 방지 통합 테스트를 추가했습니다.

  ### Issue

  - close : #

  ———

  ## ➕ 추가된 기능

  1. 그룹/하위그룹 이미지 상태 전환 회귀 방지 통합 테스트 추가
      - GroupSubgroupImageActivationIntegrationTest
  2. 생성/수정 시 이미지 연결 후 ACTIVE 전환 및 도메인 링크 생성 검증 케이스 추가

  ## 🛠️ 수정/변경사항

  1. DomainImageRepository.deleteAllByDomainTypeAndDomainId를 @Modifying(clearAutomatically=true) 커스텀 쿼리에서 파생 메서드 방식으로 변경 (영속성 컨텍스트 clear 영향 제거)
  2. GroupService/SubgroupService 이미지 연결 로직에서 image.activate() 후 imageRepository.save(image)를 명시 호출하도록 변경

  ———

  ## ✅ 남은 작업

