### PR TITLE
Feat: 알림 MQ 컨슈머 등록 및 수신 처리 추가

### DIFF
--- a/app-api/src/main/java/com/tasteam/domain/notification/event/NotificationEventListener.java
+++ b/app-api/src/main/java/com/tasteam/domain/notification/event/NotificationEventListener.java
@@ -1,5 +1,6 @@
 package com.tasteam.domain.notification.event;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
@@ -14,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Component
 @RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "tasteam.message-queue", name = "enabled", havingValue = "false", matchIfMissing = true)
 public class NotificationEventListener {
 
 	private final NotificationService notificationService;

--- a/app-api/src/main/java/com/tasteam/infra/messagequeue/NotificationMessageQueueConsumerRegistrar.java
+++ b/app-api/src/main/java/com/tasteam/infra/messagequeue/NotificationMessageQueueConsumerRegistrar.java
@@ -1,0 +1,70 @@
+package com.tasteam.infra.messagequeue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tasteam.domain.notification.entity.NotificationType;
+import com.tasteam.domain.notification.service.NotificationService;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "tasteam.message-queue", name = "enabled", havingValue = "true")
+public class NotificationMessageQueueConsumerRegistrar {
+
+	private final MessageQueueConsumer messageQueueConsumer;
+	private final MessageQueueProperties messageQueueProperties;
+	private final NotificationService notificationService;
+	private final ObjectMapper objectMapper;
+
+	private MessageQueueSubscription subscription;
+
+	@PostConstruct
+	public void subscribe() {
+		if (messageQueueProperties.providerType() == MessageQueueProviderType.NONE) {
+			log.info("메시지큐 provider가 none이라 Notification 구독 등록을 건너뜁니다");
+			return;
+		}
+
+		subscription = new MessageQueueSubscription(
+			MessageQueueTopics.GROUP_MEMBER_JOINED,
+			messageQueueProperties.getDefaultConsumerGroup(),
+			"notification-" + UUID.randomUUID());
+
+		messageQueueConsumer.subscribe(subscription, message -> {
+			GroupMemberJoinedMessagePayload payload = deserializePayload(message.payload());
+			notificationService.createNotification(
+				payload.memberId(),
+				NotificationType.SYSTEM,
+				"그룹 가입 완료",
+				payload.groupName() + " 그룹에 가입되었습니다.",
+				"/groups/" + payload.groupId());
+		});
+	}
+
+	@PreDestroy
+	public void unsubscribe() {
+		if (subscription != null) {
+			messageQueueConsumer.unsubscribe(subscription);
+		}
+	}
+
+	private GroupMemberJoinedMessagePayload deserializePayload(byte[] payload) {
+		try {
+			return objectMapper.readValue(payload, GroupMemberJoinedMessagePayload.class);
+		} catch (IOException ex) {
+			String payloadAsString = new String(payload, StandardCharsets.UTF_8);
+			throw new IllegalArgumentException("GroupMemberJoined 메시지 역직렬화에 실패했습니다. payload=" + payloadAsString, ex);
+		}
+	}
+}

--- a/app-api/src/test/java/com/tasteam/infra/messagequeue/NotificationMessageQueueConsumerRegistrarTest.java
+++ b/app-api/src/test/java/com/tasteam/infra/messagequeue/NotificationMessageQueueConsumerRegistrarTest.java
@@ -1,0 +1,117 @@
+package com.tasteam.infra.messagequeue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tasteam.config.annotation.UnitTest;
+import com.tasteam.domain.notification.entity.NotificationType;
+import com.tasteam.domain.notification.service.NotificationService;
+
+@UnitTest
+@DisplayName("Notification MQ 컨슈머 등록기")
+class NotificationMessageQueueConsumerRegistrarTest {
+
+	@Test
+	@DisplayName("provider가 none이면 구독을 등록하지 않는다")
+	void subscribe_withNoneProvider_skipsSubscription() {
+		// given
+		MessageQueueConsumer consumer = mock(MessageQueueConsumer.class);
+		MessageQueueProperties properties = new MessageQueueProperties();
+		properties.setProvider("none");
+		NotificationService notificationService = mock(NotificationService.class);
+		NotificationMessageQueueConsumerRegistrar registrar = new NotificationMessageQueueConsumerRegistrar(
+			consumer,
+			properties,
+			notificationService,
+			new ObjectMapper());
+
+		// when
+		registrar.subscribe();
+
+		// then
+		verifyNoInteractions(consumer);
+	}
+
+	@Test
+	@DisplayName("메시지를 수신하면 NotificationService로 알림 생성을 위임한다")
+	void subscribe_onMessage_delegatesToNotificationService() throws Exception {
+		// given
+		MessageQueueConsumer consumer = mock(MessageQueueConsumer.class);
+		MessageQueueProperties properties = new MessageQueueProperties();
+		properties.setProvider("redis-stream");
+		properties.setDefaultConsumerGroup("tasteam-api");
+		NotificationService notificationService = mock(NotificationService.class);
+		ObjectMapper objectMapper = new ObjectMapper();
+		NotificationMessageQueueConsumerRegistrar registrar = new NotificationMessageQueueConsumerRegistrar(
+			consumer,
+			properties,
+			notificationService,
+			objectMapper);
+
+		// when
+		registrar.subscribe();
+
+		// then
+		ArgumentCaptor<MessageQueueSubscription> subscriptionCaptor = ArgumentCaptor
+			.forClass(MessageQueueSubscription.class);
+		@SuppressWarnings("unchecked") ArgumentCaptor<MessageQueueMessageHandler> handlerCaptor = ArgumentCaptor
+			.forClass(
+				MessageQueueMessageHandler.class);
+		verify(consumer).subscribe(subscriptionCaptor.capture(), handlerCaptor.capture());
+		assertThat(subscriptionCaptor.getValue().topic()).isEqualTo(MessageQueueTopics.GROUP_MEMBER_JOINED);
+		assertThat(subscriptionCaptor.getValue().consumerGroup()).isEqualTo("tasteam-api");
+
+		GroupMemberJoinedMessagePayload payload = new GroupMemberJoinedMessagePayload(100L, 200L, "스터디 그룹", 1L);
+		handlerCaptor.getValue().handle(MessageQueueMessage.of(
+			MessageQueueTopics.GROUP_MEMBER_JOINED,
+			"200",
+			objectMapper.writeValueAsBytes(payload)));
+
+		verify(notificationService).createNotification(
+			eq(200L),
+			eq(NotificationType.SYSTEM),
+			eq("그룹 가입 완료"),
+			eq("스터디 그룹 그룹에 가입되었습니다."),
+			eq("/groups/100"));
+	}
+
+	@Test
+	@DisplayName("잘못된 payload를 수신하면 역직렬화 예외를 반환한다")
+	void subscribe_onInvalidPayload_throwsException() {
+		// given
+		MessageQueueConsumer consumer = mock(MessageQueueConsumer.class);
+		MessageQueueProperties properties = new MessageQueueProperties();
+		properties.setProvider("redis-stream");
+		NotificationService notificationService = mock(NotificationService.class);
+		NotificationMessageQueueConsumerRegistrar registrar = new NotificationMessageQueueConsumerRegistrar(
+			consumer,
+			properties,
+			notificationService,
+			new ObjectMapper());
+		registrar.subscribe();
+		ArgumentCaptor<MessageQueueMessageHandler> handlerCaptor = ArgumentCaptor
+			.forClass(MessageQueueMessageHandler.class);
+		verify(consumer).subscribe(any(MessageQueueSubscription.class), handlerCaptor.capture());
+
+		// when & then
+		assertThatThrownBy(() -> handlerCaptor.getValue().handle(
+			MessageQueueMessage.of(
+				MessageQueueTopics.GROUP_MEMBER_JOINED,
+				"200",
+				"{\"memberId\":\"invalid\"}".getBytes(StandardCharsets.UTF_8))))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("역직렬화");
+	}
+}


### PR DESCRIPTION
## 📌 PR 요약

#### Summary
- Notification MQ consumer 등록기와 수신 처리를 추가했습니다.
- MQ 활성 시 기존 `NotificationEventListener` 직접 경로를 비활성화하도록 변경했습니다.
- consumer 등록기 단위 테스트를 추가했습니다.

### Issue
- close : #338
- related : #336

---

## ➕ 추가된 기능
1. `NotificationMessageQueueConsumerRegistrar` 추가
2. 메시지 역직렬화 후 `NotificationService.createNotification` 위임

## 🛠️ 수정/변경사항
1. `NotificationEventListener` 조건부 활성화 적용
2. `NotificationMessageQueueConsumerRegistrarTest` 추가

---

## ✅ 남은 작업
* [ ] #339 통합 테스트 및 문서 반영

## 🧪 테스트
- `./gradlew :app-api:test --tests 'com.tasteam.infra.messagequeue.NotificationMessageQueueConsumerRegistrarTest'`
