### PR TITLE
✨ feat: 채팅 After 용 커서 추가

### DIFF
--- a/app-api/src/main/java/com/tasteam/domain/chat/dto/response/ChatMessageListResponse.java
+++ b/app-api/src/main/java/com/tasteam/domain/chat/dto/response/ChatMessageListResponse.java
@@ -10,6 +10,6 @@ public record ChatMessageListResponse(
 	public record Meta(Long lastReadMessageId) {
 	}
 
-	public record Page(String nextCursor, int size, boolean hasNext) {
+	public record Page(String nextCursor, String afterCursor, int size, boolean hasNext) {
 	}
 }

--- a/app-api/src/main/java/com/tasteam/domain/chat/service/ChatService.java
+++ b/app-api/src/main/java/com/tasteam/domain/chat/service/ChatService.java
@@ -144,10 +144,14 @@ public class ChatService {
 				item.createdAt()))
 			.toList();
 
+		String afterCursor = pageItems.isEmpty()
+			? null
+			: cursorCodec.encode(new ChatMessageCursor(pageItems.get(0).id()));
+
 		return new ChatMessageListResponse(
 			new ChatMessageListResponse.Meta(membership.getLastReadMessageId()),
 			items,
-			new ChatMessageListResponse.Page(page.nextCursor(), resolvedSize, page.hasNext()));
+			new ChatMessageListResponse.Page(page.nextCursor(), afterCursor, resolvedSize, page.hasNext()));
 	}
 
 	@Transactional

--- a/docs/spec/api/README.md
+++ b/docs/spec/api/README.md
@@ -3904,6 +3904,7 @@ Authorization: Bearer {accessToken}
              .             
       ], "page": {
                "nextCursor": "opaque", 
+               "afterCursor": "opaque",
                "size": 20, 
                "hasNext": true
 }

--- a/docs/spec/tech/chat/README.md
+++ b/docs/spec/tech/chat/README.md
@@ -222,6 +222,7 @@ sequenceDiagram
                 - `createdAt`: string (ISO-8601)
             - `page`: object
                 - `nextCursor`: string
+                - `afterCursor`: string
                 - `size`: number
                 - `hasNext`: boolean
         - 예시(JSON)
@@ -243,6 +244,7 @@ sequenceDiagram
             ],
             "page": {
               "nextCursor": "opaque",
+              "afterCursor": "opaque",
               "size": 20,
               "hasNext": true
             }
@@ -259,6 +261,8 @@ sequenceDiagram
         5. 응답 매핑
             - `memberNickname`, `memberProfileImageUrl`은 `member` 조인(또는 배치 조회)로 구성
             - `meta.lastReadMessageId`는 `chat_room_member.last_read_message_id`를 그대로 내려 “unread 구분선” 렌더링에 사용
+            - `page.nextCursor`는 `BEFORE`(과거 페이지) 조회용 커서
+            - `page.afterCursor`는 `AFTER`(신규 메시지 동기화) 조회용 커서
     - **트랜잭션 관리:** read-only(또는 트랜잭션 생략)
     - **동시성/멱등성(필요시):** 조회 API는 멱등
     - **에러 코드(주요, API 명세서 기준):** `UNAUTHORIZED`(401), `FORBIDDEN`(403), `CHAT_ROOM_NOT_FOUND`(404), `TOO_MANY_REQUESTS`(429), `INTERNAL_SERVER_ERROR`(500)


### PR DESCRIPTION

• ## 📌 PR 요약

  #### Summary

  - 채팅 메시지 조회 응답에 afterCursor를 추가해 AFTER 요청 전용 커서를 제공하도록 개선했습니다.
  - nextCursor(BEFORE 전용)와 afterCursor(AFTER 전용)를 분리해 커서 오용으로 인한 중복 조회를 방지했습니다.
  - 채팅 API/기술 문서에 커서 사용 규칙을 반영했습니다.

  ### Issue

  - close : #

  ———

  ## ➕ 추가된 기능

  1. GET /chat-rooms/{chatRoomId}/messages 응답 page에 afterCursor 필드 추가
  2. 서버가 현재 응답의 최신 메시지 기준으로 afterCursor를 생성해 반환

  ## 🛠️ 수정/변경사항

  1. ChatMessageListResponse.Page 구조 변경
      - 기존: nextCursor, size, hasNext
      - 변경: nextCursor, afterCursor, size, hasNext
  2. ChatService.getMessages() 응답 조립 로직 수정
      - nextCursor: 기존처럼 과거 페이지(BEFORE)용 유지
      - afterCursor: 신규 메시지 동기화(AFTER)용 추가
  3. 문서 업데이트
      - docs/spec/api/README.md: 응답 예시에 afterCursor 추가
      - docs/spec/tech/chat/README.md: nextCursor/afterCursor 용도 명시

  ———

  ## ✅ 남은 작업

