### PR TITLE
🐛 fix: 채팅 이미지 URL 발급 방식 수정

### DIFF
--- a/app-api/src/main/java/com/tasteam/domain/chat/service/ChatService.java
+++ b/app-api/src/main/java/com/tasteam/domain/chat/service/ChatService.java
@@ -94,7 +94,7 @@ public class ChatService {
 			.filter(Objects::nonNull)
 			.distinct()
 			.toList();
-		Map<Long, String> imageUrlByMemberId = fileService.getPrimaryDomainImageUrlMapStatic(
+		Map<Long, String> imageUrlByMemberId = fileService.getPrimaryDomainImageUrlMap(
 			DomainType.MEMBER,
 			memberIds);
 
@@ -146,7 +146,7 @@ public class ChatService {
 			message.getId(),
 			message.getMemberId(),
 			member.getNickname(),
-			fileService.getPrimaryDomainImageUrlStatic(DomainType.MEMBER, memberId),
+			fileService.getPrimaryDomainImageUrl(DomainType.MEMBER, memberId),
 			message.getContent(),
 			message.getType(),
 			fileItems,
@@ -296,7 +296,7 @@ public class ChatService {
 			}
 		}
 		if (file.getFileUuid() != null && !file.getFileUuid().isBlank()) {
-			return fileService.getImageStaticUrl(file.getFileUuid());
+			return fileService.getImageUrl(file.getFileUuid()).url();
 		}
 		return file.getFileUrl();
 	}
@@ -318,7 +318,7 @@ public class ChatService {
 			if (image == null || image.getFileUuid() == null) {
 				continue;
 			}
-			result.put(domainImage.getId(), fileService.getImageStaticUrl(image.getFileUuid().toString()));
+			result.put(domainImage.getId(), fileService.getPublicUrl(image.getStorageKey()));
 		}
 		return result;
 	}


### PR DESCRIPTION
• ## 📌 PR 요약

  #### Summary

  - 채팅 프로필 이미지 및 이미지 메시지 URL을 FileService의 public URL 정책과 동일하게 통일

  ### Issue

  - close : #

  ———

  ## ➕ 추가된 기능

  1. 채팅 메시지 조회 시 memberId 기반 프로필 이미지 URL 재생성 적용
  2. 채팅 이미지 메시지(file) URL 생성 경로를 FileService 기반으로 통일

  ## 🛠️ 수정/변경사항

  1. 채팅 메시지 목록 조회에서 member.profileImageUrl 직접 사용 제거, URL 생성 로직을 Service로 이동
  2. 채팅 응답 URL 생성 경로를 buildPublicUrl() 정책으로 통일(presigned/public 모드 대응)

  ———

  ## ✅ 남은 작업

