### PR TITLE
[fix] dev 환경 Alloy 배포 실패 수정

### DIFF
--- a/deploy/codedeploy/backend/deploy.sh
+++ b/deploy/codedeploy/backend/deploy.sh
@@ -283,9 +283,6 @@ start_alloy() {
   fi
 
   local alloy_config="${SCRIPT_DIR}/alloy/alloy-app.alloy"
-  if [ "${ENV_NAME}" = "dev" ]; then
-    alloy_config="${SCRIPT_DIR}/alloy/alloy-app-dev.alloy"
-  fi
 
   log "start alloy (config=${alloy_config})"
   ALLOY_CONFIG_FILE="${alloy_config}" \


### PR DESCRIPTION
## 📌 PR 요약

#### Summary
- dev 환경 CodeDeploy 배포 시 Alloy 컨테이너 시작 실패 수정 (d-URNE61Y7H)

### Issue
- deploy.sh에서 존재하지 않는 `alloy-app-dev.alloy` 파일을 참조하여 Docker bind mount 타입 불일치 발생

---

## 🛠️ 수정/변경사항

1. `deploy.sh`의 dev 환경 전용 Alloy 설정 분기 제거 — 모든 환경에서 `alloy-app.alloy` 사용

## ✅ 남은 작업

* [ ] develop 머지 후 dev 환경 재배포 확인