### PR TITLE
Feat: 그룹 가입 이벤트 MQ 발행 브리지 추가

### DIFF
--- a/app-api/src/main/java/com/tasteam/infra/messagequeue/GroupMemberJoinedMessagePayload.java
+++ b/app-api/src/main/java/com/tasteam/infra/messagequeue/GroupMemberJoinedMessagePayload.java
@@ -1,0 +1,8 @@
+package com.tasteam.infra.messagequeue;
+
+public record GroupMemberJoinedMessagePayload(
+	Long groupId,
+	Long memberId,
+	String groupName,
+	long joinedAtEpochMillis) {
+}

--- a/app-api/src/main/java/com/tasteam/infra/messagequeue/GroupMemberJoinedMessageQueuePublisher.java
+++ b/app-api/src/main/java/com/tasteam/infra/messagequeue/GroupMemberJoinedMessageQueuePublisher.java
@@ -1,0 +1,55 @@
+package com.tasteam.infra.messagequeue;
+
+import java.util.Map;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tasteam.domain.group.event.GroupMemberJoinedEvent;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "tasteam.message-queue", name = "enabled", havingValue = "true")
+public class GroupMemberJoinedMessageQueuePublisher {
+
+	private final MessageQueueProducer messageQueueProducer;
+	private final MessageQueueProperties messageQueueProperties;
+	private final ObjectMapper objectMapper;
+
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+	public void onGroupMemberJoined(GroupMemberJoinedEvent event) {
+		if (messageQueueProperties.providerType() == MessageQueueProviderType.NONE) {
+			return;
+		}
+
+		byte[] payload = serializePayload(event);
+		MessageQueueMessage message = new MessageQueueMessage(
+			MessageQueueTopics.GROUP_MEMBER_JOINED,
+			String.valueOf(event.memberId()),
+			payload,
+			Map.of("eventType", "GroupMemberJoinedEvent", "schemaVersion", "v1"),
+			event.joinedAt(),
+			null);
+
+		messageQueueProducer.publish(message);
+	}
+
+	private byte[] serializePayload(GroupMemberJoinedEvent event) {
+		GroupMemberJoinedMessagePayload payload = new GroupMemberJoinedMessagePayload(
+			event.groupId(),
+			event.memberId(),
+			event.groupName(),
+			event.joinedAt().toEpochMilli());
+		try {
+			return objectMapper.writeValueAsBytes(payload);
+		} catch (JsonProcessingException ex) {
+			throw new IllegalStateException("GroupMemberJoinedEvent 메시지 직렬화에 실패했습니다", ex);
+		}
+	}
+}

--- a/app-api/src/main/java/com/tasteam/infra/messagequeue/MessageQueueTopics.java
+++ b/app-api/src/main/java/com/tasteam/infra/messagequeue/MessageQueueTopics.java
@@ -3,6 +3,7 @@ package com.tasteam.infra.messagequeue;
 public final class MessageQueueTopics {
 
 	public static final String REVIEW_CREATED = "domain.review.created";
+	public static final String GROUP_MEMBER_JOINED = "domain.group.member-joined";
 
 	private MessageQueueTopics() {}
 }

--- a/app-api/src/test/java/com/tasteam/infra/messagequeue/GroupMemberJoinedMessageQueuePublisherTest.java
+++ b/app-api/src/test/java/com/tasteam/infra/messagequeue/GroupMemberJoinedMessageQueuePublisherTest.java
@@ -1,0 +1,104 @@
+package com.tasteam.infra.messagequeue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tasteam.config.annotation.UnitTest;
+import com.tasteam.domain.group.event.GroupMemberJoinedEvent;
+
+@UnitTest
+@DisplayName("GroupMemberJoined MQ 퍼블리셔")
+class GroupMemberJoinedMessageQueuePublisherTest {
+
+	@Test
+	@DisplayName("provider가 none이면 메시지를 발행하지 않는다")
+	void onGroupMemberJoined_withNoneProvider_skipsPublish() {
+		// given
+		MessageQueueProducer producer = mock(MessageQueueProducer.class);
+		MessageQueueProperties properties = new MessageQueueProperties();
+		properties.setProvider("none");
+		ObjectMapper objectMapper = new ObjectMapper();
+		GroupMemberJoinedMessageQueuePublisher publisher = new GroupMemberJoinedMessageQueuePublisher(
+			producer,
+			properties,
+			objectMapper);
+		GroupMemberJoinedEvent event = new GroupMemberJoinedEvent(10L, 20L, "테스트 그룹", Instant.now());
+
+		// when
+		publisher.onGroupMemberJoined(event);
+
+		// then
+		verifyNoInteractions(producer);
+	}
+
+	@Test
+	@DisplayName("provider가 redis-stream이면 GroupMemberJoined 이벤트를 MQ로 발행한다")
+	void onGroupMemberJoined_withRedisStreamProvider_publishesMessage() throws Exception {
+		// given
+		MessageQueueProducer producer = mock(MessageQueueProducer.class);
+		MessageQueueProperties properties = new MessageQueueProperties();
+		properties.setProvider("redis-stream");
+		ObjectMapper objectMapper = new ObjectMapper();
+		GroupMemberJoinedMessageQueuePublisher publisher = new GroupMemberJoinedMessageQueuePublisher(
+			producer,
+			properties,
+			objectMapper);
+		Instant joinedAt = Instant.parse("2026-02-15T00:00:00Z");
+		GroupMemberJoinedEvent event = new GroupMemberJoinedEvent(10L, 20L, "테스트 그룹", joinedAt);
+
+		// when
+		publisher.onGroupMemberJoined(event);
+
+		// then
+		ArgumentCaptor<MessageQueueMessage> messageCaptor = ArgumentCaptor.forClass(MessageQueueMessage.class);
+		verify(producer).publish(messageCaptor.capture());
+
+		MessageQueueMessage message = messageCaptor.getValue();
+		assertThat(message.topic()).isEqualTo(MessageQueueTopics.GROUP_MEMBER_JOINED);
+		assertThat(message.key()).isEqualTo("20");
+		assertThat(message.occurredAt()).isEqualTo(joinedAt);
+		assertThat(message.headers()).containsEntry("eventType", "GroupMemberJoinedEvent");
+
+		GroupMemberJoinedMessagePayload payload = objectMapper.readValue(
+			message.payload(),
+			GroupMemberJoinedMessagePayload.class);
+		assertThat(payload.groupId()).isEqualTo(10L);
+		assertThat(payload.memberId()).isEqualTo(20L);
+		assertThat(payload.groupName()).isEqualTo("테스트 그룹");
+		assertThat(payload.joinedAtEpochMillis()).isEqualTo(joinedAt.toEpochMilli());
+	}
+
+	@Test
+	@DisplayName("직렬화에 실패하면 예외를 반환한다")
+	void onGroupMemberJoined_withSerializationFailure_throwsException() throws Exception {
+		// given
+		MessageQueueProducer producer = mock(MessageQueueProducer.class);
+		MessageQueueProperties properties = new MessageQueueProperties();
+		properties.setProvider("redis-stream");
+		ObjectMapper objectMapper = mock(ObjectMapper.class);
+		when(objectMapper.writeValueAsBytes(org.mockito.ArgumentMatchers.any()))
+			.thenThrow(new JsonProcessingException("failed") {});
+		GroupMemberJoinedMessageQueuePublisher publisher = new GroupMemberJoinedMessageQueuePublisher(
+			producer,
+			properties,
+			objectMapper);
+		GroupMemberJoinedEvent event = new GroupMemberJoinedEvent(10L, 20L, "테스트 그룹", Instant.now());
+
+		// when & then
+		assertThatThrownBy(() -> publisher.onGroupMemberJoined(event))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("직렬화");
+	}
+}


### PR DESCRIPTION
## 📌 PR 요약

#### Summary
- GroupMemberJoined 도메인 이벤트를 MQ 토픽(`domain.group.member-joined`)으로 발행하도록 브리지를 추가했습니다.
- 알림 MQ 전환을 위한 메시지 payload/토픽 계약을 추가했습니다.
- 발행 브리지 단위 테스트를 추가했습니다.

### Issue
- close : #337
- related : #336

---

## ➕ 추가된 기능
1. `GroupMemberJoinedMessageQueuePublisher` 추가
2. `GroupMemberJoinedMessagePayload` 추가
3. `MessageQueueTopics.GROUP_MEMBER_JOINED` 추가

## 🛠️ 수정/변경사항
1. MQ provider 분기(`none` skip) 및 직렬화 실패 예외 처리 추가
2. 퍼블리셔 테스트(`GroupMemberJoinedMessageQueuePublisherTest`) 추가

---

## ✅ 남은 작업
* [ ] #338 Notification MQ consumer 등록/수신 처리
* [ ] #339 통합 테스트 및 문서 반영

## 🧪 테스트
- `./gradlew :app-api:test --tests 'com.tasteam.infra.messagequeue.GroupMemberJoinedMessageQueuePublisherTest'`
