### PR TITLE
🐛 fix: /admin 진입 경로 500 에러 방지

### DIFF
--- a/app-api/src/main/java/com/tasteam/domain/admin/controller/AdminSpaFallbackController.java
+++ b/app-api/src/main/java/com/tasteam/domain/admin/controller/AdminSpaFallbackController.java
@@ -6,6 +6,11 @@ import org.springframework.web.bind.annotation.GetMapping;
 @Controller
 public class AdminSpaFallbackController {
 
+	@GetMapping({"/admin", "/admin/"})
+	public String serveAdminSpa() {
+		return "forward:/admin/index.html";
+	}
+
 	@GetMapping({
 		"/admin/pages",
 		"/admin/pages/",

--- a/app-api/src/main/java/com/tasteam/global/config/WebMvcConfig.java
+++ b/app-api/src/main/java/com/tasteam/global/config/WebMvcConfig.java
@@ -2,7 +2,6 @@ package com.tasteam.global.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
-import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
@@ -19,11 +18,5 @@ public class WebMvcConfig implements WebMvcConfigurer {
 		registry.addResourceHandler("/admin/index.html")
 			.addResourceLocations("classpath:/static/admin/")
 			.setCachePeriod(0);
-	}
-
-	@Override
-	public void addViewControllers(ViewControllerRegistry registry) {
-		registry.addViewController("/admin").setViewName("forward:/admin/index.html");
-		registry.addViewController("/admin/").setViewName("forward:/admin/index.html");
 	}
 }

--- a/app-api/src/main/java/com/tasteam/global/security/common/constants/ApiEndpointSecurityPolicy.java
+++ b/app-api/src/main/java/com/tasteam/global/security/common/constants/ApiEndpointSecurityPolicy.java
@@ -87,6 +87,7 @@ public final class ApiEndpointSecurityPolicy {
 
 			// Admin Static Pages
 			permit(GET, ApiEndpoints.ADMIN_STATIC),
+			permit(GET, ApiEndpoints.ADMIN_STATIC_ROOT),
 			permit(POST, ApiEndpoints.ADMIN_AUTH_LOGIN),
 
 			// Test

--- a/app-api/src/main/java/com/tasteam/global/security/common/constants/ApiEndpoints.java
+++ b/app-api/src/main/java/com/tasteam/global/security/common/constants/ApiEndpoints.java
@@ -46,6 +46,7 @@ public final class ApiEndpoints {
 
 	// Static Admin Pages
 	public static final String ADMIN_STATIC = "/admin" + ALL;
+	public static final String ADMIN_STATIC_ROOT = "/admin";
 	public static final String ADMIN_AUTH = API_V1 + "/admin/auth";
 	public static final String ADMIN_AUTH_LOGIN = ADMIN_AUTH + "/login";
 


### PR DESCRIPTION
## 📌 PR 요약

### Summary
- `/admin` 루트 진입 시 정적 페이지 반환 경로를 컨트롤러의 `ResponseEntity<Resource>` 처리에서 포워드 라우팅으로 변경해 500 장애 가능성을 줄였습니다.
- `/admin`, `/admin/` 요청은 `forward:/admin/index.html`로 직접 처리하고 `/admin/pages/**` 폴백은 기존대로 유지했습니다.
- `/admin` 정적 루트 허용 정책을 `publicEndpoints`에 보강했습니다.
- `/admin/index.html` 정적 핸들러 등록을 유지해 직접 요청도 정적 리소스로 서빙되도록 정합성을 맞췄습니다.

### Issue
- close : 

### 추가된 변경
1. `app-api/src/main/java/com/tasteam/global/config/WebMvcConfig.java`
   - `/admin/index.html`에 대한 정적 리소스 핸들러 등록 유지.
2. `app-api/src/main/java/com/tasteam/domain/admin/controller/AdminSpaFallbackController.java`
   - `/admin`, `/admin/`를 `forward:/admin/index.html`로 전환.
3. `app-api/src/main/java/com/tasteam/global/security/common/constants/ApiEndpoints.java`
   - `ADMIN_STATIC_ROOT`(`"/admin"`) 추가.
4. `app-api/src/main/java/com/tasteam/global/security/common/constants/ApiEndpointSecurityPolicy.java`
   - `/admin` 루트 permit 정책 추가.

### 남은 작업
- [ ] 배포 후 `/admin` 및 `/admin/pages/{route}.html` 직접 접속의 200 응답/SPA 렌더 확인
- [ ] 비인증 상태에서 `/admin` 접근 시 기대 동작(로그인 화면 렌더 or 안내) 검증
- [ ] `/admin` 경로 접근 시 서버 에러/예외 모니터링 확인
