### PR TITLE
Fix: user_activity_event jsonb 매핑 타입 정합성 수정

### DIFF
--- a/app-api/src/main/java/com/tasteam/domain/analytics/persistence/UserActivityEventEntity.java
+++ b/app-api/src/main/java/com/tasteam/domain/analytics/persistence/UserActivityEventEntity.java
@@ -1,6 +1,10 @@
 package com.tasteam.domain.analytics.persistence;
 
 import java.time.Instant;
+import java.util.Map;
+
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -63,9 +67,10 @@ public class UserActivityEventEntity {
 	@Column(name = "locale", length = 20)
 	private String locale;
 
-	@Column(name = "properties", nullable = false, columnDefinition = "JSONB DEFAULT '{}'::jsonb")
-	private String properties;
+	@JdbcTypeCode(SqlTypes.JSON)
+	@Column(name = "properties", nullable = false, columnDefinition = "jsonb")
+	private Map<String, Object> properties;
 
-	@Column(name = "created_at", nullable = false, columnDefinition = "TIMESTAMPTZ DEFAULT NOW()")
+	@Column(name = "created_at", nullable = false, columnDefinition = "TIMESTAMPTZ")
 	private Instant createdAt;
 }


### PR DESCRIPTION
## 📌 PR 요약

#### Summary
- `user_activity_event.properties` 엔티티 매핑을 DB `jsonb` 타입과 정합하게 수정했습니다.
- Hibernate schema validation에서 발생하던 `jsonb(OTHER)` vs `varchar` 기대 타입 불일치를 제거했습니다.
- 서버 부팅 실패를 유발하던 매핑 정의를 최소 범위로 정리했습니다.

### Issue
- close : #367

---

## ➕ 추가된 기능

1. n/a
2. n/a

## 🛠️ 수정/변경사항

1. `UserActivityEventEntity`의 `properties`를 `String`에서 `Map<String, Object>`로 변경하고 `@JdbcTypeCode(SqlTypes.JSON)`를 적용했습니다.
2. `properties`/`created_at`의 `columnDefinition`에서 `DEFAULT` 표현을 제거해 스키마 검증 타입 충돌을 해소했습니다.
3. 검증: `./gradlew :app-api:compileJava`, `./gradlew :app-api:test --tests com.tasteam.ApiApplicationTests` 통과

---

## ✅ 남은 작업

* [x] 없음
