### PR TITLE
✨ feat(review): 리뷰 목록 API에 그룹명·하위그룹명 및 groupId·subgroupId 추가

### DIFF
--- a/app-api/src/main/java/com/tasteam/domain/restaurant/dto/request/ReviewResponse.java
+++ b/app-api/src/main/java/com/tasteam/domain/restaurant/dto/request/ReviewResponse.java
@@ -9,6 +9,14 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record ReviewResponse(
 	@Schema(description = "리뷰 ID", example = "101")
 	long id,
+	@Schema(description = "그룹 ID", example = "1")
+	long groupId,
+	@Schema(description = "하위그룹 ID (없으면 null)", example = "2")
+	Long subgroupId,
+	@Schema(description = "그룹명", example = "맛집 탐방반")
+	String groupName,
+	@Schema(description = "하위그룹명 (없으면 null)", example = "강남구 모임")
+	String subgroupName,
 	@Schema(description = "작성자 정보")
 	AuthorResponse author,
 	@Schema(description = "리뷰 본문 요약", example = "가격 대비 맛있어요.")

--- a/app-api/src/main/java/com/tasteam/domain/review/dto/ReviewQueryDto.java
+++ b/app-api/src/main/java/com/tasteam/domain/review/dto/ReviewQueryDto.java
@@ -4,6 +4,10 @@ import java.time.Instant;
 
 public record ReviewQueryDto(
 	Long reviewId,
+	Long groupId,
+	Long subgroupId,
+	String groupName,
+	String subgroupName,
 	Long memberId,
 	String memberName,
 	String content,

--- a/app-api/src/main/java/com/tasteam/domain/review/repository/impl/ReviewQueryRepositoryImpl.java
+++ b/app-api/src/main/java/com/tasteam/domain/review/repository/impl/ReviewQueryRepositoryImpl.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Repository;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.tasteam.domain.common.repository.QueryDslSupport;
+import com.tasteam.domain.group.entity.QGroup;
 import com.tasteam.domain.member.entity.QMember;
 import com.tasteam.domain.restaurant.entity.QRestaurant;
 import com.tasteam.domain.review.dto.ReviewCursor;
@@ -16,6 +17,7 @@ import com.tasteam.domain.review.dto.ReviewQueryDto;
 import com.tasteam.domain.review.entity.QReview;
 import com.tasteam.domain.review.entity.Review;
 import com.tasteam.domain.review.repository.ReviewQueryRepository;
+import com.tasteam.domain.subgroup.entity.QSubgroup;
 
 @Repository
 public class ReviewQueryRepositoryImpl extends QueryDslSupport implements ReviewQueryRepository {
@@ -28,11 +30,17 @@ public class ReviewQueryRepositoryImpl extends QueryDslSupport implements Review
 	public List<ReviewQueryDto> findRestaurantReviews(Long restaurantId, ReviewCursor cursor, int size) {
 		QReview review = QReview.review;
 		QMember member = QMember.member;
+		QGroup group = QGroup.group;
+		QSubgroup subgroup = QSubgroup.subgroup;
 
 		return getQueryFactory()
 			.select(Projections.constructor(
 				ReviewQueryDto.class,
 				review.id,
+				review.groupId,
+				review.subgroupId,
+				group.name,
+				subgroup.name,
 				member.id,
 				member.nickname,
 				review.content,
@@ -40,6 +48,8 @@ public class ReviewQueryRepositoryImpl extends QueryDslSupport implements Review
 				review.createdAt))
 			.from(review)
 			.join(review.member, member)
+			.join(group).on(review.groupId.eq(group.id))
+			.leftJoin(subgroup).on(review.subgroupId.eq(subgroup.id))
 			.where(
 				review.restaurant.id.eq(restaurantId),
 				review.deletedAt.isNull(),
@@ -53,11 +63,17 @@ public class ReviewQueryRepositoryImpl extends QueryDslSupport implements Review
 	public List<ReviewQueryDto> findGroupReviews(Long groupId, ReviewCursor cursor, int size) {
 		QReview review = QReview.review;
 		QMember member = QMember.member;
+		QGroup group = QGroup.group;
+		QSubgroup subgroup = QSubgroup.subgroup;
 
 		return getQueryFactory()
 			.select(Projections.constructor(
 				ReviewQueryDto.class,
 				review.id,
+				review.groupId,
+				review.subgroupId,
+				group.name,
+				subgroup.name,
 				member.id,
 				member.nickname,
 				review.content,
@@ -65,6 +81,8 @@ public class ReviewQueryRepositoryImpl extends QueryDslSupport implements Review
 				review.createdAt))
 			.from(review)
 			.join(review.member, member)
+			.join(group).on(review.groupId.eq(group.id))
+			.leftJoin(subgroup).on(review.subgroupId.eq(subgroup.id))
 			.where(
 				review.groupId.eq(groupId),
 				review.deletedAt.isNull(),
@@ -78,11 +96,17 @@ public class ReviewQueryRepositoryImpl extends QueryDslSupport implements Review
 	public List<ReviewQueryDto> findSubgroupReviews(Long subgroupId, ReviewCursor cursor, int size) {
 		QReview review = QReview.review;
 		QMember member = QMember.member;
+		QGroup group = QGroup.group;
+		QSubgroup subgroup = QSubgroup.subgroup;
 
 		return getQueryFactory()
 			.select(Projections.constructor(
 				ReviewQueryDto.class,
 				review.id,
+				review.groupId,
+				review.subgroupId,
+				group.name,
+				subgroup.name,
 				member.id,
 				member.nickname,
 				review.content,
@@ -90,6 +114,8 @@ public class ReviewQueryRepositoryImpl extends QueryDslSupport implements Review
 				review.createdAt))
 			.from(review)
 			.join(review.member, member)
+			.join(group).on(review.groupId.eq(group.id))
+			.leftJoin(subgroup).on(review.subgroupId.eq(subgroup.id))
 			.where(
 				review.subgroupId.eq(subgroupId),
 				review.deletedAt.isNull(),

--- a/app-api/src/main/java/com/tasteam/domain/review/service/ReviewService.java
+++ b/app-api/src/main/java/com/tasteam/domain/review/service/ReviewService.java
@@ -341,6 +341,10 @@ public class ReviewService {
 		return pageContent.stream()
 			.map(review -> new ReviewResponse(
 				review.reviewId(),
+				review.groupId(),
+				review.subgroupId(),
+				review.groupName(),
+				review.subgroupName(),
 				new ReviewResponse.AuthorResponse(review.memberName()),
 				review.content(),
 				review.isRecommended(),

--- a/app-api/src/test/java/com/tasteam/domain/group/controller/GroupControllerTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/group/controller/GroupControllerTest.java
@@ -389,7 +389,7 @@ class GroupControllerTest {
 		void 그룹_리뷰_목록_조회_성공() throws Exception {
 			// given
 			CursorPageResponse<ReviewResponse> response = new CursorPageResponse<>(
-				List.of(new ReviewResponse(1L,
+				List.of(new ReviewResponse(1L, 2L, 3L, "테스트그룹", "테스트하위그룹",
 					new ReviewResponse.AuthorResponse("테스트유저"),
 					"맛있어요", true, List.of("친절"),
 					List.of(new ReviewResponse.ReviewImageResponse(1L, "https://example.com/review.jpg")),

--- a/app-api/src/test/java/com/tasteam/domain/restaurant/controller/RestaurantControllerTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/restaurant/controller/RestaurantControllerTest.java
@@ -161,7 +161,7 @@ class RestaurantControllerTest {
 		void 음식점_리뷰_목록_조회_성공() throws Exception {
 			// given
 			CursorPageResponse<ReviewResponse> response = new CursorPageResponse<>(
-				List.of(new ReviewResponse(1L,
+				List.of(new ReviewResponse(1L, 2L, 3L, "테스트그룹", "테스트하위그룹",
 					new ReviewResponse.AuthorResponse("테스트유저"),
 					"맛있어요", true, List.of("친절", "깨끗"),
 					List.of(new ReviewResponse.ReviewImageResponse(1L, "https://example.com/review.jpg")),

--- a/app-api/src/test/java/com/tasteam/domain/subgroup/controller/SubgroupControllerTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/subgroup/controller/SubgroupControllerTest.java
@@ -48,7 +48,7 @@ class SubgroupControllerTest {
 		void 서브그룹_리뷰_목록_조회_성공() throws Exception {
 			// given
 			CursorPageResponse<ReviewResponse> response = new CursorPageResponse<>(
-				List.of(new ReviewResponse(1L,
+				List.of(new ReviewResponse(1L, 2L, 3L, "테스트그룹", "테스트하위그룹",
 					new ReviewResponse.AuthorResponse("테스트유저"),
 					"맛있어요", true, List.of("친절"),
 					List.of(new ReviewResponse.ReviewImageResponse(1L, "https://example.com/review.jpg")),


### PR DESCRIPTION
## 📌 PR 요약

#### Summary
- ReviewResponse에 groupId, subgroupId, groupName, subgroupName 필드 추가
- ReviewQueryDto에 groupId, subgroupId, groupName, subgroupName 추가
- ReviewQueryRepositoryImpl에서 Group/Subgroup 조인 후 name·id 프로젝션
- ReviewService buildReviewResponses에서 ID·이름 매핑
- 컨트롤러·리포지토리 테스트 수정

### Issue
- close : #

---

## ➕ 추가된 기능
<!--
  새로운 기능을 소개하세요. 무엇이 새롭게 생기는지, 어떤 화면/API가 추가되는지를 기술하고 예시를 덧붙이면 좋습니다.
  예: "관리자 설정에서 `예약 알림` 토글을 추가하여 알림을 켜고 끌 수 있게 함."
-->

1.
2. 

## 🛠️ 수정/변경사항
<!--
  기존 기능 변경, 버그 수정, 리팩토링 등을 나열하세요. 영향 범위도 함께 쓰면 리뷰어가 이해하기 쉽습니다.
  예: "- 예약 API 응답에 `status` 필드를 추가함", "- 기존 실패율 경고 문구 변경"
-->

1.
2.

---

## ✅ 남은 작업

<!--
  아직 완료되지 않은 작업이나 사후에 처리해야 할 항목을 정리하세요. 검토자/다음 작업자에게 힌트가 됩니다.
-->
* [ ] 
