### PR TITLE
🐛 fix: 커넥션 풀 default(10)에서 50으로 변경

### DIFF
--- a/app-api/src/main/resources/application.prod.yml
+++ b/app-api/src/main/resources/application.prod.yml
@@ -15,6 +15,13 @@ spring:
     url: ${DB_URL}
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
+    hikari:
+      maximum-pool-size: 50
+      minimum-idle: 10
+      connection-timeout: 30000
+      idle-timeout: 600000
+      max-lifetime: 1800000
+      leak-detection-threshold: 60000
 
   flyway:
     url: ${FLYWAY_URL:${DB_URL}}


### PR DESCRIPTION
## 📌 PR 요약

#### Summary
- 커넥션 풀 default 값 10에서 50으로 변경

### Issue
- close : #178 

---

## ➕ 추가된 기능
<!--
  새로운 기능을 소개하세요. 무엇이 새롭게 생기는지, 어떤 화면/API가 추가되는지를 기술하고 예시를 덧붙이면 좋습니다.
  예: "관리자 설정에서 `예약 알림` 토글을 추가하여 알림을 켜고 끌 수 있게 함."
-->

기능 변경 사항은 없습니다.

## 🛠️ 수정/변경사항
<!--
  기존 기능 변경, 버그 수정, 리팩토링 등을 나열하세요. 영향 범위도 함께 쓰면 리뷰어가 이해하기 쉽습니다.
  예: "- 예약 API 응답에 `status` 필드를 추가함", "- 기존 실패율 경고 문구 변경"
-->

1. HikariCP의 커넥션 풀을 늘려서 부하를 받을 수 있도록 변경했습니다.

---

## ✅ 남은 작업

<!--
  아직 완료되지 않은 작업이나 사후에 처리해야 할 항목을 정리하세요. 검토자/다음 작업자에게 힌트가 됩니다.
-->
* [ ] 
