### PR TITLE
Feat: ui.restaurant.shared 이벤트 허용 목록에 추가

### DIFF
--- a/app-api/src/main/java/com/tasteam/domain/analytics/ingest/AnalyticsIngestProperties.java
+++ b/app-api/src/main/java/com/tasteam/domain/analytics/ingest/AnalyticsIngestProperties.java
@@ -30,7 +30,8 @@ public class AnalyticsIngestProperties {
 		"ui.favorite.sheet_opened",
 		"ui.favorite.updated",
 		"ui.event.clicked",
-		"ui.tab.changed");
+		"ui.tab.changed",
+		"ui.restaurant.shared");
 	private RateLimit rateLimit = new RateLimit();
 
 	public int validatedMaxBatchSize() {


### PR DESCRIPTION
## 배경
식당 공유 기능 추가로 인해 클라이언트에서 `ui.restaurant.shared` 이벤트를 수집해야 하나, 서버 허용 목록에 등록되지 않아 수집이 불가능한 상태였습니다.

## 변경 사항
- `AnalyticsIngestProperties`의 허용 이벤트 목록에 `ui.restaurant.shared` 추가

## 테스트
- [ ] 클라이언트에서 `ui.restaurant.shared` 이벤트 전송 시 정상 수집 확인