### PR TITLE
chore(.gitignore): hprof 힙 덤프 파일 무시 패턴 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ application-*.yaml
 /.github/issue
 /scripts
 scripts/create-issues.sh
+*.hprof


### PR DESCRIPTION
## 배경
부하 테스트 중 JVM 힙 덤프(`.hprof`) 파일이 생성되었으나 `.gitignore`에 등록되지 않아 실수로 커밋될 수 있는 상태였습니다.

## 변경 사항
- `.gitignore`에 `*.hprof` 패턴 추가

## 테스트
- [ ] 힙 덤프 파일 생성 후 `git status`에 표시되지 않음을 확인