### PR TITLE
fix: access token 검증 실패 응답 일관화

### DIFF
--- a/app-api/src/main/java/com/tasteam/global/security/jwt/filter/JwtAuthenticationFilter.java
+++ b/app-api/src/main/java/com/tasteam/global/security/jwt/filter/JwtAuthenticationFilter.java
@@ -10,10 +10,13 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+import com.tasteam.global.exception.code.AuthErrorCode;
 import com.tasteam.global.security.common.constants.SecurityConstants;
+import com.tasteam.global.security.exception.model.CustomAuthenticationException;
 import com.tasteam.global.security.jwt.provider.JwtTokenProvider;
 import com.tasteam.global.security.user.dto.CustomUserDetails;
 
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -52,10 +55,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 				SecurityContextHolder.getContext().setAuthentication(authentication);
 			}
+		} catch (ExpiredJwtException e) {
+			log.debug("만료된 JWT 토큰: {}", e.getMessage());
+			throw new CustomAuthenticationException(AuthErrorCode.AUTHENTICATION_REQUIRED, "토큰이 만료되었습니다.");
 		} catch (JwtException e) {
-			log.error("JWT 검증 실패: {}", e.getMessage());
+			log.debug("유효하지 않은 JWT 토큰: {}", e.getMessage());
+			throw new CustomAuthenticationException(AuthErrorCode.AUTHENTICATION_REQUIRED, "유효하지 않은 토큰입니다.");
 		} catch (Exception e) {
 			log.error("JWT 인증 처리 중 오류: {}", e.getMessage());
+			throw new CustomAuthenticationException(AuthErrorCode.AUTHENTICATION_REQUIRED, "인증 처리 중 오류가 발생했습니다.");
 		}
 
 		filterChain.doFilter(request, response);


### PR DESCRIPTION
## 📌 PR 요약

#### Summary
- JWT access token 검증 실패 시 필터 예외를 인증 예외로 일관되게 변환하도록 수정했습니다.
- 만료/유효하지 않음/기타 처리 오류를 구분해 클라이언트 대응 가능성을 높였습니다.

### Issue
- close : #473

---

## ➕ 추가된 기능

1. access token 만료 시 인증 예외(`AUTHENTICATION_REQUIRED`) 변환
2. 유효하지 않은 token 및 처리 오류 시 인증 예외 일관 변환

## 🛠️ 수정/변경사항

1. `JwtAuthenticationFilter`에 `ExpiredJwtException` 분기 추가
2. `JwtException`, `Exception` 분기에서 `CustomAuthenticationException`으로 변환하도록 변경
3. JWT 검증 실패 로그 레벨을 `debug` 중심으로 정리

---

## ✅ 남은 작업

* [ ] 클라이언트 측 토큰 만료/무효 토큰 에러 처리 메시지 매핑 확인
