### PR TITLE
🐛 fix: 채팅 프로필 이미지 URL 정책을 public URL로 통일

### DIFF
--- a/app-api/src/main/java/com/tasteam/domain/chat/dto/ChatMessageQueryDto.java
+++ b/app-api/src/main/java/com/tasteam/domain/chat/dto/ChatMessageQueryDto.java
@@ -8,7 +8,6 @@ public record ChatMessageQueryDto(
 	Long id,
 	Long memberId,
 	String memberNickname,
-	String memberProfileImageUrl,
 	String content,
 	ChatMessageType messageType,
 	Instant createdAt) {

--- a/app-api/src/main/java/com/tasteam/domain/chat/repository/ChatMessageRepository.java
+++ b/app-api/src/main/java/com/tasteam/domain/chat/repository/ChatMessageRepository.java
@@ -17,7 +17,6 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
 			m.id,
 			m.memberId,
 			member.nickname,
-			member.profileImageUrl,
 			m.content,
 			m.type,
 			m.createdAt

--- a/app-api/src/main/java/com/tasteam/domain/chat/service/ChatService.java
+++ b/app-api/src/main/java/com/tasteam/domain/chat/service/ChatService.java
@@ -2,6 +2,8 @@ package com.tasteam.domain.chat.service;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -72,12 +74,19 @@ public class ChatService {
 			resolvedSize,
 			last -> new ChatMessageCursor(last.id()));
 
+		List<Long> memberIds = page.items().stream()
+			.map(ChatMessageQueryDto::memberId)
+			.filter(Objects::nonNull)
+			.distinct()
+			.toList();
+		Map<Long, String> imageUrlByMemberId = fileService.getPrimaryDomainImageUrlMap(DomainType.MEMBER, memberIds);
+
 		List<ChatMessageItemResponse> items = page.items().stream()
 			.map(item -> new ChatMessageItemResponse(
 				item.id(),
 				item.memberId(),
 				item.memberNickname(),
-				item.memberProfileImageUrl(),
+				imageUrlByMemberId.get(item.memberId()),
 				item.content(),
 				item.messageType(),
 				item.createdAt()))


### PR DESCRIPTION
 ## 📌 PR 요약

  #### Summary

  - 채팅 메시지 응답에서 만료되는 presigned 프로필 URL 제거
  - FileService 기반 public URL 정책으로 채팅 프로필 이미지 응답 통일

  ### Issue

  - close : #

  ———

  ## ➕ 추가된 기능

  1. 채팅 메시지 조회 시 memberId 기반 프로필 이미지 URL 생성 적용
  2. 채팅 응답 URL 정책을 도메인 이미지 정책과 동일하게 통일

  ## 🛠️ 수정/변경사항

  1. ChatMessageQueryDto에서 memberProfileImageUrl 제거 및 JPQL 조회 로직 변경
  2. ChatService.getMessages에서 FileService.getPrimaryDomainImageUrlMap으로 URL 생성

  ———

  ## ✅ 남은 작업
-
