### PR TITLE
🔁 ci: 배포용 JAR 빌드를 app-api bootJar로 고정하고 아티팩트 업로드 조건 강화

### DIFF
--- a/.github/workflows/ci-cd-full.yml
+++ b/.github/workflows/ci-cd-full.yml
@@ -168,16 +168,20 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
 
-      # 배포용 빌드 (JAR 생성, 테스트는 PR에서 이미 완료)
+      # 배포용 빌드 (실행 가능한 Boot JAR만 생성)
       - name: Build JAR for deployment
-        run: ./gradlew build -x test
+        run: ./gradlew :app-api:bootJar -x test
 
-      # JAR 파일 업로드 (deploy job에서 사용, plain JAR 제외)
+      # JAR 파일 업로드 (deploy job에서 사용)
       - name: Upload JAR artifact
         uses: actions/upload-artifact@v4
         with:
           name: backend-jar-${{ github.ref_name }}-${{ github.run_number }}
-          path: app-api/build/libs/*[!plain].jar
+          path: |
+            app-api/build/libs/*.jar
+            !app-api/build/libs/*-plain.jar
+            !app-api/build/libs/*-test-fixtures.jar
+          if-no-files-found: error
           retention-days: 7
 
       # 빌드 실패 알림


### PR DESCRIPTION
## 📌 PR 요약

#### Summary
- 배포용 JAR 빌드를 app-api bootJar로 고정하고 아티팩트 업로드 조건 강화

### Issue
- close : #

---

## ➕ 추가된 기능
<!--
  새로운 기능을 소개하세요. 무엇이 새롭게 생기는지, 어떤 화면/API가 추가되는지를 기술하고 예시를 덧붙이면 좋습니다.
  예: "관리자 설정에서 `예약 알림` 토글을 추가하여 알림을 켜고 끌 수 있게 함."
-->

1. 배포용 JAR 빌드를 app-api bootJar로 고정
2. 아티팩트 업로드 조건 강화

## 🛠️ 수정/변경사항
<!--
  기존 기능 변경, 버그 수정, 리팩토링 등을 나열하세요. 영향 범위도 함께 쓰면 리뷰어가 이해하기 쉽습니다.
  예: "- 예약 API 응답에 `status` 필드를 추가함", "- 기존 실패율 경고 문구 변경"
-->

1.
2.

---

## ✅ 남은 작업

<!--
  아직 완료되지 않은 작업이나 사후에 처리해야 할 항목을 정리하세요. 검토자/다음 작업자에게 힌트가 됩니다.
-->
* [ ] 
