### PR TITLE
Test: 알림 MQ 통합 테스트 누락 복구

### DIFF
--- a/app-api/src/test/java/com/tasteam/infra/messagequeue/NotificationMessageQueueFlowIntegrationTest.java
+++ b/app-api/src/test/java/com/tasteam/infra/messagequeue/NotificationMessageQueueFlowIntegrationTest.java
@@ -1,0 +1,171 @@
+package com.tasteam.infra.messagequeue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tasteam.domain.group.event.GroupMemberJoinedEvent;
+import com.tasteam.domain.notification.entity.NotificationType;
+import com.tasteam.domain.notification.service.NotificationService;
+
+import jakarta.annotation.Resource;
+
+@SpringBootTest(classes = NotificationMessageQueueFlowIntegrationTest.TestConfig.class, webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@ActiveProfiles("test")
+@Tag("integration")
+@DisplayName("Notification MQ 연동 통합 테스트")
+class NotificationMessageQueueFlowIntegrationTest {
+
+	private static final String CONSUMER_GROUP = "tasteam-api";
+
+	@Resource
+	private ApplicationEventPublisher applicationEventPublisher;
+
+	@Resource
+	private MessageQueueProducer messageQueueProducer;
+
+	@Resource
+	private MessageQueueConsumer messageQueueConsumer;
+
+	@Resource
+	private NotificationService notificationService;
+
+	@Resource
+	private ObjectMapper objectMapper;
+
+	@Test
+	@DisplayName("GroupMemberJoined 이벤트 발행 시 MQ publish와 notification 소비 처리까지 이어진다")
+	void groupMemberJoinedEvent_publishAndConsume() throws Exception {
+		// given
+		ArgumentCaptor<MessageQueueMessage> publishedMessageCaptor = ArgumentCaptor.forClass(MessageQueueMessage.class);
+		ArgumentCaptor<MessageQueueSubscription> subscriptionCaptor = ArgumentCaptor
+			.forClass(MessageQueueSubscription.class);
+		@SuppressWarnings("unchecked") ArgumentCaptor<MessageQueueMessageHandler> handlerCaptor = ArgumentCaptor
+			.forClass(
+				MessageQueueMessageHandler.class);
+		verify(messageQueueConsumer).subscribe(subscriptionCaptor.capture(), handlerCaptor.capture());
+
+		// when
+		applicationEventPublisher.publishEvent(new GroupMemberJoinedEvent(10L, 20L, "스터디 그룹",
+			Instant.parse("2026-02-15T00:00:00Z")));
+
+		// then
+		verify(messageQueueProducer).publish(publishedMessageCaptor.capture());
+		MessageQueueMessage publishedMessage = publishedMessageCaptor.getValue();
+		assertThat(publishedMessage.topic()).isEqualTo(MessageQueueTopics.GROUP_MEMBER_JOINED);
+		assertThat(publishedMessage.key()).isEqualTo("20");
+		assertThat(publishedMessage.headers()).containsEntry("eventType", "GroupMemberJoinedEvent");
+
+		GroupMemberJoinedMessagePayload payload = objectMapper.readValue(
+			publishedMessage.payload(),
+			GroupMemberJoinedMessagePayload.class);
+		assertThat(payload.groupId()).isEqualTo(10L);
+		assertThat(payload.memberId()).isEqualTo(20L);
+		assertThat(payload.groupName()).isEqualTo("스터디 그룹");
+
+		MessageQueueSubscription subscription = subscriptionCaptor.getValue();
+		assertThat(subscription.topic()).isEqualTo(MessageQueueTopics.GROUP_MEMBER_JOINED);
+		assertThat(subscription.consumerGroup()).isEqualTo(CONSUMER_GROUP);
+
+		handlerCaptor.getValue().handle(MessageQueueMessage.of(
+			MessageQueueTopics.GROUP_MEMBER_JOINED,
+			"20",
+			objectMapper.writeValueAsBytes(payload)));
+
+		verify(notificationService).createNotification(
+			eq(20L),
+			eq(NotificationType.SYSTEM),
+			eq("그룹 가입 완료"),
+			eq("스터디 그룹 그룹에 가입되었습니다."),
+			eq("/groups/10"));
+	}
+
+	@Test
+	@DisplayName("잘못된 payload를 수신하면 예외를 반환한다")
+	void consumerHandler_withInvalidPayload_throwsException() {
+		// given
+		ArgumentCaptor<MessageQueueMessageHandler> handlerCaptor = ArgumentCaptor
+			.forClass(MessageQueueMessageHandler.class);
+		verify(messageQueueConsumer).subscribe(any(MessageQueueSubscription.class), handlerCaptor.capture());
+
+		// when & then
+		org.assertj.core.api.Assertions.assertThatThrownBy(() -> handlerCaptor.getValue().handle(
+			MessageQueueMessage.of(
+				MessageQueueTopics.GROUP_MEMBER_JOINED,
+				"20",
+				"{\"memberId\":\"invalid\"}".getBytes(StandardCharsets.UTF_8))))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("역직렬화");
+	}
+
+	@Configuration
+	static class TestConfig {
+
+		@Bean
+		MessageQueueProperties messageQueueProperties() {
+			MessageQueueProperties properties = new MessageQueueProperties();
+			properties.setEnabled(true);
+			properties.setProvider(MessageQueueProviderType.REDIS_STREAM.value());
+			properties.setDefaultConsumerGroup(CONSUMER_GROUP);
+			return properties;
+		}
+
+		@Bean
+		ObjectMapper objectMapper() {
+			return new ObjectMapper();
+		}
+
+		@Bean
+		MessageQueueProducer messageQueueProducer() {
+			return Mockito.mock(MessageQueueProducer.class);
+		}
+
+		@Bean
+		MessageQueueConsumer messageQueueConsumer() {
+			return Mockito.mock(MessageQueueConsumer.class);
+		}
+
+		@Bean
+		NotificationService notificationService() {
+			return Mockito.mock(NotificationService.class);
+		}
+
+		@Bean
+		GroupMemberJoinedMessageQueuePublisher groupMemberJoinedMessageQueuePublisher(
+			MessageQueueProducer messageQueueProducer,
+			MessageQueueProperties messageQueueProperties,
+			ObjectMapper objectMapper) {
+			return new GroupMemberJoinedMessageQueuePublisher(messageQueueProducer, messageQueueProperties,
+				objectMapper);
+		}
+
+		@Bean
+		NotificationMessageQueueConsumerRegistrar notificationMessageQueueConsumerRegistrar(
+			MessageQueueConsumer messageQueueConsumer,
+			MessageQueueProperties messageQueueProperties,
+			NotificationService notificationService,
+			ObjectMapper objectMapper) {
+			return new NotificationMessageQueueConsumerRegistrar(
+				messageQueueConsumer,
+				messageQueueProperties,
+				notificationService,
+				objectMapper);
+		}
+	}
+}


### PR DESCRIPTION
## 📌 PR 요약

#### Summary
- develop 브랜치에서 누락된 `NotificationMessageQueueFlowIntegrationTest` 파일을 복구했습니다.
- 알림 MQ 발행/소비 통합 흐름 회귀 검증을 다시 포함시켰습니다.

### Issue
- close : #345

---

## ➕ 추가된 기능

1. `NotificationMessageQueueFlowIntegrationTest` 테스트 파일 복구
2. 알림 MQ end-to-end 통합 시나리오 검증 경로 복원

## 🛠️ 수정/변경사항

1. 누락 파일을 기준 커밋에서 복원해 `develop` 대비 테스트 공백 해소
2. 복구 후 단건 테스트 실행으로 동작 확인

---

## ✅ 남은 작업

* [x] 없음
* [ ] 필요 시 전체 테스트 스위트 재실행
