### PR TITLE
🐛 fix: 리뷰 생성 후 분석 작업을 비동기로 분리

### DIFF
--- a/app-api/src/main/java/com/tasteam/domain/restaurant/service/analysis/ReviewCreatedAiAnalysisEventListener.java
+++ b/app-api/src/main/java/com/tasteam/domain/restaurant/service/analysis/ReviewCreatedAiAnalysisEventListener.java
@@ -1,7 +1,9 @@
 package com.tasteam.domain.restaurant.service.analysis;
 
-import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 import com.tasteam.domain.review.event.ReviewCreatedEvent;
 
@@ -13,7 +15,8 @@ public class ReviewCreatedAiAnalysisEventListener {
 
 	private final RestaurantReviewAnalysisService restaurantReviewAnalysisService;
 
-	@EventListener
+	@Async("aiAnalysisExecutor")
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void onReviewCreated(ReviewCreatedEvent event) {
 		restaurantReviewAnalysisService.onReviewCreated(event.restaurantId());
 	}

--- a/app-api/src/main/java/com/tasteam/global/config/AsyncConfig.java
+++ b/app-api/src/main/java/com/tasteam/global/config/AsyncConfig.java
@@ -38,6 +38,17 @@ public class AsyncConfig implements AsyncConfigurer {
 		return executor;
 	}
 
+	@Bean(name = "aiAnalysisExecutor")
+	public Executor aiAnalysisExecutor() {
+		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+		executor.setCorePoolSize(1);
+		executor.setMaxPoolSize(1);
+		executor.setQueueCapacity(200);
+		executor.setThreadNamePrefix("ai-analysis-");
+		executor.initialize();
+		return executor;
+	}
+
 	@Override
 	public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
 		return (ex, method, params) -> log.error("비동기 메서드 {}에서 예외 발생: {}", method.getName(),


### PR DESCRIPTION
## 📌 PR 요약

#### Summary
- 리뷰 작성과 리뷰 분석이 동기적으로 이뤄져 리뷰 작성 API가 리뷰 분석 완료를 기다리며 Pending 상태가 됩니다.
- 리뷰 작성 후에 이뤄지는 리뷰 분석 작업을 비동기로 처리하도록 변경했습니다.

### Issue
- close : #

---
## 🛠️ 수정/변경사항
1. 리뷰 분석 적용 비동기 스레드 풀 추가
    - AI 서버가 하나의 워커로 CPU 바운드 작업을 진행하므로, 사실상 순차 처리만 가능한 상황
    - CorePoolSize, MaxPoolSize를 1로 설정하는 대신 QueueCapacity를 200으로 여유있게 설정
2. 리뷰 작성 트랜잭션 커밋 후 비동기로 리뷰 분석을 진행하도록 어노테이션 추가
    - 리뷰 작성 전/리뷰 작성 실패시 분석 작업이 비동기로 진행되는 것을 막기 위해 
    - @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT) 추가