### PR TITLE
🐛 fix: 하위그룹 이벤트 추가

### DIFF
--- a/app-api/src/main/java/com/tasteam/domain/chat/event/SubgroupMemberJoinedSystemMessageListener.java
+++ b/app-api/src/main/java/com/tasteam/domain/chat/event/SubgroupMemberJoinedSystemMessageListener.java
@@ -1,0 +1,74 @@
+package com.tasteam.domain.chat.event;
+
+import java.util.List;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.tasteam.domain.chat.dto.response.ChatMessageItemResponse;
+import com.tasteam.domain.chat.entity.ChatMessage;
+import com.tasteam.domain.chat.repository.ChatMessageRepository;
+import com.tasteam.domain.chat.repository.ChatRoomRepository;
+import com.tasteam.domain.chat.stream.ChatStreamPublisher;
+import com.tasteam.domain.chat.type.ChatMessageType;
+import com.tasteam.domain.member.entity.Member;
+import com.tasteam.domain.member.repository.MemberRepository;
+import com.tasteam.domain.subgroup.event.SubgroupMemberJoinedEvent;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class SubgroupMemberJoinedSystemMessageListener {
+
+	private static final String DEFAULT_SYSTEM_MESSAGE = "새 멤버가 입장했습니다.";
+
+	private final ChatRoomRepository chatRoomRepository;
+	private final ChatMessageRepository chatMessageRepository;
+	private final ChatStreamPublisher chatStreamPublisher;
+	private final MemberRepository memberRepository;
+
+	@EventListener
+	@Transactional
+	public void onSubgroupMemberJoined(SubgroupMemberJoinedEvent event) {
+		Long chatRoomId = chatRoomRepository.findBySubgroupIdAndDeletedAtIsNull(event.subgroupId())
+			.map(chatRoom -> chatRoom.getId())
+			.orElse(null);
+		if (chatRoomId == null) {
+			return;
+		}
+
+		String nickname = memberRepository.findByIdAndDeletedAtIsNull(event.memberId())
+			.map(Member::getNickname)
+			.orElse(null);
+		String content = buildMessage(nickname);
+
+		ChatMessage message = chatMessageRepository.save(ChatMessage.builder()
+			.chatRoomId(chatRoomId)
+			.memberId(null)
+			.type(ChatMessageType.SYSTEM)
+			.content(content)
+			.deletedAt(null)
+			.build());
+
+		ChatMessageItemResponse item = new ChatMessageItemResponse(
+			message.getId(),
+			null,
+			"",
+			"",
+			message.getContent(),
+			message.getType(),
+			List.of(),
+			message.getCreatedAt());
+
+		chatStreamPublisher.publish(chatRoomId, item);
+	}
+
+	private String buildMessage(String nickname) {
+		if (nickname == null || nickname.isBlank()) {
+			return DEFAULT_SYSTEM_MESSAGE;
+		}
+		return nickname + "님이 입장했습니다.";
+	}
+}

--- a/app-api/src/main/java/com/tasteam/domain/subgroup/event/SubgroupEventPublisher.java
+++ b/app-api/src/main/java/com/tasteam/domain/subgroup/event/SubgroupEventPublisher.java
@@ -1,0 +1,36 @@
+package com.tasteam.domain.subgroup.event;
+
+import java.time.Instant;
+
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+@Component
+public class SubgroupEventPublisher {
+
+	private final ApplicationEventPublisher publisher;
+
+	public SubgroupEventPublisher(ApplicationEventPublisher publisher) {
+		this.publisher = publisher;
+	}
+
+	public void publishMemberJoined(Long groupId, Long subgroupId, Long memberId, String subgroupName,
+		Instant joinedAt) {
+		publishAfterCommit(new SubgroupMemberJoinedEvent(groupId, subgroupId, memberId, subgroupName, joinedAt));
+	}
+
+	private void publishAfterCommit(Object event) {
+		if (TransactionSynchronizationManager.isActualTransactionActive()) {
+			TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+				@Override
+				public void afterCommit() {
+					publisher.publishEvent(event);
+				}
+			});
+			return;
+		}
+		publisher.publishEvent(event);
+	}
+}

--- a/app-api/src/main/java/com/tasteam/domain/subgroup/event/SubgroupMemberJoinedEvent.java
+++ b/app-api/src/main/java/com/tasteam/domain/subgroup/event/SubgroupMemberJoinedEvent.java
@@ -1,0 +1,11 @@
+package com.tasteam.domain.subgroup.event;
+
+import java.time.Instant;
+
+public record SubgroupMemberJoinedEvent(
+	Long groupId,
+	Long subgroupId,
+	Long memberId,
+	String subgroupName,
+	Instant joinedAt) {
+}

--- a/app-api/src/main/java/com/tasteam/domain/subgroup/service/SubgroupCommandService.java
+++ b/app-api/src/main/java/com/tasteam/domain/subgroup/service/SubgroupCommandService.java
@@ -27,6 +27,7 @@ import com.tasteam.domain.subgroup.dto.SubgroupJoinResponse;
 import com.tasteam.domain.subgroup.dto.SubgroupUpdateRequest;
 import com.tasteam.domain.subgroup.entity.Subgroup;
 import com.tasteam.domain.subgroup.entity.SubgroupMember;
+import com.tasteam.domain.subgroup.event.SubgroupEventPublisher;
 import com.tasteam.domain.subgroup.repository.SubgroupMemberRepository;
 import com.tasteam.domain.subgroup.repository.SubgroupRepository;
 import com.tasteam.domain.subgroup.type.SubgroupJoinType;
@@ -55,6 +56,7 @@ public class SubgroupCommandService {
 	private final FileService fileService;
 	private final ChatRoomRepository chatRoomRepository;
 	private final ChatRoomMemberRepository chatRoomMemberRepository;
+	private final SubgroupEventPublisher subgroupEventPublisher;
 
 	@Transactional
 	public SubgroupCreateResponse createSubgroup(Long groupId, Long memberId, SubgroupCreateRequest request) {
@@ -102,12 +104,19 @@ public class SubgroupCommandService {
 
 		Member member = memberRepository.findByIdAndDeletedAtIsNull(memberId)
 			.orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
-		subgroupMemberRepository.save(SubgroupMember.create(subgroup.getId(), member));
+		SubgroupMember subgroupMember = subgroupMemberRepository.save(SubgroupMember.create(subgroup.getId(), member));
 		chatRoomMemberRepository.save(ChatRoomMember.builder()
 			.chatRoomId(chatRoom.getId())
 			.memberId(memberId)
 			.deletedAt(null)
 			.build());
+
+		subgroupEventPublisher.publishMemberJoined(
+			subgroup.getGroup().getId(),
+			subgroup.getId(),
+			memberId,
+			subgroup.getName(),
+			subgroupMember.getCreatedAt());
 
 		return SubgroupCreateResponse.from(subgroup);
 	}
@@ -158,6 +167,13 @@ public class SubgroupCommandService {
 		} else if (chatRoomMember.getDeletedAt() != null) {
 			chatRoomMember.restore();
 		}
+
+		subgroupEventPublisher.publishMemberJoined(
+			groupId,
+			subgroupId,
+			memberId,
+			subgroup.getName(),
+			joinedAt);
 
 		return new SubgroupJoinResponse(
 			new SubgroupJoinResponse.JoinData(


### PR DESCRIPTION
 ## 📌 PR 요약

  #### Summary

  - 채팅 알림/푸시 로직, 하위그룹 참여 이벤트, 하위그룹 멤버 이미지 조회 방식까지 일괄 보강

  ### Issue

  - close : #

  ———

  ## ➕ 추가된 기능

  1. 하위그룹 참여 시 SubgroupMemberJoinedEvent 발행 및 채팅방 SYSTEM 메시지 자동 전송
  2. 채팅 알림 인앱 저장 + 조건부 FCM PUSH 발송(실시간 구독/최근 읽음 10초 기준) 및 Redis presence 추적

  ## 🛠️ 수정/변경사항

  1. 서브그룹 멤버 조회에서 member.profileImageUrl 제거 → DomainImage URL로 채움
  2. FCM 다건 전송 및 알림 설정 조회 로직 확장, Promotion 테스트 시간 의존성 수정

  ———

  
