### PR TITLE
fix: 어드민 프로모션 이미지 업로드 저장 실패 수정

### DIFF
--- a/app-api/src/main/resources/static/admin/js/api.js
+++ b/app-api/src/main/resources/static/admin/js/api.js
@@ -144,13 +144,46 @@ async function createMenu(restaurantId, data) {
 }
 
 async function createPresignedUploads(purpose, files) {
+    const allowedContentTypes = new Set(['image/jpeg', 'image/jpg', 'image/png', 'image/webp']);
+
+    const getAllowedContentTypeFromFileName = (fileName) => {
+        const normalizedName = (fileName || '').trim().toLowerCase();
+        const lastDot = normalizedName.lastIndexOf('.');
+        const extension = lastDot >= 0 ? normalizedName.substring(lastDot + 1) : '';
+
+        const extensionMap = {
+            jpg: 'image/jpeg',
+            jpeg: 'image/jpeg',
+            png: 'image/png',
+            webp: 'image/webp'
+        };
+
+        return extensionMap[extension];
+    };
+
+    const getFileContentType = (file) => {
+        const explicitType = (file.type || '').trim().toLowerCase();
+        if (explicitType && explicitType !== 'application/octet-stream') {
+            return explicitType;
+        }
+
+        return getAllowedContentTypeFromFileName(file.name);
+    };
+
+    const filesWithType = files.map(file => ({
+        fileName: file.name,
+        contentType: getFileContentType(file),
+        size: file.size
+    }));
+
+    const invalidType = filesWithType.find((item) => !item.contentType || !allowedContentTypes.has(item.contentType));
+    if (invalidType) {
+        throw new Error('지원하지 않는 이미지 파일 형식입니다.');
+    }
+
     const request = {
         purpose,
-        files: files.map(file => ({
-            fileName: file.name,
-            contentType: file.type || 'application/octet-stream',
-            size: file.size
-        }))
+        files: filesWithType
     };
 
     return apiRequest('/files/uploads/presigned', {


### PR DESCRIPTION
## 📌 PR 요약

#### Summary
- 어드민 프로모션 이미지 업로드 시 MIME 타입이 `application/octet-stream`으로 전달되어 저장이 실패하던 문제를 수정했습니다.
- 파일 확장자 기반으로 허용 MIME 타입을 보정하고, 허용되지 않는 형식은 업로드 요청 전 차단하도록 보강했습니다.

### Issue
- close : #468

---

## ➕ 추가된 기능

1. 프론트 업로드 요청 전 MIME 타입 정규화 로직 추가
2. 허용되지 않은 이미지 타입 사전 검증 및 사용자 에러 메시지 처리

## 🛠️ 수정/변경사항

1. `createPresignedUploads`에서 `file.type`이 비어있거나 `application/octet-stream`인 경우 확장자(`jpg`, `jpeg`, `png`, `webp`) 기반으로 `contentType` 보정
2. 서버 허용 타입 집합(`image/jpeg`, `image/jpg`, `image/png`, `image/webp`) 검증 후 presigned 요청 전 실패 처리

---

## ✅ 남은 작업

* [ ] 스테이징 환경에서 관리자 화면 실사용 업로드/저장 동작 확인
