### PR TITLE
Feat: Activity 매퍼 레지스트리 및 오케스트레이터 구현

### DIFF
--- a/app-api/src/main/java/com/tasteam/domain/analytics/api/ActivityEvent.java
+++ b/app-api/src/main/java/com/tasteam/domain/analytics/api/ActivityEvent.java
@@ -1,0 +1,53 @@
+package com.tasteam.domain.analytics.api;
+
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * 내부/외부 분석 sink로 전달되는 정규화 사용자 활동 이벤트 계약입니다.
+ *
+ * @param eventId 이벤트 멱등 처리를 위한 전역 식별자
+ * @param eventName 이벤트 이름 (예: review.created)
+ * @param eventVersion 이벤트 스키마 버전
+ * @param occurredAt 이벤트 발생 시각
+ * @param memberId 인증 사용자 식별자 (익명 이벤트면 null)
+ * @param anonymousId 익명 사용자 식별자 (인증 이벤트면 null)
+ * @param properties 이벤트 세부 속성
+ */
+public record ActivityEvent(
+	String eventId,
+	String eventName,
+	String eventVersion,
+	Instant occurredAt,
+	Long memberId,
+	String anonymousId,
+	Map<String, Object> properties) {
+
+	public ActivityEvent {
+		if (isBlank(eventId)) {
+			throw new IllegalArgumentException("eventId는 비어 있을 수 없습니다.");
+		}
+		if (isBlank(eventName)) {
+			throw new IllegalArgumentException("eventName은 비어 있을 수 없습니다.");
+		}
+		if (isBlank(eventVersion)) {
+			throw new IllegalArgumentException("eventVersion은 비어 있을 수 없습니다.");
+		}
+		occurredAt = Objects.requireNonNull(occurredAt, "occurredAt은 null일 수 없습니다.");
+		anonymousId = normalizeNullable(anonymousId);
+		properties = properties == null ? Map.of() : Map.copyOf(new LinkedHashMap<>(properties));
+	}
+
+	private static boolean isBlank(String value) {
+		return value == null || value.isBlank();
+	}
+
+	private static String normalizeNullable(String value) {
+		if (value == null || value.isBlank()) {
+			return null;
+		}
+		return value;
+	}
+}

--- a/app-api/src/main/java/com/tasteam/domain/analytics/api/ActivityEventMapper.java
+++ b/app-api/src/main/java/com/tasteam/domain/analytics/api/ActivityEventMapper.java
@@ -1,0 +1,34 @@
+package com.tasteam.domain.analytics.api;
+
+/**
+ * 도메인 이벤트를 정규화된 {@link ActivityEvent}로 변환하는 매퍼 포트입니다.
+ *
+ * @param <T> 매핑 대상 도메인 이벤트 타입
+ */
+public interface ActivityEventMapper<T> {
+
+	/**
+	 * 매핑을 지원하는 도메인 이벤트 타입을 반환합니다.
+	 *
+	 * @return 지원 도메인 이벤트 클래스
+	 */
+	Class<T> sourceType();
+
+	/**
+	 * 도메인 이벤트를 정규화 이벤트로 변환합니다.
+	 *
+	 * @param event 도메인 이벤트
+	 * @return 정규화 이벤트
+	 */
+	ActivityEvent map(T event);
+
+	/**
+	 * 입력 이벤트 타입 지원 여부를 반환합니다.
+	 *
+	 * @param eventType 확인할 이벤트 타입
+	 * @return 지원하면 true
+	 */
+	default boolean supports(Class<?> eventType) {
+		return sourceType().equals(eventType);
+	}
+}

--- a/app-api/src/main/java/com/tasteam/domain/analytics/api/ActivitySink.java
+++ b/app-api/src/main/java/com/tasteam/domain/analytics/api/ActivitySink.java
@@ -1,0 +1,40 @@
+package com.tasteam.domain.analytics.api;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * 정규화된 사용자 활동 이벤트를 저장소/외부 도구로 전달하는 sink 포트입니다.
+ * 구현체는 내부 DB 저장, MQ 발행, 외부 분석 전송 등 목적에 맞게 확장합니다.
+ */
+public interface ActivitySink {
+
+	/**
+	 * sink 유형명을 반환합니다.
+	 *
+	 * @return 운영 로그/지표 구분에 사용할 sink 이름
+	 */
+	String sinkType();
+
+	/**
+	 * 단일 이벤트를 sink로 전달합니다.
+	 *
+	 * @param event 전달할 이벤트
+	 */
+	void sink(ActivityEvent event);
+
+	/**
+	 * 복수 이벤트를 sink로 전달합니다.
+	 * 기본 구현은 개별 sink 호출이며, 구현체가 배치 최적화를 원하면 오버라이드합니다.
+	 *
+	 * @param events 전달할 이벤트 목록
+	 */
+	default void sinkBatch(List<ActivityEvent> events) {
+		if (events == null || events.isEmpty()) {
+			return;
+		}
+		for (ActivityEvent event : events) {
+			sink(Objects.requireNonNull(event, "events의 원소는 null일 수 없습니다."));
+		}
+	}
+}

--- a/app-api/src/main/java/com/tasteam/domain/analytics/application/ActivityDomainEventListener.java
+++ b/app-api/src/main/java/com/tasteam/domain/analytics/application/ActivityDomainEventListener.java
@@ -1,0 +1,40 @@
+package com.tasteam.domain.analytics.application;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.tasteam.domain.group.event.GroupMemberJoinedEvent;
+import com.tasteam.domain.review.event.ReviewCreatedEvent;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 도메인 이벤트를 사용자 활동 수집 오케스트레이터로 연결하는 진입점입니다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ActivityDomainEventListener {
+
+	private final ActivityEventOrchestrator orchestrator;
+
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+	public void onReviewCreated(ReviewCreatedEvent event) {
+		handle(event);
+	}
+
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+	public void onGroupMemberJoined(GroupMemberJoinedEvent event) {
+		handle(event);
+	}
+
+	private void handle(Object event) {
+		try {
+			orchestrator.handleDomainEvent(event);
+		} catch (Exception ex) {
+			log.error("사용자 이벤트 수집 처리 중 예외가 발생해 작업을 건너뜁니다. eventType={}", event.getClass().getName(), ex);
+		}
+	}
+}

--- a/app-api/src/main/java/com/tasteam/domain/analytics/application/ActivityEventMapperRegistry.java
+++ b/app-api/src/main/java/com/tasteam/domain/analytics/application/ActivityEventMapperRegistry.java
@@ -1,0 +1,56 @@
+package com.tasteam.domain.analytics.application;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+
+import com.tasteam.domain.analytics.api.ActivityEventMapper;
+
+/**
+ * 도메인 이벤트 타입별 매퍼를 조회하는 레지스트리입니다.
+ * 신규 이벤트는 매퍼 구현체 추가만으로 확장할 수 있도록 OCP 경계를 제공합니다.
+ */
+@Component
+public class ActivityEventMapperRegistry {
+
+	private final Map<Class<?>, ActivityEventMapper<Object>> mapperBySourceType;
+
+	public ActivityEventMapperRegistry(List<ActivityEventMapper<?>> mappers) {
+		this.mapperBySourceType = Collections.unmodifiableMap(indexMappers(mappers));
+	}
+
+	/**
+	 * 입력 이벤트 타입에 대응하는 매퍼를 조회합니다.
+	 *
+	 * @param eventType 도메인 이벤트 타입
+	 * @return 매퍼가 있으면 Optional로 반환
+	 */
+	public Optional<ActivityEventMapper<Object>> findMapper(Class<?> eventType) {
+		if (eventType == null) {
+			return Optional.empty();
+		}
+		return Optional.ofNullable(mapperBySourceType.get(eventType));
+	}
+
+	private Map<Class<?>, ActivityEventMapper<Object>> indexMappers(List<ActivityEventMapper<?>> mappers) {
+		Map<Class<?>, ActivityEventMapper<Object>> indexed = new LinkedHashMap<>();
+		for (ActivityEventMapper<?> mapper : mappers) {
+			Class<?> sourceType = mapper.sourceType();
+			ActivityEventMapper<Object> duplicated = indexed.putIfAbsent(sourceType, cast(mapper));
+			if (duplicated != null) {
+				throw new IllegalStateException(
+					"동일 이벤트 타입 매퍼가 중복 등록되었습니다. eventType=" + sourceType.getName());
+			}
+		}
+		return indexed;
+	}
+
+	@SuppressWarnings("unchecked")
+	private ActivityEventMapper<Object> cast(ActivityEventMapper<?> mapper) {
+		return (ActivityEventMapper<Object>)mapper;
+	}
+}

--- a/app-api/src/main/java/com/tasteam/domain/analytics/application/ActivityEventOrchestrator.java
+++ b/app-api/src/main/java/com/tasteam/domain/analytics/application/ActivityEventOrchestrator.java
@@ -1,0 +1,84 @@
+package com.tasteam.domain.analytics.application;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+
+import com.tasteam.domain.analytics.api.ActivityEvent;
+import com.tasteam.domain.analytics.api.ActivityEventMapper;
+import com.tasteam.domain.analytics.api.ActivitySink;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 도메인 이벤트를 정규화 이벤트로 변환하고 등록된 sink로 전달하는 오케스트레이터입니다.
+ * 매핑/전달 중 예외가 발생해도 도메인 흐름을 중단시키지 않도록 실패를 격리합니다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ActivityEventOrchestrator {
+
+	private final ActivityEventMapperRegistry mapperRegistry;
+	private final List<ActivitySink> activitySinks;
+
+	/**
+	 * 도메인 이벤트를 수집 경로로 전달합니다.
+	 *
+	 * @param domainEvent 수집 대상 도메인 이벤트
+	 */
+	public void handleDomainEvent(Object domainEvent) {
+		if (domainEvent == null) {
+			log.debug("사용자 이벤트 처리 대상이 null이어서 작업을 건너뜁니다.");
+			return;
+		}
+
+		Optional<ActivityEventMapper<Object>> mapper = mapperRegistry.findMapper(domainEvent.getClass());
+		if (mapper.isEmpty()) {
+			log.debug("등록된 사용자 이벤트 매퍼가 없어 수집을 건너뜁니다. eventType={}", domainEvent.getClass().getName());
+			return;
+		}
+
+		ActivityEvent activityEvent = mapSafely(mapper.get(), domainEvent);
+		if (activityEvent == null) {
+			return;
+		}
+		dispatchToSinks(activityEvent);
+	}
+
+	private ActivityEvent mapSafely(ActivityEventMapper<Object> mapper, Object domainEvent) {
+		try {
+			return mapper.map(domainEvent);
+		} catch (Exception ex) {
+			log.error("도메인 이벤트 매핑에 실패했습니다. eventType={}", domainEvent.getClass().getName(), ex);
+			return null;
+		}
+	}
+
+	private void dispatchToSinks(ActivityEvent event) {
+		if (activitySinks.isEmpty()) {
+			log.debug("등록된 사용자 이벤트 sink가 없어 전달을 건너뜁니다. eventName={}, eventId={}",
+				event.eventName(), event.eventId());
+			return;
+		}
+
+		for (ActivitySink sink : activitySinks) {
+			try {
+				sink.sink(event);
+			} catch (Exception ex) {
+				log.error("사용자 이벤트 sink 전달에 실패했습니다. sinkType={}, eventName={}, eventId={}",
+					resolveSinkType(sink), event.eventName(), event.eventId(), ex);
+			}
+		}
+	}
+
+	private String resolveSinkType(ActivitySink sink) {
+		try {
+			return sink.sinkType();
+		} catch (Exception ignored) {
+			return sink.getClass().getSimpleName();
+		}
+	}
+}

--- a/app-api/src/main/java/com/tasteam/domain/analytics/application/mapper/GroupMemberJoinedActivityEventMapper.java
+++ b/app-api/src/main/java/com/tasteam/domain/analytics/application/mapper/GroupMemberJoinedActivityEventMapper.java
@@ -1,0 +1,51 @@
+package com.tasteam.domain.analytics.application.mapper;
+
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import com.tasteam.domain.analytics.api.ActivityEvent;
+import com.tasteam.domain.analytics.api.ActivityEventMapper;
+import com.tasteam.domain.group.event.GroupMemberJoinedEvent;
+
+/**
+ * 그룹 가입 도메인 이벤트를 정규화 사용자 활동 이벤트로 변환합니다.
+ */
+@Component
+public class GroupMemberJoinedActivityEventMapper implements ActivityEventMapper<GroupMemberJoinedEvent> {
+
+	@Override
+	public Class<GroupMemberJoinedEvent> sourceType() {
+		return GroupMemberJoinedEvent.class;
+	}
+
+	@Override
+	public ActivityEvent map(GroupMemberJoinedEvent event) {
+		Objects.requireNonNull(event, "event는 null일 수 없습니다.");
+
+		Map<String, Object> properties = new LinkedHashMap<>();
+		if (event.groupId() != null) {
+			properties.put("groupId", event.groupId());
+		}
+		if (event.groupName() != null && !event.groupName().isBlank()) {
+			properties.put("groupName", event.groupName());
+		}
+
+		return new ActivityEvent(
+			UUID.randomUUID().toString(),
+			"group.joined",
+			"v1",
+			resolveOccurredAt(event.joinedAt()),
+			event.memberId(),
+			null,
+			properties);
+	}
+
+	private Instant resolveOccurredAt(Instant joinedAt) {
+		return joinedAt == null ? Instant.now() : joinedAt;
+	}
+}

--- a/app-api/src/main/java/com/tasteam/domain/analytics/application/mapper/ReviewCreatedActivityEventMapper.java
+++ b/app-api/src/main/java/com/tasteam/domain/analytics/application/mapper/ReviewCreatedActivityEventMapper.java
@@ -1,0 +1,37 @@
+package com.tasteam.domain.analytics.application.mapper;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import com.tasteam.domain.analytics.api.ActivityEvent;
+import com.tasteam.domain.analytics.api.ActivityEventMapper;
+import com.tasteam.domain.review.event.ReviewCreatedEvent;
+
+/**
+ * 리뷰 생성 도메인 이벤트를 정규화 사용자 활동 이벤트로 변환합니다.
+ */
+@Component
+public class ReviewCreatedActivityEventMapper implements ActivityEventMapper<ReviewCreatedEvent> {
+
+	@Override
+	public Class<ReviewCreatedEvent> sourceType() {
+		return ReviewCreatedEvent.class;
+	}
+
+	@Override
+	public ActivityEvent map(ReviewCreatedEvent event) {
+		Objects.requireNonNull(event, "event는 null일 수 없습니다.");
+		return new ActivityEvent(
+			UUID.randomUUID().toString(),
+			"review.created",
+			"v1",
+			Instant.now(),
+			null,
+			null,
+			Map.of("restaurantId", event.restaurantId()));
+	}
+}

--- a/app-api/src/test/java/com/tasteam/domain/analytics/application/ActivityEventMapperRegistryTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/analytics/application/ActivityEventMapperRegistryTest.java
@@ -1,0 +1,87 @@
+package com.tasteam.domain.analytics.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.tasteam.config.annotation.UnitTest;
+import com.tasteam.domain.analytics.api.ActivityEvent;
+import com.tasteam.domain.analytics.api.ActivityEventMapper;
+
+@UnitTest
+@DisplayName("사용자 이벤트 매퍼 레지스트리")
+class ActivityEventMapperRegistryTest {
+
+	@Test
+	@DisplayName("이벤트 타입에 매칭되는 매퍼가 있으면 조회된다")
+	void findMapper_returnsMapperWhenRegistered() {
+		// given
+		ActivityEventMapperRegistry registry = new ActivityEventMapperRegistry(List.of(new SampleEventMapper()));
+
+		// when
+		ActivityEventMapper<Object> mapper = registry.findMapper(SampleEvent.class).orElse(null);
+
+		// then
+		assertThat(mapper).isNotNull();
+		assertThat(mapper.sourceType()).isEqualTo(SampleEvent.class);
+	}
+
+	@Test
+	@DisplayName("등록되지 않은 이벤트 타입이면 빈 결과를 반환한다")
+	void findMapper_returnsEmptyWhenNotRegistered() {
+		// given
+		ActivityEventMapperRegistry registry = new ActivityEventMapperRegistry(List.of(new SampleEventMapper()));
+
+		// when
+		boolean exists = registry.findMapper(UnknownEvent.class).isPresent();
+
+		// then
+		assertThat(exists).isFalse();
+	}
+
+	@Test
+	@DisplayName("동일 이벤트 타입 매퍼가 중복되면 레지스트리 생성에 실패한다")
+	void constructor_throwsWhenDuplicateMapperRegistered() {
+		// given
+		List<ActivityEventMapper<?>> duplicatedMappers = List.of(
+			new SampleEventMapper(),
+			new SampleEventMapper());
+
+		// when & then
+		assertThatThrownBy(() -> new ActivityEventMapperRegistry(duplicatedMappers))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("중복 등록");
+	}
+
+	private record SampleEvent(long value) {
+	}
+
+	private record UnknownEvent(long value) {
+	}
+
+	private static class SampleEventMapper implements ActivityEventMapper<SampleEvent> {
+
+		@Override
+		public Class<SampleEvent> sourceType() {
+			return SampleEvent.class;
+		}
+
+		@Override
+		public ActivityEvent map(SampleEvent event) {
+			return new ActivityEvent(
+				"event-1",
+				"sample.event",
+				"v1",
+				Instant.parse("2026-02-18T00:00:00Z"),
+				null,
+				null,
+				Map.of("value", event.value()));
+		}
+	}
+}

--- a/app-api/src/test/java/com/tasteam/domain/analytics/application/ActivityEventOrchestratorTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/analytics/application/ActivityEventOrchestratorTest.java
@@ -1,0 +1,107 @@
+package com.tasteam.domain.analytics.application;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.tasteam.config.annotation.UnitTest;
+import com.tasteam.domain.analytics.api.ActivityEvent;
+import com.tasteam.domain.analytics.api.ActivityEventMapper;
+import com.tasteam.domain.analytics.api.ActivitySink;
+
+@UnitTest
+@DisplayName("사용자 이벤트 오케스트레이터")
+class ActivityEventOrchestratorTest {
+
+	@Test
+	@DisplayName("지원되는 도메인 이벤트를 수신하면 모든 sink에 전달한다")
+	void handleDomainEvent_dispatchesToEverySink() {
+		// given
+		ActivitySink firstSink = mock(ActivitySink.class);
+		ActivitySink secondSink = mock(ActivitySink.class);
+		ActivityEventOrchestrator orchestrator = new ActivityEventOrchestrator(
+			new ActivityEventMapperRegistry(List.of(new SampleEventMapper())),
+			List.of(firstSink, secondSink));
+		SampleEvent domainEvent = new SampleEvent(10L);
+
+		// when
+		orchestrator.handleDomainEvent(domainEvent);
+
+		// then
+		verify(firstSink).sink(any(ActivityEvent.class));
+		verify(secondSink).sink(any(ActivityEvent.class));
+	}
+
+	@Test
+	@DisplayName("일부 sink에서 실패해도 나머지 sink 전달은 계속된다")
+	void handleDomainEvent_continuesWhenSinkFails() {
+		// given
+		ActivitySink failedSink = mock(ActivitySink.class);
+		ActivitySink healthySink = mock(ActivitySink.class);
+		org.mockito.Mockito.doThrow(new IllegalStateException("sink failure"))
+			.when(failedSink)
+			.sink(any(ActivityEvent.class));
+
+		ActivityEventOrchestrator orchestrator = new ActivityEventOrchestrator(
+			new ActivityEventMapperRegistry(List.of(new SampleEventMapper())),
+			List.of(failedSink, healthySink));
+
+		// when
+		orchestrator.handleDomainEvent(new SampleEvent(20L));
+
+		// then
+		verify(failedSink, times(1)).sink(any(ActivityEvent.class));
+		verify(healthySink, times(1)).sink(any(ActivityEvent.class));
+	}
+
+	@Test
+	@DisplayName("지원 매퍼가 없는 이벤트는 sink에 전달하지 않는다")
+	void handleDomainEvent_skipsWhenNoMapperExists() {
+		// given
+		ActivitySink sink = mock(ActivitySink.class);
+		ActivityEventOrchestrator orchestrator = new ActivityEventOrchestrator(
+			new ActivityEventMapperRegistry(List.of(new SampleEventMapper())),
+			List.of(sink));
+
+		// when
+		orchestrator.handleDomainEvent(new UnknownEvent(1L));
+
+		// then
+		verifyNoInteractions(sink);
+	}
+
+	private record SampleEvent(long value) {
+	}
+
+	private record UnknownEvent(long value) {
+	}
+
+	private static class SampleEventMapper implements ActivityEventMapper<SampleEvent> {
+
+		@Override
+		public Class<SampleEvent> sourceType() {
+			return SampleEvent.class;
+		}
+
+		@Override
+		public ActivityEvent map(SampleEvent event) {
+			return new ActivityEvent(
+				"event-1",
+				"sample.event",
+				"v1",
+				Instant.parse("2026-02-18T00:00:00Z"),
+				null,
+				null,
+				Map.of("value", event.value()));
+		}
+	}
+}

--- a/app-api/src/test/java/com/tasteam/domain/analytics/application/mapper/GroupMemberJoinedActivityEventMapperTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/analytics/application/mapper/GroupMemberJoinedActivityEventMapperTest.java
@@ -1,0 +1,55 @@
+package com.tasteam.domain.analytics.application.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.tasteam.config.annotation.UnitTest;
+import com.tasteam.domain.analytics.api.ActivityEvent;
+import com.tasteam.domain.group.event.GroupMemberJoinedEvent;
+
+@UnitTest
+@DisplayName("그룹 가입 사용자 이벤트 매퍼")
+class GroupMemberJoinedActivityEventMapperTest {
+
+	private final GroupMemberJoinedActivityEventMapper mapper = new GroupMemberJoinedActivityEventMapper();
+
+	@Test
+	@DisplayName("그룹 가입 이벤트를 정규화 이벤트로 변환한다")
+	void map_convertsGroupMemberJoinedEventToActivityEvent() {
+		// given
+		Instant joinedAt = Instant.parse("2026-02-18T07:00:00Z");
+		GroupMemberJoinedEvent event = new GroupMemberJoinedEvent(7L, 9L, "강남 점심팟", joinedAt);
+
+		// when
+		ActivityEvent mapped = mapper.map(event);
+
+		// then
+		assertThat(mapped.eventId()).isNotBlank();
+		assertThat(mapped.eventName()).isEqualTo("group.joined");
+		assertThat(mapped.eventVersion()).isEqualTo("v1");
+		assertThat(mapped.memberId()).isEqualTo(9L);
+		assertThat(mapped.occurredAt()).isEqualTo(joinedAt);
+		assertThat(mapped.properties())
+			.containsEntry("groupId", 7L)
+			.containsEntry("groupName", "강남 점심팟");
+	}
+
+	@Test
+	@DisplayName("joinedAt이 없으면 현재 시각 기준으로 occurredAt을 채운다")
+	void map_setsOccurredAtNowWhenJoinedAtIsNull() {
+		// given
+		GroupMemberJoinedEvent event = new GroupMemberJoinedEvent(7L, 9L, "강남 점심팟", null);
+		Instant before = Instant.now();
+
+		// when
+		ActivityEvent mapped = mapper.map(event);
+		Instant after = Instant.now();
+
+		// then
+		assertThat(mapped.occurredAt()).isBetween(before, after);
+	}
+}

--- a/app-api/src/test/java/com/tasteam/domain/analytics/application/mapper/ReviewCreatedActivityEventMapperTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/analytics/application/mapper/ReviewCreatedActivityEventMapperTest.java
@@ -1,0 +1,36 @@
+package com.tasteam.domain.analytics.application.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.tasteam.config.annotation.UnitTest;
+import com.tasteam.domain.analytics.api.ActivityEvent;
+import com.tasteam.domain.review.event.ReviewCreatedEvent;
+
+@UnitTest
+@DisplayName("리뷰 생성 사용자 이벤트 매퍼")
+class ReviewCreatedActivityEventMapperTest {
+
+	private final ReviewCreatedActivityEventMapper mapper = new ReviewCreatedActivityEventMapper();
+
+	@Test
+	@DisplayName("리뷰 생성 이벤트를 정규화 이벤트로 변환한다")
+	void map_convertsReviewCreatedEventToActivityEvent() {
+		// given
+		ReviewCreatedEvent event = new ReviewCreatedEvent(33L);
+
+		// when
+		ActivityEvent mapped = mapper.map(event);
+
+		// then
+		assertThat(mapped.eventId()).isNotBlank();
+		assertThat(mapped.eventName()).isEqualTo("review.created");
+		assertThat(mapped.eventVersion()).isEqualTo("v1");
+		assertThat(mapped.memberId()).isNull();
+		assertThat(mapped.occurredAt()).isNotNull();
+		assertThat(mapped.properties())
+			.containsEntry("restaurantId", 33L);
+	}
+}


### PR DESCRIPTION
## 📌 PR 요약

#### Summary
- 사용자 이벤트 수집의 확장 경계를 위한 포트/레지스트리/오케스트레이터를 추가했습니다.
- 도메인 이벤트(`ReviewCreatedEvent`, `GroupMemberJoinedEvent`)를 정규화 이벤트로 변환하는 매퍼를 추가했습니다.
- sink 실패가 전체 수집 흐름을 중단하지 않도록 오케스트레이터에서 장애를 격리했습니다.

### Issue
- close : #351

---

## ➕ 추가된 기능
1. `ActivityEvent`, `ActivitySink`, `ActivityEventMapper<T>` 계약 추가
2. `ActivityEventMapperRegistry`, `ActivityEventOrchestrator`, `ActivityDomainEventListener` 추가

## 🛠️ 수정/변경사항
1. `ReviewCreatedActivityEventMapper`, `GroupMemberJoinedActivityEventMapper` 구현
2. 레지스트리/오케스트레이터/매퍼 단위 테스트 추가

---

## ✅ 남은 작업
* [ ] USER_ACTIVITY MQ Publisher/Consumer 및 멱등 저장 구현 (#352)
* [ ] 수집 장애 격리·재처리·운영 지표 구현 (#353)
* [ ] PostHog Sink Dispatcher 및 재시도 정책 구현 (#354)
