### PR TITLE
Fix(file): 공용 에셋 대기 상태 URL 조회 허용

### DIFF
--- a/app-api/src/main/java/com/tasteam/domain/file/service/FileService.java
+++ b/app-api/src/main/java/com/tasteam/domain/file/service/FileService.java
@@ -152,7 +152,9 @@ public class FileService {
 		Image image = imageRepository.findByFileUuid(parseUuid(fileUuid))
 			.orElseThrow(() -> new BusinessException(FileErrorCode.FILE_NOT_FOUND));
 
-		if (image.getStatus() != ImageStatus.ACTIVE) {
+		boolean isCommonAssetPending = image.getPurpose() == FilePurpose.COMMON_ASSET
+			&& image.getStatus() == ImageStatus.PENDING;
+		if (image.getStatus() != ImageStatus.ACTIVE && !isCommonAssetPending) {
 			throw new BusinessException(FileErrorCode.FILE_NOT_ACTIVE);
 		}
 

--- a/app-api/src/test/java/com/tasteam/domain/file/service/FileServiceIntegrationTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/file/service/FileServiceIntegrationTest.java
@@ -219,6 +219,30 @@ class FileServiceIntegrationTest {
 		}
 
 		@Test
+		@DisplayName("COMMON_ASSET 용도의 PENDING 이미지도 URL 조회가 가능하다")
+		void getImageUrlPendingCommonAssetSuccess() {
+			imageRepository.save(ImageFixture.create(
+				FilePurpose.COMMON_ASSET,
+				"uploads/common/asset/promo-banner.png",
+				FILE_UUID));
+
+			ImageUrlResponse response = fileService.getImageUrl(FILE_UUID.toString());
+
+			assertThat(response.url()).contains("uploads/common/asset/promo-banner.png");
+		}
+
+		@Test
+		@DisplayName("COMMON_ASSET가 아닌 PENDING 이미지는 URL 조회에 실패한다")
+		void getImageUrlPendingNonCommonAssetFails() {
+			createAndSaveImage(FILE_UUID, "uploads/test/pending-url.png");
+
+			assertThatThrownBy(() -> fileService.getImageUrl(FILE_UUID.toString()))
+				.isInstanceOf(BusinessException.class)
+				.extracting(ex -> ((BusinessException)ex).getErrorCode())
+				.isEqualTo(FileErrorCode.FILE_NOT_ACTIVE.name());
+		}
+
+		@Test
 		@DisplayName("존재하지 않는 파일 UUID면 실패한다")
 		void getImageUrlMissingFileFails() {
 			assertThatThrownBy(() -> fileService.getImageUrl(FILE_UUID_MISSING.toString()))


### PR DESCRIPTION
## 📌 PR 요약

#### Summary
- 공용 에셋 대기 상태 URL 조회 허용

--- 

## 🛠️ 수정/변경사항
<!--
  기존 기능 변경, 버그 수정, 리팩토링 등을 나열하세요. 영향 범위도 함께 쓰면 리뷰어가 이해하기 쉽습니다.
  예: "- 예약 API 응답에 `status` 필드를 추가함", "- 기존 실패율 경고 문구 변경"
-->

- COMMON_ASSET PENDING 파일 URL 조회 예외 허용
- 비공용 PENDING 파일 차단 동작 유지 테스트 추가
- COMMON_ASSET PENDING URL 조회 성공 테스트 추가


- FileServiceIntegrationTest 통과
- ./gradlew :app-api:test --tests com.tasteam.domain.file.service.FileServiceIntegrationTest 실행

---

## ✅ 남은 작업

<!--
  아직 완료되지 않은 작업이나 사후에 처리해야 할 항목을 정리하세요. 검토자/다음 작업자에게 힌트가 됩니다.
-->
* [ ] 
