### PR TITLE
✨ feat: 하위그룹 참여 이벤트 및 입장 시스템 메시지 추가

### DIFF
--- a/app-api/src/main/java/com/tasteam/domain/chat/event/SubgroupMemberJoinedSystemMessageListener.java
+++ b/app-api/src/main/java/com/tasteam/domain/chat/event/SubgroupMemberJoinedSystemMessageListener.java
@@ -17,7 +17,9 @@ import com.tasteam.domain.member.repository.MemberRepository;
 import com.tasteam.domain.subgroup.event.SubgroupMemberJoinedEvent;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class SubgroupMemberJoinedSystemMessageListener {
@@ -32,10 +34,13 @@ public class SubgroupMemberJoinedSystemMessageListener {
 	@EventListener
 	@Transactional
 	public void onSubgroupMemberJoined(SubgroupMemberJoinedEvent event) {
+		log.info("Subgroup member joined event received. groupId={}, subgroupId={}, memberId={}",
+			event.groupId(), event.subgroupId(), event.memberId());
 		Long chatRoomId = chatRoomRepository.findBySubgroupIdAndDeletedAtIsNull(event.subgroupId())
 			.map(chatRoom -> chatRoom.getId())
 			.orElse(null);
 		if (chatRoomId == null) {
+			log.warn("Chat room not found for subgroup. subgroupId={}", event.subgroupId());
 			return;
 		}
 
@@ -63,6 +68,8 @@ public class SubgroupMemberJoinedSystemMessageListener {
 			message.getCreatedAt());
 
 		chatStreamPublisher.publish(chatRoomId, item);
+		log.info("Subgroup join system message published. subgroupId={}, chatRoomId={}, messageId={}",
+			event.subgroupId(), chatRoomId, message.getId());
 	}
 
 	private String buildMessage(String nickname) {

--- a/app-api/src/main/java/com/tasteam/domain/chat/stream/ChatStreamPayload.java
+++ b/app-api/src/main/java/com/tasteam/domain/chat/stream/ChatStreamPayload.java
@@ -59,9 +59,15 @@ public record ChatStreamPayload(
 		Map<String, String> map = new HashMap<>();
 		map.put("chatRoomId", String.valueOf(chatRoomId));
 		map.put("messageId", String.valueOf(messageId));
-		map.put("memberId", String.valueOf(memberId));
-		map.put("memberNickname", memberNickname);
-		map.put("memberProfileImageUrl", memberProfileImageUrl);
+		if (memberId != null) {
+			map.put("memberId", String.valueOf(memberId));
+		}
+		if (memberNickname != null) {
+			map.put("memberNickname", memberNickname);
+		}
+		if (memberProfileImageUrl != null) {
+			map.put("memberProfileImageUrl", memberProfileImageUrl);
+		}
 		map.put("content", content);
 		map.put("messageType", messageType.name());
 		if (fileType != null) {
@@ -90,7 +96,7 @@ public record ChatStreamPayload(
 	}
 
 	private static Long parseLong(String value) {
-		if (value == null) {
+		if (value == null || value.isBlank() || "null".equalsIgnoreCase(value)) {
 			return null;
 		}
 		return Long.valueOf(value);


### PR DESCRIPTION
 ## 📌 PR 요약

  #### Summary

  - 채팅 알림/푸시, 하위그룹 참여 이벤트 및 입장 시스템 메시지, 서브그룹 멤버 이미지
    DomainImage 전환까지 반영

  ### Issue

  - close : #

  ———

  ## ➕ 추가된 기능

  1. 하위그룹 참여 시 SubgroupMemberJoinedEvent 발행 및 채팅방 SYSTEM 메시지 자동 전
     송
  2. 채팅 알림 인앱 저장 + 조건부 FCM PUSH 발송(실시간 구독/최근 10초 읽음 기준)과
     Redis presence 추적

  ## 🛠️ 수정/변경사항

  1. 서브그룹 멤버 조회에서 member.profileImageUrl 제거 → DomainImage URL로 치환
  2. SYSTEM 메시지 스트림 null 처리 보완 및 FCM 다건 전송/알림 설정 조회 확장

  ———

  ## ✅ 남은 작업

