### PR TITLE
fix(auth): TestAuthController에 local 프로파일 추가

### DIFF
--- a/app-api/src/main/java/com/tasteam/domain/auth/controller/TestAuthController.java
+++ b/app-api/src/main/java/com/tasteam/domain/auth/controller/TestAuthController.java
@@ -17,7 +17,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
-@Profile({"dev", "test"})
+@Profile({"dev", "test", "local"})
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/auth")


### PR DESCRIPTION
## 배경
로컬 환경에서 부하 테스트 및 개발 중 테스트용 인증 엔드포인트(`/api/v1/auth/test`)를 사용해야 하는 경우가 있으나, 기존에는 `dev`, `test` 프로파일에서만 활성화되어 있었습니다.

## 변경 사항
- `@Profile({"dev", "test"})` → `@Profile({"dev", "test", "local"})`

## 테스트
- [ ] local 프로파일로 앱 실행 후 테스트 인증 엔드포인트 정상 동작 확인