### PR TITLE
Test: 비동기 이벤트/웹훅 테스트 코드 보강

### DIFF
--- a/app-api/src/test/java/com/tasteam/batch/ai/report/BatchReportWebhookEventListenerTest.java
+++ b/app-api/src/test/java/com/tasteam/batch/ai/report/BatchReportWebhookEventListenerTest.java
@@ -1,0 +1,66 @@
+package com.tasteam.batch.ai.report;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import com.tasteam.batch.ai.event.BatchExecutionFinishedEvent;
+import com.tasteam.config.annotation.UnitTest;
+import com.tasteam.domain.batch.entity.BatchExecutionStatus;
+import com.tasteam.domain.batch.entity.BatchType;
+import com.tasteam.domain.batch.repository.AiJobRepository;
+import com.tasteam.infra.webhook.discord.BatchReportDiscordWebhookClient;
+import com.tasteam.infra.webhook.discord.DiscordMessage;
+
+@UnitTest
+@DisplayName("BatchReportWebhookEventListener")
+class BatchReportWebhookEventListenerTest {
+
+	@Mock
+	private AiJobRepository aiJobRepository;
+
+	@Mock
+	private BatchReportDiscordMessageFactory messageFactory;
+
+	@Mock
+	private BatchReportDiscordWebhookClient batchReportWebhookClient;
+
+	@InjectMocks
+	private BatchReportWebhookEventListener listener;
+
+	@Test
+	@DisplayName("배치 완료 이벤트 수신 시 리포트 웹훅을 전송한다")
+	void onBatchExecutionFinished_sendsReportWebhook() {
+		BatchExecutionFinishedEvent event = new BatchExecutionFinishedEvent(
+			1L, BatchType.REVIEW_ANALYSIS_DAILY, BatchExecutionStatus.COMPLETED,
+			Instant.now(), Instant.now(), 10, 8, 2, 0);
+		given(aiJobRepository.countByBatchExecutionIdGroupByJobTypeAndStatus(1L)).willReturn(List.of());
+		DiscordMessage message = new DiscordMessage(List.of());
+		given(messageFactory.create(event, List.of())).willReturn(message);
+
+		listener.onBatchExecutionFinished(event);
+
+		then(batchReportWebhookClient).should().send(message);
+	}
+
+	@Test
+	@DisplayName("처리 중 예외가 발생해도 전파되지 않는다")
+	void onBatchExecutionFinished_whenExceptionOccurs_doesNotPropagate() {
+		BatchExecutionFinishedEvent event = new BatchExecutionFinishedEvent(
+			1L, BatchType.REVIEW_ANALYSIS_DAILY, BatchExecutionStatus.FAILED,
+			Instant.now(), Instant.now(), 10, 0, 10, 0);
+		given(aiJobRepository.countByBatchExecutionIdGroupByJobTypeAndStatus(1L))
+			.willThrow(new RuntimeException("DB 오류"));
+
+		assertThatCode(() -> listener.onBatchExecutionFinished(event))
+			.doesNotThrowAnyException();
+	}
+}

--- a/app-api/src/test/java/com/tasteam/domain/notification/event/NotificationEventListenerTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/notification/event/NotificationEventListenerTest.java
@@ -1,0 +1,57 @@
+package com.tasteam.domain.notification.event;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import com.tasteam.config.annotation.UnitTest;
+import com.tasteam.domain.group.event.GroupMemberJoinedEvent;
+import com.tasteam.domain.notification.entity.NotificationType;
+import com.tasteam.domain.notification.service.NotificationService;
+
+@UnitTest
+@DisplayName("NotificationEventListener")
+class NotificationEventListenerTest {
+
+	@Mock
+	private NotificationService notificationService;
+
+	@InjectMocks
+	private NotificationEventListener notificationEventListener;
+
+	@Test
+	@DisplayName("그룹 가입 이벤트 수신 시 올바른 파라미터로 알림을 생성한다")
+	void onGroupMemberJoined_createsNotificationWithCorrectParams() {
+		GroupMemberJoinedEvent event = new GroupMemberJoinedEvent(1L, 2L, "스터디", Instant.now());
+
+		notificationEventListener.onGroupMemberJoined(event);
+
+		then(notificationService).should().createNotification(
+			2L,
+			NotificationType.SYSTEM,
+			"그룹 가입 완료",
+			"스터디 그룹에 가입되었습니다.",
+			"/groups/1");
+	}
+
+	@Test
+	@DisplayName("알림 생성 실패해도 예외가 전파되지 않는다")
+	void onGroupMemberJoined_whenServiceThrows_doesNotPropagate() {
+		GroupMemberJoinedEvent event = new GroupMemberJoinedEvent(1L, 2L, "스터디", Instant.now());
+		willThrow(new RuntimeException("알림 생성 실패"))
+			.given(notificationService)
+			.createNotification(anyLong(), any(), any(), any(), any());
+
+		assertThatCode(() -> notificationEventListener.onGroupMemberJoined(event))
+			.doesNotThrowAnyException();
+	}
+}

--- a/app-api/src/test/java/com/tasteam/domain/restaurant/service/analysis/ReviewCreatedAiAnalysisEventListenerTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/restaurant/service/analysis/ReviewCreatedAiAnalysisEventListenerTest.java
@@ -1,0 +1,32 @@
+package com.tasteam.domain.restaurant.service.analysis;
+
+import static org.mockito.BDDMockito.then;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import com.tasteam.config.annotation.UnitTest;
+import com.tasteam.domain.review.event.ReviewCreatedEvent;
+
+@UnitTest
+@DisplayName("ReviewCreatedAiAnalysisEventListener")
+class ReviewCreatedAiAnalysisEventListenerTest {
+
+	@Mock
+	private RestaurantAnalysisFacade restaurantAnalysisFacade;
+
+	@InjectMocks
+	private ReviewCreatedAiAnalysisEventListener reviewCreatedAiAnalysisEventListener;
+
+	@Test
+	@DisplayName("리뷰 이벤트 수신 시 AI 분석 Facade를 호출한다")
+	void onReviewCreated_callsFacadeWithRestaurantId() {
+		ReviewCreatedEvent event = new ReviewCreatedEvent(42L);
+
+		reviewCreatedAiAnalysisEventListener.onReviewCreated(event);
+
+		then(restaurantAnalysisFacade).should().onReviewCreated(42L);
+	}
+}

--- a/app-api/src/test/java/com/tasteam/domain/review/event/ReviewEventPublisherTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/review/event/ReviewEventPublisherTest.java
@@ -1,0 +1,27 @@
+package com.tasteam.domain.review.event;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationEventPublisher;
+
+import com.tasteam.config.annotation.UnitTest;
+
+@UnitTest
+@DisplayName("ReviewEventPublisher")
+class ReviewEventPublisherTest {
+
+	@Test
+	@DisplayName("트랜잭션이 없으면 즉시 이벤트를 발행한다")
+	void publishReviewCreated_whenNoTransaction_publishesImmediately() {
+		ApplicationEventPublisher mockPublisher = mock(ApplicationEventPublisher.class);
+		ReviewEventPublisher publisher = new ReviewEventPublisher(mockPublisher);
+
+		publisher.publishReviewCreated(1L);
+
+		then(mockPublisher).should().publishEvent(any(ReviewCreatedEvent.class));
+	}
+}

--- a/app-api/src/test/java/com/tasteam/domain/search/service/SearchHistoryRecorderTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/search/service/SearchHistoryRecorderTest.java
@@ -1,0 +1,102 @@
+package com.tasteam.domain.search.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import com.tasteam.config.annotation.UnitTest;
+import com.tasteam.domain.search.entity.MemberSearchHistory;
+import com.tasteam.domain.search.repository.MemberSearchHistoryRepository;
+
+@UnitTest
+@DisplayName("SearchHistoryRecorder")
+class SearchHistoryRecorderTest {
+
+	@Mock
+	private MemberSearchHistoryRepository memberSearchHistoryRepository;
+
+	@InjectMocks
+	private SearchHistoryRecorder searchHistoryRecorder;
+
+	@Test
+	@DisplayName("memberId가 null이면 저장 없이 스킵한다")
+	void recordSearchHistory_whenMemberIdIsNull_skips() {
+		searchHistoryRecorder.recordSearchHistory(null, "치킨");
+
+		verifyNoInteractions(memberSearchHistoryRepository);
+	}
+
+	@Test
+	@DisplayName("기록이 없으면 새로 생성한다")
+	void recordSearchHistory_whenNoExistingRecord_savesNew() {
+		given(memberSearchHistoryRepository.findAllByMemberIdAndKeywordAndDeletedAtIsNull(1L, "치킨"))
+			.willReturn(List.of());
+
+		searchHistoryRecorder.recordSearchHistory(1L, "치킨");
+
+		then(memberSearchHistoryRepository).should().save(any(MemberSearchHistory.class));
+	}
+
+	@Test
+	@DisplayName("동일 키워드 기록이 있으면 카운트를 증가시킨다")
+	void recordSearchHistory_whenExistingRecord_incrementsCount() {
+		MemberSearchHistory existing = MemberSearchHistory.create(1L, "치킨");
+		given(memberSearchHistoryRepository.findAllByMemberIdAndKeywordAndDeletedAtIsNull(1L, "치킨"))
+			.willReturn(List.of(existing));
+
+		searchHistoryRecorder.recordSearchHistory(1L, "치킨");
+
+		then(memberSearchHistoryRepository).should(never()).save(any());
+		assertThat(existing.getCount()).isEqualTo(2L);
+	}
+
+	@Test
+	@DisplayName("중복 기록이 여러 개이면 첫 번째만 카운트업하고 나머지는 삭제한다")
+	void recordSearchHistory_whenDuplicateRecords_incrementsFirstAndDeletesRest() {
+		MemberSearchHistory h1 = MemberSearchHistory.create(1L, "치킨");
+		MemberSearchHistory h2 = MemberSearchHistory.create(1L, "치킨");
+		given(memberSearchHistoryRepository.findAllByMemberIdAndKeywordAndDeletedAtIsNull(1L, "치킨"))
+			.willReturn(List.of(h1, h2));
+
+		searchHistoryRecorder.recordSearchHistory(1L, "치킨");
+
+		assertThat(h1.getCount()).isEqualTo(2L);
+		assertThat(h2.getDeletedAt()).isNotNull();
+	}
+
+	@Test
+	@DisplayName("예외가 발생해도 전파되지 않는다")
+	void recordSearchHistory_whenExceptionOccurs_doesNotPropagate() {
+		given(memberSearchHistoryRepository.findAllByMemberIdAndKeywordAndDeletedAtIsNull(1L, "치킨"))
+			.willThrow(new RuntimeException("DB 오류"));
+
+		assertThatCode(() -> searchHistoryRecorder.recordSearchHistory(1L, "치킨"))
+			.doesNotThrowAnyException();
+	}
+
+	@Test
+	@DisplayName("DataIntegrityViolationException 발생 시 재조회 후 카운트업을 시도한다")
+	void recordSearchHistory_whenDataIntegrityViolation_retriesAndIncrements() {
+		MemberSearchHistory existing = MemberSearchHistory.create(1L, "치킨");
+		given(memberSearchHistoryRepository.findAllByMemberIdAndKeywordAndDeletedAtIsNull(1L, "치킨"))
+			.willThrow(new DataIntegrityViolationException("unique violation"))
+			.willReturn(List.of(existing));
+
+		assertThatCode(() -> searchHistoryRecorder.recordSearchHistory(1L, "치킨"))
+			.doesNotThrowAnyException();
+
+		assertThat(existing.getCount()).isEqualTo(2L);
+	}
+}

--- a/app-api/src/test/java/com/tasteam/infra/webhook/WebhookErrorEventListenerTest.java
+++ b/app-api/src/test/java/com/tasteam/infra/webhook/WebhookErrorEventListenerTest.java
@@ -1,0 +1,133 @@
+package com.tasteam.infra.webhook;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.http.HttpStatus;
+
+import com.tasteam.config.annotation.UnitTest;
+import com.tasteam.infra.webhook.event.ErrorContext;
+import com.tasteam.infra.webhook.event.ErrorOccurredEvent;
+import com.tasteam.infra.webhook.template.BusinessExceptionTemplate;
+import com.tasteam.infra.webhook.template.SystemExceptionTemplate;
+
+@UnitTest
+@DisplayName("WebhookErrorEventListener")
+class WebhookErrorEventListenerTest {
+
+	@Mock
+	private WebhookClient webhookClient;
+
+	@Mock
+	private BusinessExceptionTemplate businessExceptionTemplate;
+
+	@Mock
+	private SystemExceptionTemplate systemExceptionTemplate;
+
+	private WebhookProperties webhookProperties;
+	private WebhookErrorEventListener listener;
+
+	@BeforeEach
+	void setUp() {
+		webhookProperties = new WebhookProperties();
+		listener = new WebhookErrorEventListener(
+			webhookClient, businessExceptionTemplate, systemExceptionTemplate, webhookProperties);
+	}
+
+	@Test
+	@DisplayName("웹훅 클라이언트가 비활성화되어 있으면 전송하지 않는다")
+	void onErrorOccurred_whenClientDisabled_doesNotSend() {
+		given(webhookClient.isEnabled()).willReturn(false);
+		ErrorOccurredEvent event = errorEvent("SYSTEM", "INTERNAL_SERVER_ERROR", HttpStatus.INTERNAL_SERVER_ERROR);
+
+		listener.onErrorOccurred(event);
+
+		then(webhookClient).should(never()).send(any());
+	}
+
+	@Test
+	@DisplayName("제외 에러코드에 해당하면 전송하지 않는다")
+	void onErrorOccurred_whenExcludedErrorCode_doesNotSend() {
+		given(webhookClient.isEnabled()).willReturn(true);
+		webhookProperties.getFilters().setExcludeErrorCodes(List.of("NOT_FOUND"));
+		ErrorOccurredEvent event = errorEvent("BUSINESS", "NOT_FOUND", HttpStatus.NOT_FOUND);
+
+		listener.onErrorOccurred(event);
+
+		then(webhookClient).should(never()).send(any());
+	}
+
+	@Test
+	@DisplayName("minHttpStatus 미만이면 전송하지 않는다")
+	void onErrorOccurred_whenBelowMinHttpStatus_doesNotSend() {
+		given(webhookClient.isEnabled()).willReturn(true);
+		webhookProperties.getFilters().setMinHttpStatus(500);
+		ErrorOccurredEvent event = errorEvent("BUSINESS", "BAD_REQUEST", HttpStatus.BAD_REQUEST);
+
+		listener.onErrorOccurred(event);
+
+		then(webhookClient).should(never()).send(any());
+	}
+
+	@Test
+	@DisplayName("BUSINESS 에러 타입이면 businessExceptionTemplate을 사용한다")
+	void onErrorOccurred_whenBusinessType_usesBusinessTemplate() {
+		given(webhookClient.isEnabled()).willReturn(true);
+		webhookProperties.getFilters().setMinHttpStatus(400);
+		ErrorOccurredEvent event = errorEvent("BUSINESS", "SOME_ERROR", HttpStatus.BAD_REQUEST);
+		WebhookMessage message = new WebhookMessage("title", "desc", null, null, Instant.now(), null);
+		given(businessExceptionTemplate.build(event.context())).willReturn(message);
+
+		listener.onErrorOccurred(event);
+
+		then(businessExceptionTemplate).should().build(event.context());
+		then(webhookClient).should().send(message);
+	}
+
+	@Test
+	@DisplayName("SYSTEM 에러 타입이면 systemExceptionTemplate을 사용한다")
+	void onErrorOccurred_whenSystemType_usesSystemTemplate() {
+		given(webhookClient.isEnabled()).willReturn(true);
+		webhookProperties.getFilters().setMinHttpStatus(500);
+		ErrorOccurredEvent event = errorEvent("SYSTEM", "INTERNAL_SERVER_ERROR", HttpStatus.INTERNAL_SERVER_ERROR);
+		WebhookMessage message = new WebhookMessage("title", "desc", null, null, Instant.now(), null);
+		given(systemExceptionTemplate.build(event.context())).willReturn(message);
+
+		listener.onErrorOccurred(event);
+
+		then(systemExceptionTemplate).should().build(event.context());
+		then(webhookClient).should().send(message);
+	}
+
+	@Test
+	@DisplayName("전송 중 예외가 발생해도 전파되지 않는다")
+	void onErrorOccurred_whenSendThrows_doesNotPropagate() {
+		given(webhookClient.isEnabled()).willReturn(true);
+		webhookProperties.getFilters().setMinHttpStatus(500);
+		ErrorOccurredEvent event = errorEvent("SYSTEM", "INTERNAL_SERVER_ERROR", HttpStatus.INTERNAL_SERVER_ERROR);
+		WebhookMessage message = new WebhookMessage("title", "desc", null, null, Instant.now(), null);
+		given(systemExceptionTemplate.build(event.context())).willReturn(message);
+		willThrow(new RuntimeException("전송 실패")).given(webhookClient).send(message);
+
+		assertThatCode(() -> listener.onErrorOccurred(event))
+			.doesNotThrowAnyException();
+	}
+
+	private ErrorOccurredEvent errorEvent(String errorType, String errorCode, HttpStatus httpStatus) {
+		ErrorContext context = new ErrorContext(
+			errorType, errorCode, "테스트 에러 메시지", httpStatus,
+			"GET", "/api/test", "JUnit", Instant.now(), "RuntimeException", null);
+		return new ErrorOccurredEvent(context);
+	}
+}


### PR DESCRIPTION
## 📌 PR 요약

#### Summary
- 비동기 이벤트/웹훅 관련 핵심 컴포넌트 6곳에 단위 테스트를 추가해 회귀 검증 범위를 확장했습니다.
- 이벤트 리스너/퍼블리셔/기록 서비스의 정상/실패 처리 경로를 명시적으로 검증하도록 테스트 시나리오를 보강했습니다.

### Issue
- close : #421
- related : #216

---

## ➕ 추가된 기능

1. 비동기 이벤트/웹훅 테스트 클래스 6개 신규 추가
2. mock 상호작용 검증 중심 테스트 케이스 추가

## 🛠️ 수정/변경사항

1. 프로덕션 코드 변경 없음 (테스트 코드만 추가)
2. 비동기 아키텍처 영역의 회귀 테스트 범위 확대

---

## ✅ 남은 작업

* [ ] 로컬/CI에서 전체 `./gradlew test` 검증
* [ ] flaky 가능성이 있는 비동기 테스트 안정화 점검
