### PR TITLE
Chore: PR assignee 자동 할당 및 BE 라벨 자동 부착

### DIFF
--- a/.github/workflows/pr-review-gate.yml
+++ b/.github/workflows/pr-review-gate.yml
@@ -2,10 +2,11 @@ name: PR Review Gate
 
 on:
   pull_request:
-    types: [opened, ready_for_review, reopened, labeled, unlabeled, edited]
+    types: [opened, ready_for_review, reopened]
 
 permissions:
   contents: read
+  issues: write
   pull-requests: write
 
 jobs:
@@ -13,7 +14,7 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
-      - name: Validate labels and assignees
+      - name: Auto assign assignee and BE label
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -24,13 +25,44 @@ jobs:
               return;
             }
 
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pull_number = pr.number;
+            const author = pr.user.login;
+
             if (!Array.isArray(pr.assignees) || pr.assignees.length === 0) {
-              core.setFailed("PR에 assignee를 반드시 추가해야 합니다. 할당 후 다시 시도해 주세요.");
-              return;
+              try {
+                await github.rest.issues.addAssignees({
+                  owner,
+                  repo,
+                  issue_number: pull_number,
+                  assignees: [author],
+                });
+                core.info(`Assignee 자동 할당 완료: ${author}`);
+              } catch (error) {
+                core.warning(`Assignee 자동 할당 실패: ${error.message}`);
+              }
+            } else {
+              core.info("Assignee가 이미 설정되어 있어 자동 할당을 건너뜁니다.");
             }
 
-            if (!Array.isArray(pr.labels) || pr.labels.length === 0) {
-              core.setFailed("PR에 라벨을 하나 이상 붙여야 합니다. 라벨을 추가 후 다시 시도해 주세요.");
+            const hasBELabel = Array.isArray(pr.labels)
+              && pr.labels.some((label) => label.name === "BE");
+
+            if (!hasBELabel) {
+              try {
+                await github.rest.issues.addLabels({
+                  owner,
+                  repo,
+                  issue_number: pull_number,
+                  labels: ["BE"],
+                });
+                core.info("`BE` 라벨 자동 부착 완료");
+              } catch (error) {
+                core.warning(`BE 라벨 자동 부착 실패: ${error.message}`);
+              }
+            } else {
+              core.info("`BE` 라벨이 이미 존재하여 자동 부착을 건너뜁니다.");
             }
 
   request-reviewers:


### PR DESCRIPTION
## 📌 PR 요약

#### Summary
- PR assignee 누락 시 실패하던 게이트를 자동 할당 방식으로 변경했습니다.
- PR에 `BE` 라벨이 없을 때 자동 부착하도록 수정했습니다.

### Issue
- close : #347

---

## ➕ 추가된 기능

1. assignee 미지정 PR에 대해 작성자 자동 할당
2. BE 라벨 미보유 PR에 대해 BE 라벨 자동 부착

## 🛠️ 수정/변경사항

1. `pr-review-gate`의 assignee/label 미지정 실패 로직 제거
2. `pull_request` 트리거 이벤트를 `opened`, `ready_for_review`, `reopened`로 정리

---

## ✅ 남은 작업

* [ ] n/a
