### PR TITLE
✨ feat: 채팅 이미지 제약조건 추가

### DIFF
--- a/app-api/src/main/resources/db/migration/V202602251200__update_image_purpose_check_add_chat_image.sql
+++ b/app-api/src/main/resources/db/migration/V202602251200__update_image_purpose_check_add_chat_image.sql
@@ -1,0 +1,14 @@
+ALTER TABLE image
+    DROP CONSTRAINT IF EXISTS image_purpose_check;
+
+ALTER TABLE image
+    ADD CONSTRAINT image_purpose_check
+    CHECK (purpose IN (
+        'REVIEW_IMAGE',
+        'RESTAURANT_IMAGE',
+        'MENU_IMAGE',
+        'COMMON_ASSET',
+        'PROFILE_IMAGE',
+        'GROUP_IMAGE',
+        'CHAT_IMAGE'
+    ));


### PR DESCRIPTION
• ## 📌 PR 요약

  #### Summary

  - image.purpose 제약에 CHAT_IMAGE 허용 추가

  ### Issue

  - close : #

  ———

  ## ➕ 추가된 기능

  1. image 테이블의 purpose 값으로 CHAT_IMAGE 저장 가능

  ## 🛠️ 수정/변경사항

  1. image_purpose_check 제약 재정의 (CHAT_IMAGE 포함)
  2. Flyway 마이그레이션 추가
     app-api/src/main/resources/db/migration/V202602251200__update_image_purpose_check_add_chat_image.sql

  ———

  ## ✅ 남은 작업

  - [ ] 스테이징/프로덕션 마이그레이션 적용 확인
