### PR TITLE
Fix: 검색 히스토리 테이블 생성 마이그레이션 추가

### DIFF
--- a/app-api/src/main/resources/db/migration/V20260206__create_member_search_history.sql
+++ b/app-api/src/main/resources/db/migration/V20260206__create_member_search_history.sql
@@ -1,0 +1,11 @@
+CREATE TABLE member_search_history (
+    id BIGSERIAL PRIMARY KEY,
+    member_id BIGINT NOT NULL,
+    keyword VARCHAR(100) NOT NULL,
+    count BIGINT NOT NULL,
+    deleted_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE member_search_history IS '회원 검색어 기록';


### PR DESCRIPTION
## 📌 PR 요약

#### Summary
- 누락된 `member_search_history` 테이블 생성 마이그레이션을 추가해 엔티티 매핑과 DB 스키마를 일치시켰습니다.

### Issue
- close : #

---

## ➕ 추가된 기능
1. Flyway 마이그레이션 `V20260206__create_member_search_history.sql`에 회원 검색어 기록 테이블 생성 스크립트 추가
2. 

## 🛠️ 수정/변경사항
1. 테이블 생성 시 기본 키, 회원 ID, 키워드, 카운트, 생성/수정/삭제 일시 컬럼을 정의해 조회/집계에 필요한 필드를 확보했습니다.
2. 

---

## ✅ 남은 작업
* [ ] 스테이징/프로덕션에 마이그레이션 적용 후 검색 기록 기능 동작 확인
