### PR TITLE
Fix: 검색 히스토리 테이블명 오타 수정

### DIFF
--- a/app-api/src/main/java/com/tasteam/domain/search/entity/MemberSearchHistory.java
+++ b/app-api/src/main/java/com/tasteam/domain/search/entity/MemberSearchHistory.java
@@ -23,7 +23,7 @@ import lombok.NoArgsConstructor;
 @Builder(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "member_serach_history")
+@Table(name = "member_search_history")
 @Comment("회원 검색어 기록")
 public class MemberSearchHistory extends BaseTimeEntity {
 


### PR DESCRIPTION
## 📌 PR 요약

#### Summary
- JPA 엔티티의 테이블명을 실제 테이블(`member_search_history`)과 일치하도록 오타를 수정했습니다.

### Issue
- close : #

---

## ➕ 추가된 기능
1. 없음
2. 

## 🛠️ 수정/변경사항
1. `MemberSearchHistory`의 `@Table` 이름을 `member_serach_history` → `member_search_history`로 정정하여 매핑 오류를 방지했습니다.
2. 

---

## ✅ 남은 작업
* [ ] 스테이징에서 JPA 스키마 검증 실행
