### PR TITLE
Fix: PostgreSQL와 Hibernate의 시퀀스 자동 생성시 테이블 명 불일치 수정

### DIFF
--- a/app-api/src/main/java/com/tasteam/domain/file/entity/DomainImage.java
+++ b/app-api/src/main/java/com/tasteam/domain/file/entity/DomainImage.java
@@ -16,6 +16,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
@@ -35,7 +36,8 @@ import lombok.NoArgsConstructor;
 public class DomainImage extends BaseCreatedAtEntity {
 
 	@Id
-	@GeneratedValue(strategy = GenerationType.SEQUENCE)
+	@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "domain_image_seq_gen")
+	@SequenceGenerator(name = "domain_image_seq_gen", sequenceName = "domain_image_seq", allocationSize = 50)
 	private Long id;
 
 	@Enumerated(EnumType.STRING)

--- a/app-api/src/main/java/com/tasteam/domain/file/entity/Image.java
+++ b/app-api/src/main/java/com/tasteam/domain/file/entity/Image.java
@@ -14,6 +14,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -30,7 +31,8 @@ import lombok.NoArgsConstructor;
 public class Image extends BaseTimeEntity {
 
 	@Id
-	@GeneratedValue(strategy = GenerationType.SEQUENCE)
+	@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "image_seq_gen")
+	@SequenceGenerator(name = "image_seq_gen", sequenceName = "image_seq", allocationSize = 50)
 	private Long id;
 
 	@Column(name = "file_name", nullable = false, length = 256)


### PR DESCRIPTION
## 📌 PR 요약

#### Summary
- 

---

## 🛠️ 수정/변경사항
<!--
  기존 기능 변경, 버그 수정, 리팩토링 등을 나열하세요. 영향 범위도 함께 쓰면 리뷰어가 이해하기 쉽습니다.
  예: "- 예약 API 응답에 `status` 필드를 추가함", "- 기존 실패율 경고 문구 변경"
-->

1. Flyway 마이그레이션에서 BIGSERIAL을 사용하면 PostgreSQL이 시퀀스를 자동 생성합니다. 하지만 Hibernate는 다른 이름의 시퀀스를 기대합니다.
수정사항 : @SequenceGenerator로 실제 시퀀스 이름 명시

---

## ✅ 남은 작업

<!--
  아직 완료되지 않은 작업이나 사후에 처리해야 할 항목을 정리하세요. 검토자/다음 작업자에게 힌트가 됩니다.
-->
* [ ] 
