### PR TITLE
🐛 fix: 텍스트 채팅 fileType 파싱 방지

### DIFF
--- a/app-api/src/main/java/com/tasteam/domain/chat/stream/ChatStreamPayload.java
+++ b/app-api/src/main/java/com/tasteam/domain/chat/stream/ChatStreamPayload.java
@@ -40,7 +40,8 @@ public record ChatStreamPayload(
 	}
 
 	public static ChatStreamPayload fromMap(Map<String, String> map) {
-		String fileTypeValue = map.get("fileType");
+		String fileTypeValue = normalizeOptional(map.get("fileType"));
+		String fileUrlValue = normalizeOptional(map.get("fileUrl"));
 		return new ChatStreamPayload(
 			parseLong(map.get("chatRoomId")),
 			parseLong(map.get("messageId")),
@@ -50,7 +51,7 @@ public record ChatStreamPayload(
 			map.get("content"),
 			ChatMessageType.valueOf(map.get("messageType")),
 			fileTypeValue == null ? null : ChatMessageFileType.valueOf(fileTypeValue),
-			map.get("fileUrl"),
+			fileUrlValue,
 			Instant.parse(map.get("createdAt")));
 	}
 
@@ -63,8 +64,12 @@ public record ChatStreamPayload(
 		map.put("memberProfileImageUrl", memberProfileImageUrl);
 		map.put("content", content);
 		map.put("messageType", messageType.name());
-		map.put("fileType", fileType == null ? null : fileType.name());
-		map.put("fileUrl", fileUrl);
+		if (fileType != null) {
+			map.put("fileType", fileType.name());
+		}
+		if (fileUrl != null && !fileUrl.isBlank()) {
+			map.put("fileUrl", fileUrl);
+		}
 		map.put("createdAt", createdAt.toString());
 		return map;
 	}
@@ -89,5 +94,16 @@ public record ChatStreamPayload(
 			return null;
 		}
 		return Long.valueOf(value);
+	}
+
+	private static String normalizeOptional(String value) {
+		if (value == null) {
+			return null;
+		}
+		String trimmed = value.trim();
+		if (trimmed.isEmpty() || "null".equalsIgnoreCase(trimmed)) {
+			return null;
+		}
+		return trimmed;
 	}
 }

--- a/app-api/src/main/java/com/tasteam/domain/chat/stream/ChatStreamSubscriber.java
+++ b/app-api/src/main/java/com/tasteam/domain/chat/stream/ChatStreamSubscriber.java
@@ -73,6 +73,13 @@ public class ChatStreamSubscriber {
 		}
 	}
 
+	public void ensureSubscribed(Long roomId) {
+		if (roomId == null) {
+			return;
+		}
+		subscriptions.computeIfAbsent(roomId, this::registerRoomSubscription);
+	}
+
 	@Scheduled(fixedDelayString = "PT30S")
 	public void recoverPendingMessages() {
 		StreamOperations<String, String, String> streamOperations = stringRedisTemplate.opsForStream();

--- a/app-api/src/main/java/com/tasteam/domain/chat/ws/ChatRoomSubscriptionListener.java
+++ b/app-api/src/main/java/com/tasteam/domain/chat/ws/ChatRoomSubscriptionListener.java
@@ -1,0 +1,39 @@
+package com.tasteam.domain.chat.ws;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionSubscribeEvent;
+
+import com.tasteam.domain.chat.stream.ChatStreamSubscriber;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ChatRoomSubscriptionListener {
+
+	private static final String DESTINATION_PREFIX = "/topic/chat-rooms/";
+
+	private final ChatStreamSubscriber chatStreamSubscriber;
+
+	@EventListener
+	public void handleSubscribe(SessionSubscribeEvent event) {
+		String destination = SimpMessageHeaderAccessor.wrap(event.getMessage()).getDestination();
+		if (destination == null || !destination.startsWith(DESTINATION_PREFIX)) {
+			return;
+		}
+
+		String roomIdText = destination.substring(DESTINATION_PREFIX.length());
+		if (roomIdText.isBlank()) {
+			return;
+		}
+
+		try {
+			Long roomId = Long.valueOf(roomIdText);
+			chatStreamSubscriber.ensureSubscribed(roomId);
+		} catch (NumberFormatException ignored) {
+			// Ignore invalid destination format.
+		}
+	}
+}


### PR DESCRIPTION
 #### Summary

  - 채팅 이미지 전송 플로우에 맞춰 파일 저장/조회 구조를 정비하고, WS 브로드캐스트 안정성 이슈를 수정했습니다.

  ### Issue

  - close : #

  ———

  ## ➕ 추가된 기능

  1. 채팅 이미지가 DomainImage(domain_type=CHAT_MESSAGE)로 연결되어 최적화 파이프라인 대상에 포함
  2. 채팅 이미지 조회 시 fileUuid 기반으로 URL을 생성하도록 변경

  ## 🛠️ 수정/변경사항

  1. chat_message_file에 file_uuid, domain_image_id 추가 및 file_url nullable 처리
  2. WS 스트림 파싱 시 TEXT 메시지에서 fileType 파싱 오류 방지

  ———

  ## ✅ 남은 작업

