### PR TITLE
Feat: USER_ACTIVITY MQ publisher/consumer 및 멱등 저장 구현

### DIFF
--- a/app-api/src/main/java/com/tasteam/domain/analytics/persistence/UserActivityEventJdbcRepository.java
+++ b/app-api/src/main/java/com/tasteam/domain/analytics/persistence/UserActivityEventJdbcRepository.java
@@ -1,0 +1,68 @@
+package com.tasteam.domain.analytics.persistence;
+
+import java.util.Map;
+import java.util.Objects;
+
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tasteam.domain.analytics.api.ActivityEvent;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class UserActivityEventJdbcRepository {
+
+	private static final String DEFAULT_SOURCE = "SERVER";
+
+	private static final String INSERT_SQL = """
+		INSERT INTO user_activity_event (
+			event_id, event_name, event_version, occurred_at,
+			member_id, anonymous_id, session_id, source,
+			request_path, request_method, device_id, platform,
+			app_version, locale, properties, created_at
+		) VALUES (
+			:eventId, :eventName, :eventVersion, :occurredAt,
+			:memberId, :anonymousId, :sessionId, :source,
+			:requestPath, :requestMethod, :deviceId, :platform,
+			:appVersion, :locale, CAST(:properties AS jsonb), NOW()
+		)
+		ON CONFLICT (event_id) DO NOTHING
+		""";
+
+	private final NamedParameterJdbcTemplate jdbcTemplate;
+	private final ObjectMapper objectMapper;
+
+	public boolean insertIgnoreDuplicate(ActivityEvent event) {
+		Objects.requireNonNull(event, "event는 null일 수 없습니다.");
+		MapSqlParameterSource params = new MapSqlParameterSource()
+			.addValue("eventId", event.eventId())
+			.addValue("eventName", event.eventName())
+			.addValue("eventVersion", event.eventVersion())
+			.addValue("occurredAt", event.occurredAt())
+			.addValue("memberId", event.memberId())
+			.addValue("anonymousId", event.anonymousId())
+			.addValue("sessionId", null)
+			.addValue("source", DEFAULT_SOURCE)
+			.addValue("requestPath", null)
+			.addValue("requestMethod", null)
+			.addValue("deviceId", null)
+			.addValue("platform", null)
+			.addValue("appVersion", null)
+			.addValue("locale", null)
+			.addValue("properties", serializeProperties(event.properties()));
+		return jdbcTemplate.update(INSERT_SQL, params) > 0;
+	}
+
+	private String serializeProperties(Map<String, Object> properties) {
+		try {
+			return objectMapper.writeValueAsString(properties == null ? Map.of() : properties);
+		} catch (JsonProcessingException ex) {
+			throw new IllegalStateException("사용자 이벤트 properties 직렬화에 실패했습니다", ex);
+		}
+	}
+}

--- a/app-api/src/main/java/com/tasteam/domain/analytics/persistence/UserActivityEventStoreService.java
+++ b/app-api/src/main/java/com/tasteam/domain/analytics/persistence/UserActivityEventStoreService.java
@@ -1,0 +1,26 @@
+package com.tasteam.domain.analytics.persistence;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.tasteam.domain.analytics.api.ActivityEvent;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserActivityEventStoreService {
+
+	private final UserActivityEventJdbcRepository userActivityEventJdbcRepository;
+
+	@Transactional
+	public void store(ActivityEvent event) {
+		boolean inserted = userActivityEventJdbcRepository.insertIgnoreDuplicate(event);
+		if (!inserted) {
+			log.info("중복 사용자 이벤트를 감지하여 저장을 건너뜁니다. eventId={}, eventName={}",
+				event.eventId(), event.eventName());
+		}
+	}
+}

--- a/app-api/src/main/java/com/tasteam/infra/messagequeue/MessageQueueTopics.java
+++ b/app-api/src/main/java/com/tasteam/infra/messagequeue/MessageQueueTopics.java
@@ -4,6 +4,7 @@ public final class MessageQueueTopics {
 
 	public static final String REVIEW_CREATED = "domain.review.created";
 	public static final String GROUP_MEMBER_JOINED = "domain.group.member-joined";
+	public static final String USER_ACTIVITY = "domain.user.activity";
 
 	private MessageQueueTopics() {}
 }

--- a/app-api/src/main/java/com/tasteam/infra/messagequeue/UserActivityMessageQueueConsumerRegistrar.java
+++ b/app-api/src/main/java/com/tasteam/infra/messagequeue/UserActivityMessageQueueConsumerRegistrar.java
@@ -1,0 +1,65 @@
+package com.tasteam.infra.messagequeue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tasteam.domain.analytics.api.ActivityEvent;
+import com.tasteam.domain.analytics.persistence.UserActivityEventStoreService;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "tasteam.message-queue", name = "enabled", havingValue = "true")
+public class UserActivityMessageQueueConsumerRegistrar {
+
+	private final MessageQueueConsumer messageQueueConsumer;
+	private final MessageQueueProperties messageQueueProperties;
+	private final UserActivityEventStoreService userActivityEventStoreService;
+	private final ObjectMapper objectMapper;
+
+	private MessageQueueSubscription subscription;
+
+	@PostConstruct
+	public void subscribe() {
+		if (messageQueueProperties.providerType() == MessageQueueProviderType.NONE) {
+			log.info("메시지큐 provider가 none이라 User Activity 구독 등록을 건너뜁니다");
+			return;
+		}
+
+		subscription = new MessageQueueSubscription(
+			MessageQueueTopics.USER_ACTIVITY,
+			messageQueueProperties.getDefaultConsumerGroup() + "-user-activity",
+			"user-activity-" + UUID.randomUUID());
+
+		messageQueueConsumer.subscribe(subscription, message -> {
+			ActivityEvent payload = deserializePayload(message.payload());
+			userActivityEventStoreService.store(payload);
+		});
+	}
+
+	@PreDestroy
+	public void unsubscribe() {
+		if (subscription != null) {
+			messageQueueConsumer.unsubscribe(subscription);
+		}
+	}
+
+	private ActivityEvent deserializePayload(byte[] payload) {
+		try {
+			return objectMapper.readValue(payload, ActivityEvent.class);
+		} catch (IOException ex) {
+			String payloadAsString = new String(payload, StandardCharsets.UTF_8);
+			throw new IllegalArgumentException("UserActivity 메시지 역직렬화에 실패했습니다. payload=" + payloadAsString, ex);
+		}
+	}
+}

--- a/app-api/src/main/java/com/tasteam/infra/messagequeue/UserActivityMessageQueuePublisher.java
+++ b/app-api/src/main/java/com/tasteam/infra/messagequeue/UserActivityMessageQueuePublisher.java
@@ -1,0 +1,73 @@
+package com.tasteam.infra.messagequeue;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tasteam.domain.analytics.api.ActivityEvent;
+import com.tasteam.domain.analytics.api.ActivitySink;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "tasteam.message-queue", name = "enabled", havingValue = "true")
+public class UserActivityMessageQueuePublisher implements ActivitySink {
+
+	private final MessageQueueProducer messageQueueProducer;
+	private final MessageQueueProperties messageQueueProperties;
+	private final ObjectMapper objectMapper;
+
+	@Override
+	public String sinkType() {
+		return "USER_ACTIVITY_MQ";
+	}
+
+	@Override
+	public void sink(ActivityEvent event) {
+		Objects.requireNonNull(event, "event는 null일 수 없습니다.");
+		if (messageQueueProperties.providerType() == MessageQueueProviderType.NONE) {
+			return;
+		}
+
+		MessageQueueMessage message = new MessageQueueMessage(
+			MessageQueueTopics.USER_ACTIVITY,
+			resolveMessageKey(event),
+			serialize(event),
+			buildHeaders(event),
+			event.occurredAt(),
+			event.eventId());
+		messageQueueProducer.publish(message);
+	}
+
+	private byte[] serialize(ActivityEvent event) {
+		try {
+			return objectMapper.writeValueAsBytes(event);
+		} catch (JsonProcessingException ex) {
+			throw new IllegalStateException("사용자 이벤트 메시지 직렬화에 실패했습니다", ex);
+		}
+	}
+
+	private Map<String, String> buildHeaders(ActivityEvent event) {
+		Map<String, String> headers = new LinkedHashMap<>();
+		headers.put("eventType", "ActivityEvent");
+		headers.put("eventName", event.eventName());
+		headers.put("schemaVersion", event.eventVersion());
+		return Map.copyOf(headers);
+	}
+
+	private String resolveMessageKey(ActivityEvent event) {
+		if (event.memberId() != null) {
+			return String.valueOf(event.memberId());
+		}
+		if (event.anonymousId() != null && !event.anonymousId().isBlank()) {
+			return event.anonymousId();
+		}
+		return event.eventId();
+	}
+}

--- a/app-api/src/test/java/com/tasteam/domain/analytics/persistence/UserActivityEventJdbcRepositoryTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/analytics/persistence/UserActivityEventJdbcRepositoryTest.java
@@ -1,0 +1,79 @@
+package com.tasteam.domain.analytics.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.tasteam.config.annotation.UnitTest;
+import com.tasteam.domain.analytics.api.ActivityEvent;
+
+@UnitTest
+@DisplayName("사용자 이벤트 JDBC 저장소")
+class UserActivityEventJdbcRepositoryTest {
+
+	@Test
+	@DisplayName("이벤트를 저장하면 ON CONFLICT DO NOTHING 기반 insert를 수행한다")
+	void insertIgnoreDuplicate_executesInsertQuery() {
+		// given
+		NamedParameterJdbcTemplate jdbcTemplate = mock(NamedParameterJdbcTemplate.class);
+		when(jdbcTemplate.update(any(String.class), any(MapSqlParameterSource.class))).thenReturn(1);
+
+		UserActivityEventJdbcRepository repository = new UserActivityEventJdbcRepository(
+			jdbcTemplate,
+			JsonMapper.builder().findAndAddModules().build());
+
+		ActivityEvent event = new ActivityEvent(
+			"evt-1",
+			"review.created",
+			"v1",
+			Instant.parse("2026-02-18T00:00:00Z"),
+			11L,
+			null,
+			Map.of("restaurantId", 88L));
+
+		// when
+		boolean inserted = repository.insertIgnoreDuplicate(event);
+
+		// then
+		assertThat(inserted).isTrue();
+		verify(jdbcTemplate).update(any(String.class), any(MapSqlParameterSource.class));
+	}
+
+	@Test
+	@DisplayName("중복 이벤트면 insert 결과가 0으로 반환된다")
+	void insertIgnoreDuplicate_returnsFalseWhenDuplicate() {
+		// given
+		NamedParameterJdbcTemplate jdbcTemplate = mock(NamedParameterJdbcTemplate.class);
+		when(jdbcTemplate.update(any(String.class), any(MapSqlParameterSource.class))).thenReturn(0);
+
+		UserActivityEventJdbcRepository repository = new UserActivityEventJdbcRepository(
+			jdbcTemplate,
+			JsonMapper.builder().findAndAddModules().build());
+
+		ActivityEvent event = new ActivityEvent(
+			"evt-1",
+			"group.joined",
+			"v1",
+			Instant.parse("2026-02-18T00:00:00Z"),
+			11L,
+			null,
+			Map.of("groupId", 77L));
+
+		// when
+		boolean inserted = repository.insertIgnoreDuplicate(event);
+
+		// then
+		assertThat(inserted).isFalse();
+	}
+}

--- a/app-api/src/test/java/com/tasteam/infra/messagequeue/UserActivityMessageQueueConsumerRegistrarTest.java
+++ b/app-api/src/test/java/com/tasteam/infra/messagequeue/UserActivityMessageQueueConsumerRegistrarTest.java
@@ -1,0 +1,126 @@
+package com.tasteam.infra.messagequeue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.tasteam.config.annotation.UnitTest;
+import com.tasteam.domain.analytics.api.ActivityEvent;
+import com.tasteam.domain.analytics.persistence.UserActivityEventStoreService;
+
+@UnitTest
+@DisplayName("사용자 이벤트 MQ consumer registrar")
+class UserActivityMessageQueueConsumerRegistrarTest {
+
+	@Test
+	@DisplayName("구독 등록 시 USER_ACTIVITY 토픽 핸들러를 등록한다")
+	void subscribe_registersUserActivitySubscription() throws Exception {
+		// given
+		MessageQueueConsumer messageQueueConsumer = mock(MessageQueueConsumer.class);
+		MessageQueueProperties properties = new MessageQueueProperties();
+		properties.setEnabled(true);
+		properties.setProvider(MessageQueueProviderType.REDIS_STREAM.value());
+		properties.setDefaultConsumerGroup("tasteam-api");
+		UserActivityEventStoreService storeService = mock(UserActivityEventStoreService.class);
+		ObjectMapper objectMapper = JsonMapper.builder().findAndAddModules().build();
+		UserActivityMessageQueueConsumerRegistrar registrar = new UserActivityMessageQueueConsumerRegistrar(
+			messageQueueConsumer,
+			properties,
+			storeService,
+			objectMapper);
+
+		// when
+		registrar.subscribe();
+
+		// then
+		ArgumentCaptor<MessageQueueSubscription> subscriptionCaptor = ArgumentCaptor
+			.forClass(MessageQueueSubscription.class);
+		@SuppressWarnings("unchecked") ArgumentCaptor<MessageQueueMessageHandler> handlerCaptor = ArgumentCaptor
+			.forClass(
+				MessageQueueMessageHandler.class);
+		verify(messageQueueConsumer).subscribe(subscriptionCaptor.capture(), handlerCaptor.capture());
+		assertThat(subscriptionCaptor.getValue().topic()).isEqualTo(MessageQueueTopics.USER_ACTIVITY);
+		assertThat(subscriptionCaptor.getValue().consumerGroup()).isEqualTo("tasteam-api-user-activity");
+
+		ActivityEvent event = new ActivityEvent(
+			"evt-1",
+			"group.joined",
+			"v1",
+			Instant.parse("2026-02-18T00:00:00Z"),
+			20L,
+			null,
+			Map.of("groupId", 99L));
+		handlerCaptor.getValue().handle(
+			MessageQueueMessage.of(MessageQueueTopics.USER_ACTIVITY, "20", objectMapper.writeValueAsBytes(event)));
+		verify(storeService).store(any(ActivityEvent.class));
+	}
+
+	@Test
+	@DisplayName("provider가 none이면 구독 등록을 수행하지 않는다")
+	void subscribe_skipsWhenProviderNone() {
+		// given
+		MessageQueueConsumer messageQueueConsumer = mock(MessageQueueConsumer.class);
+		MessageQueueProperties properties = new MessageQueueProperties();
+		properties.setEnabled(true);
+		properties.setProvider(MessageQueueProviderType.NONE.value());
+		UserActivityEventStoreService storeService = mock(UserActivityEventStoreService.class);
+		UserActivityMessageQueueConsumerRegistrar registrar = new UserActivityMessageQueueConsumerRegistrar(
+			messageQueueConsumer,
+			properties,
+			storeService,
+			JsonMapper.builder().findAndAddModules().build());
+
+		// when
+		registrar.subscribe();
+
+		// then
+		verifyNoInteractions(messageQueueConsumer);
+	}
+
+	@Test
+	@DisplayName("잘못된 payload를 수신하면 역직렬화 예외를 반환한다")
+	void subscribe_handlerThrowsWhenPayloadInvalid() {
+		// given
+		MessageQueueConsumer messageQueueConsumer = mock(MessageQueueConsumer.class);
+		MessageQueueProperties properties = new MessageQueueProperties();
+		properties.setEnabled(true);
+		properties.setProvider(MessageQueueProviderType.REDIS_STREAM.value());
+		properties.setDefaultConsumerGroup("tasteam-api");
+		UserActivityEventStoreService storeService = mock(UserActivityEventStoreService.class);
+		UserActivityMessageQueueConsumerRegistrar registrar = new UserActivityMessageQueueConsumerRegistrar(
+			messageQueueConsumer,
+			properties,
+			storeService,
+			JsonMapper.builder().findAndAddModules().build());
+
+		registrar.subscribe();
+
+		@SuppressWarnings("unchecked") ArgumentCaptor<MessageQueueMessageHandler> handlerCaptor = ArgumentCaptor
+			.forClass(
+				MessageQueueMessageHandler.class);
+		verify(messageQueueConsumer).subscribe(any(MessageQueueSubscription.class), handlerCaptor.capture());
+
+		// when & then
+		assertThatThrownBy(() -> handlerCaptor.getValue().handle(
+			MessageQueueMessage.of(
+				MessageQueueTopics.USER_ACTIVITY,
+				"key",
+				"{\"eventId\":\"evt\"}".getBytes(StandardCharsets.UTF_8))))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("역직렬화");
+		verifyNoInteractions(storeService);
+	}
+}

--- a/app-api/src/test/java/com/tasteam/infra/messagequeue/UserActivityMessageQueueFlowIntegrationTest.java
+++ b/app-api/src/test/java/com/tasteam/infra/messagequeue/UserActivityMessageQueueFlowIntegrationTest.java
@@ -1,0 +1,164 @@
+package com.tasteam.infra.messagequeue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.tasteam.domain.analytics.api.ActivityEvent;
+import com.tasteam.domain.analytics.api.ActivityEventMapper;
+import com.tasteam.domain.analytics.api.ActivitySink;
+import com.tasteam.domain.analytics.application.ActivityDomainEventListener;
+import com.tasteam.domain.analytics.application.ActivityEventMapperRegistry;
+import com.tasteam.domain.analytics.application.ActivityEventOrchestrator;
+import com.tasteam.domain.analytics.application.mapper.ReviewCreatedActivityEventMapper;
+import com.tasteam.domain.analytics.persistence.UserActivityEventStoreService;
+import com.tasteam.domain.review.event.ReviewCreatedEvent;
+
+import jakarta.annotation.Resource;
+
+@SpringBootTest(classes = UserActivityMessageQueueFlowIntegrationTest.TestConfig.class, webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@ActiveProfiles("test")
+@Tag("integration")
+@DisplayName("User Activity MQ 연동 통합 테스트")
+class UserActivityMessageQueueFlowIntegrationTest {
+
+	@Resource
+	private ApplicationEventPublisher applicationEventPublisher;
+
+	@Resource
+	private MessageQueueProducer messageQueueProducer;
+
+	@Resource
+	private MessageQueueConsumer messageQueueConsumer;
+
+	@Resource
+	private UserActivityEventStoreService userActivityEventStoreService;
+
+	@Resource
+	private ObjectMapper objectMapper;
+
+	@Test
+	@DisplayName("ReviewCreated 이벤트를 발행하면 USER_ACTIVITY 메시지를 발행하고 소비 핸들러로 저장된다")
+	void reviewCreatedEvent_publishAndConsumeUserActivity() throws Exception {
+		// given
+		ArgumentCaptor<MessageQueueMessage> publishedMessageCaptor = ArgumentCaptor.forClass(MessageQueueMessage.class);
+		ArgumentCaptor<MessageQueueSubscription> subscriptionCaptor = ArgumentCaptor
+			.forClass(MessageQueueSubscription.class);
+		@SuppressWarnings("unchecked") ArgumentCaptor<MessageQueueMessageHandler> handlerCaptor = ArgumentCaptor
+			.forClass(
+				MessageQueueMessageHandler.class);
+		verify(messageQueueConsumer).subscribe(subscriptionCaptor.capture(), handlerCaptor.capture());
+
+		// when
+		applicationEventPublisher.publishEvent(new ReviewCreatedEvent(130L));
+
+		// then
+		verify(messageQueueProducer).publish(publishedMessageCaptor.capture());
+		MessageQueueMessage published = publishedMessageCaptor.getValue();
+		assertThat(published.topic()).isEqualTo(MessageQueueTopics.USER_ACTIVITY);
+		assertThat(published.messageId()).isNotBlank();
+
+		ActivityEvent payload = objectMapper.readValue(published.payload(), ActivityEvent.class);
+		assertThat(payload.eventName()).isEqualTo("review.created");
+		assertThat(((Number)payload.properties().get("restaurantId")).longValue()).isEqualTo(130L);
+
+		assertThat(subscriptionCaptor.getValue().topic()).isEqualTo(MessageQueueTopics.USER_ACTIVITY);
+		assertThat(subscriptionCaptor.getValue().consumerGroup()).isEqualTo("tasteam-api-user-activity");
+
+		handlerCaptor.getValue().handle(MessageQueueMessage.of(
+			MessageQueueTopics.USER_ACTIVITY,
+			published.key(),
+			published.payload()));
+		verify(userActivityEventStoreService).store(any(ActivityEvent.class));
+	}
+
+	@Configuration
+	static class TestConfig {
+
+		@Bean
+		MessageQueueProperties messageQueueProperties() {
+			MessageQueueProperties properties = new MessageQueueProperties();
+			properties.setEnabled(true);
+			properties.setProvider(MessageQueueProviderType.REDIS_STREAM.value());
+			properties.setDefaultConsumerGroup("tasteam-api");
+			return properties;
+		}
+
+		@Bean
+		ObjectMapper objectMapper() {
+			return JsonMapper.builder().findAndAddModules().build();
+		}
+
+		@Bean
+		MessageQueueProducer messageQueueProducer() {
+			return Mockito.mock(MessageQueueProducer.class);
+		}
+
+		@Bean
+		MessageQueueConsumer messageQueueConsumer() {
+			return Mockito.mock(MessageQueueConsumer.class);
+		}
+
+		@Bean
+		UserActivityEventStoreService userActivityEventStoreService() {
+			return Mockito.mock(UserActivityEventStoreService.class);
+		}
+
+		@Bean
+		ActivityEventMapper<?> reviewCreatedActivityEventMapper() {
+			return new ReviewCreatedActivityEventMapper();
+		}
+
+		@Bean
+		UserActivityMessageQueuePublisher userActivityMessageQueuePublisher(
+			MessageQueueProducer messageQueueProducer,
+			MessageQueueProperties messageQueueProperties,
+			ObjectMapper objectMapper) {
+			return new UserActivityMessageQueuePublisher(messageQueueProducer, messageQueueProperties, objectMapper);
+		}
+
+		@Bean
+		ActivityEventMapperRegistry activityEventMapperRegistry(
+			java.util.List<ActivityEventMapper<?>> mappers) {
+			return new ActivityEventMapperRegistry(mappers);
+		}
+
+		@Bean
+		ActivityEventOrchestrator activityEventOrchestrator(
+			ActivityEventMapperRegistry mapperRegistry,
+			java.util.List<ActivitySink> sinks) {
+			return new ActivityEventOrchestrator(mapperRegistry, sinks);
+		}
+
+		@Bean
+		ActivityDomainEventListener activityDomainEventListener(ActivityEventOrchestrator orchestrator) {
+			return new ActivityDomainEventListener(orchestrator);
+		}
+
+		@Bean
+		UserActivityMessageQueueConsumerRegistrar userActivityMessageQueueConsumerRegistrar(
+			MessageQueueConsumer messageQueueConsumer,
+			MessageQueueProperties messageQueueProperties,
+			UserActivityEventStoreService userActivityEventStoreService,
+			ObjectMapper objectMapper) {
+			return new UserActivityMessageQueueConsumerRegistrar(
+				messageQueueConsumer,
+				messageQueueProperties,
+				userActivityEventStoreService,
+				objectMapper);
+		}
+	}
+}

--- a/app-api/src/test/java/com/tasteam/infra/messagequeue/UserActivityMessageQueuePublisherTest.java
+++ b/app-api/src/test/java/com/tasteam/infra/messagequeue/UserActivityMessageQueuePublisherTest.java
@@ -1,0 +1,94 @@
+package com.tasteam.infra.messagequeue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.time.Instant;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.tasteam.config.annotation.UnitTest;
+import com.tasteam.domain.analytics.api.ActivityEvent;
+
+@UnitTest
+@DisplayName("사용자 이벤트 MQ publisher")
+class UserActivityMessageQueuePublisherTest {
+
+	@Test
+	@DisplayName("사용자 이벤트를 발행하면 USER_ACTIVITY 토픽 메시지로 변환한다")
+	void sink_publishesUserActivityMessage() throws Exception {
+		// given
+		MessageQueueProducer producer = mock(MessageQueueProducer.class);
+		MessageQueueProperties properties = new MessageQueueProperties();
+		properties.setEnabled(true);
+		properties.setProvider(MessageQueueProviderType.REDIS_STREAM.value());
+		UserActivityMessageQueuePublisher publisher = new UserActivityMessageQueuePublisher(
+			producer,
+			properties,
+			JsonMapper.builder().findAndAddModules().build());
+
+		ActivityEvent event = new ActivityEvent(
+			"evt-1",
+			"group.joined",
+			"v1",
+			Instant.parse("2026-02-18T00:00:00Z"),
+			101L,
+			null,
+			Map.of("groupId", 10L));
+
+		// when
+		publisher.sink(event);
+
+		// then
+		ArgumentCaptor<MessageQueueMessage> captor = ArgumentCaptor.forClass(MessageQueueMessage.class);
+		verify(producer).publish(captor.capture());
+		MessageQueueMessage message = captor.getValue();
+		assertThat(message.topic()).isEqualTo(MessageQueueTopics.USER_ACTIVITY);
+		assertThat(message.key()).isEqualTo("101");
+		assertThat(message.messageId()).isEqualTo("evt-1");
+		assertThat(message.headers())
+			.containsEntry("eventType", "ActivityEvent")
+			.containsEntry("eventName", "group.joined")
+			.containsEntry("schemaVersion", "v1");
+
+		ActivityEvent payload = JsonMapper.builder().findAndAddModules().build()
+			.readValue(message.payload(), ActivityEvent.class);
+		assertThat(payload.eventId()).isEqualTo("evt-1");
+		assertThat(payload.eventName()).isEqualTo("group.joined");
+		assertThat(((Number)payload.properties().get("groupId")).longValue()).isEqualTo(10L);
+	}
+
+	@Test
+	@DisplayName("provider가 none이면 사용자 이벤트 발행을 건너뛴다")
+	void sink_skipsWhenProviderIsNone() {
+		// given
+		MessageQueueProducer producer = mock(MessageQueueProducer.class);
+		MessageQueueProperties properties = new MessageQueueProperties();
+		properties.setEnabled(true);
+		properties.setProvider(MessageQueueProviderType.NONE.value());
+		UserActivityMessageQueuePublisher publisher = new UserActivityMessageQueuePublisher(
+			producer,
+			properties,
+			JsonMapper.builder().findAndAddModules().build());
+		ActivityEvent event = new ActivityEvent(
+			"evt-1",
+			"review.created",
+			"v1",
+			Instant.parse("2026-02-18T00:00:00Z"),
+			null,
+			"anon-1",
+			Map.of("restaurantId", 55L));
+
+		// when
+		publisher.sink(event);
+
+		// then
+		verifyNoInteractions(producer);
+	}
+}


### PR DESCRIPTION
## 📌 PR 요약

#### Summary
- `domain.user.activity` 토픽 기반의 내부 수집 MQ 경로를 추가했습니다.
- `ActivitySink` 구현체에서 USER_ACTIVITY 메시지를 발행하고, consumer에서 멱등 저장(`ON CONFLICT DO NOTHING`)하도록 연결했습니다.
- 저장 실패 시 ACK가 수행되지 않아 재처리 가능한 동작을 테스트로 보강했습니다.

### Issue
- close : #352

---

## ➕ 추가된 기능
1. `MessageQueueTopics.USER_ACTIVITY` 추가 및 `UserActivityMessageQueuePublisher` 구현
2. `UserActivityMessageQueueConsumerRegistrar` + `UserActivityEventStoreService` + JDBC 멱등 저장소 구현

## 🛠️ 수정/변경사항
1. `user_activity_event` 저장 로직을 native insert + `ON CONFLICT(event_id) DO NOTHING`으로 구현
2. MQ publisher/consumer/flow 테스트 추가 및 Redis consumer 실패 시 ACK 미수행 회귀 테스트 추가

---

## ✅ 남은 작업
* [ ] 수집 장애 격리·재처리·운영 지표 구현 (#353)
* [ ] PostHog Sink Dispatcher 및 재시도 정책 구현 (#354)
