### PR TITLE
✨ feat: 채팅 조회 모드 추가

### DIFF
--- a/app-api/src/main/java/com/tasteam/domain/chat/controller/ChatController.java
+++ b/app-api/src/main/java/com/tasteam/domain/chat/controller/ChatController.java
@@ -20,6 +20,7 @@ import com.tasteam.domain.chat.dto.response.ChatMessageListResponse;
 import com.tasteam.domain.chat.dto.response.ChatMessageSendResponse;
 import com.tasteam.domain.chat.dto.response.ChatReadCursorUpdateResponse;
 import com.tasteam.domain.chat.service.ChatService;
+import com.tasteam.domain.chat.type.ChatMessageListMode;
 import com.tasteam.global.dto.api.SuccessResponse;
 import com.tasteam.global.security.jwt.annotation.CurrentUser;
 
@@ -43,11 +44,13 @@ public class ChatController implements ChatControllerDocs {
 		Long chatRoomId,
 		@RequestParam(required = false)
 		String cursor,
+		@RequestParam(required = false)
+		ChatMessageListMode mode,
 		@RequestParam(defaultValue = "20") @Min(1) @Max(100)
 		int size,
 		@CurrentUser
 		Long memberId) {
-		return SuccessResponse.success(chatService.getMessages(chatRoomId, memberId, cursor, size));
+		return SuccessResponse.success(chatService.getMessages(chatRoomId, memberId, cursor, mode, size));
 	}
 
 	@PostMapping("/{chatRoomId}/messages")

--- a/app-api/src/main/java/com/tasteam/domain/chat/controller/docs/ChatControllerDocs.java
+++ b/app-api/src/main/java/com/tasteam/domain/chat/controller/docs/ChatControllerDocs.java
@@ -9,6 +9,7 @@ import com.tasteam.domain.chat.dto.request.ChatReadCursorUpdateRequest;
 import com.tasteam.domain.chat.dto.response.ChatMessageListResponse;
 import com.tasteam.domain.chat.dto.response.ChatMessageSendResponse;
 import com.tasteam.domain.chat.dto.response.ChatReadCursorUpdateResponse;
+import com.tasteam.domain.chat.type.ChatMessageListMode;
 import com.tasteam.global.dto.api.SuccessResponse;
 import com.tasteam.global.security.jwt.annotation.CurrentUser;
 
@@ -33,6 +34,8 @@ public interface ChatControllerDocs {
 		Long chatRoomId,
 		@Parameter(description = "커서", example = "opaque") @RequestParam(required = false)
 		String cursor,
+		@Parameter(description = "조회 모드 (ENTER/BEFORE/AFTER)", example = "ENTER") @RequestParam(required = false)
+		ChatMessageListMode mode,
 		@Parameter(description = "페이지 크기", example = "20") @RequestParam(defaultValue = "20") @Min(1) @Max(100)
 		int size,
 		@CurrentUser

--- a/app-api/src/main/java/com/tasteam/domain/chat/repository/ChatMessageRepository.java
+++ b/app-api/src/main/java/com/tasteam/domain/chat/repository/ChatMessageRepository.java
@@ -35,5 +35,51 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
 		Long cursorId,
 		Pageable pageable);
 
+	@Query("""
+		select new com.tasteam.domain.chat.dto.ChatMessageQueryDto(
+			m.id,
+			m.memberId,
+			member.nickname,
+			m.content,
+			m.type,
+			m.createdAt
+		)
+		from ChatMessage m
+		left join Member member on member.id = m.memberId
+		where m.chatRoomId = :chatRoomId
+		and m.deletedAt is null
+		and (:maxId is null or m.id <= :maxId)
+		order by m.id desc
+		""")
+	List<ChatMessageQueryDto> findMessagePageUpTo(
+		@Param("chatRoomId")
+		Long chatRoomId,
+		@Param("maxId")
+		Long maxId,
+		Pageable pageable);
+
+	@Query("""
+		select new com.tasteam.domain.chat.dto.ChatMessageQueryDto(
+			m.id,
+			m.memberId,
+			member.nickname,
+			m.content,
+			m.type,
+			m.createdAt
+		)
+		from ChatMessage m
+		left join Member member on member.id = m.memberId
+		where m.chatRoomId = :chatRoomId
+		and m.deletedAt is null
+		and m.id > :cursorId
+		order by m.id asc
+		""")
+	List<ChatMessageQueryDto> findMessagePageAfter(
+		@Param("chatRoomId")
+		Long chatRoomId,
+		@Param("cursorId")
+		Long cursorId,
+		Pageable pageable);
+
 	boolean existsByIdAndChatRoomIdAndDeletedAtIsNull(Long id, Long chatRoomId);
 }

--- a/app-api/src/main/java/com/tasteam/domain/chat/type/ChatMessageListMode.java
+++ b/app-api/src/main/java/com/tasteam/domain/chat/type/ChatMessageListMode.java
@@ -1,0 +1,7 @@
+package com.tasteam.domain.chat.type;
+
+public enum ChatMessageListMode {
+	ENTER,
+	BEFORE,
+	AFTER
+}


### PR DESCRIPTION
 ## 📌 PR 요약

  #### Summary

  - 채팅 메시지 목록 조회에 mode(ENTER/BEFORE/AFTER) 추가 및 커서 정책 확장

  ### Issue

  - close : #

  ———

  ## ➕ 추가된 기능

  1. GET /chat-rooms/{chatRoomId}/messages에 mode 파라미터 추가
  2. mode=ENTER로 읽음 커서 기준 메시지 목록 조회 지원

  ## 🛠️ 수정/변경사항

  1. 채팅 목록 조회 로직을 mode별로 분기(ENTER/BEFORE/AFTER)
  2. Repository에 ENTER/AFTER 전용 조회 쿼리 추가 및 정렬 보정

  ———

  ## ✅ 남은 작업
