### PR TITLE
🐛 fix: 그룹 이미지 링크 직접 참조하지 않도록 수정

### DIFF
--- a/app-api/src/main/java/com/tasteam/domain/search/service/SearchService.java
+++ b/app-api/src/main/java/com/tasteam/domain/search/service/SearchService.java
@@ -169,11 +169,15 @@ public class SearchService {
 					GroupMemberCountProjection::getGroupId,
 					GroupMemberCountProjection::getMemberCount));
 
+		Map<Long, List<DomainImageItem>> logos = groupIds.isEmpty()
+			? Map.of()
+			: fileService.getDomainImageUrls(DomainType.GROUP, groupIds);
+
 		return groups.stream()
 			.map(group -> new SearchGroupSummary(
 				group.getId(),
 				group.getName(),
-				group.getLogoImageUrl(),
+				firstDomainImageUrl(logos.getOrDefault(group.getId(), List.of())),
 				memberCounts.getOrDefault(group.getId(), 0L)))
 			.toList();
 	}
@@ -202,6 +206,13 @@ public class SearchService {
 	}
 
 	private String thumbnailUrl(List<RestaurantImageDto> images) {
+		if (images == null || images.isEmpty()) {
+			return null;
+		}
+		return images.getFirst().url();
+	}
+
+	private String firstDomainImageUrl(List<DomainImageItem> images) {
 		if (images == null || images.isEmpty()) {
 			return null;
 		}


### PR DESCRIPTION
## 📌 PR 요약

  #### Summary

  - 통합 검색의 그룹 로고 URL 반환 로직을 group.logo_image_url 컬럼 의존에서 DomainImage 링크 기반으로 변경했습니다.
  - 그룹/하위그룹 이미지 연결 시 PENDING -> ACTIVE 상태 반영 누락 이슈를 함께 보완해, 저장 직후 조회에서 이미지가 null로 내려오는 문제 해결

  ### Issue

  - close : #

  ———

  ## ➕ 추가된 기능

  1. 통합 검색 그룹 결과(SearchGroupSummary.logoImageUrl)를 DomainType.GROUP 이미지 링크 기반으로 조회
  2. 그룹/하위그룹 이미지 연결 후 Image.status가 즉시 ACTIVE로 반영되도록 안정화 로직 및 통합 테스트 추가

  ## 🛠️ 수정/변경사항

  1. SearchService.searchGroups()에서 group.getLogoImageUrl() 사용 제거, fileService.getDomainImageUrls(DomainType.GROUP, groupIds) 기반 매핑으로 변경
  2. GroupService/SubgroupService 이미지 연결 로직에서 image.activate() 후 imageRepository.save(image) 명시 호출 + DomainImageRepository 삭제 메서드의 clear 부작용 제거

  ———

  ## ✅ 남은 작업

