### PR TITLE
perf: http.server.requests 히스토그램 활성화

### DIFF
--- a/app-api/src/main/resources/application.yml
+++ b/app-api/src/main/resources/application.yml
@@ -251,6 +251,9 @@ tasteam:
 ## ====== 운영 & 관리 ======
 management:
   metrics:
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true
     tags:
       application: tasteam-api
       environment: ${spring.profiles.active:local}


### PR DESCRIPTION
## 📌 PR 요약

#### Summary
- `http.server.requests`에 percentile histogram 수집 설정을 추가했습니다.
- 운영 지표 분석 시 latency 분포 관측 정확도를 높이기 위한 설정 반영입니다.

### Issue
- close : #463

---

## ➕ 추가된 기능
1. `management.metrics.distribution.percentiles-histogram.http.server.requests=true` 설정 추가

## 🛠️ 수정/변경사항
1. [`app-api/src/main/resources/application.yml`](app-api/src/main/resources/application.yml)의 `management.metrics` 하위에 histogram 설정을 추가
2. 기존 메트릭 태그/엔드포인트 설정은 그대로 유지

---

## ✅ 남은 작업
* [ ] 배포 환경에서 Prometheus scrape 결과로 histogram bucket 수집 여부 확인

## 원인 및 영향
기존 설정에서는 `http.server.requests`에 대한 히스토그램이 활성화되어 있지 않아, latency 분포 기반 관측(예: 구간별 요청 시간 분석)이 제한될 수 있었습니다. 이 변경으로 Micrometer가 해당 메트릭에 대한 histogram을 생성하여 성능 분석과 SLO 관측에 필요한 시계열이 확보됩니다.

## 검증
- pre-push 훅에서 백엔드 테스트 실행 후 `BUILD SUCCESSFUL` 확인
