### PR TITLE
feat: 더미 데이터 시드 대용량 상한 및 스트리밍 삽입

### DIFF
--- a/app-api/src/main/java/com/tasteam/batch/dummy/service/DummyDataSeedService.java
+++ b/app-api/src/main/java/com/tasteam/batch/dummy/service/DummyDataSeedService.java
@@ -1,13 +1,11 @@
 package com.tasteam.batch.dummy.service;
 
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import java.util.Set;
 import java.util.UUID;
 import java.util.function.Supplier;
 
@@ -39,20 +37,23 @@ public class DummyDataSeedService {
 	private static final int DEFAULT_MEMBER_PER_GROUP = 30;
 	private static final int DEFAULT_REVIEW_COUNT = 1000;
 	private static final int DEFAULT_CHAT_MESSAGE_PER_ROOM = 50;
-	private static final int MAX_MEMBER_COUNT = 2000;
-	private static final int MAX_RESTAURANT_COUNT = 2000;
-	private static final int MAX_GROUP_COUNT = 200;
-	private static final int MAX_SUBGROUP_PER_GROUP = 50;
-	private static final int MAX_MEMBER_PER_GROUP = 500;
-	private static final int MAX_REVIEW_COUNT = 10000;
-	private static final int MAX_CHAT_MESSAGE_PER_ROOM = 200;
+	private static final int MAX_MEMBER_COUNT = 100_000;
+	private static final int MAX_RESTAURANT_COUNT = 50_000_000;
+	private static final int MAX_GROUP_COUNT = 1_000;
+	private static final int MAX_SUBGROUP_PER_GROUP = 1_000;
+	private static final int MAX_MEMBER_PER_GROUP = 1_000;
+	private static final int MAX_REVIEW_COUNT = 100_000_000;
+	private static final int MAX_CHAT_MESSAGE_PER_ROOM = 1_000_000_000;
+	private static final int SERVICE_CHUNK_SIZE = 5_000;
+	private static final int RELATION_FLUSH_SIZE = 5_000;
+	private static final int MAX_KEYWORDS_PER_REVIEW = 3;
 	private static final long SLOW_STEP_THRESHOLD_MS = 2_000L;
 
 	private final DummyDataJdbcRepository dummyRepo;
 
-	@Transactional
 	public AdminDummySeedResponse seed(AdminDummySeedRequest req) {
 		long start = System.currentTimeMillis();
+		String runToken = UUID.randomUUID().toString();
 
 		int memberCount = normalizeCount("memberCount", req.memberCount(), DEFAULT_MEMBER_COUNT, MAX_MEMBER_COUNT);
 		int restaurantCount = normalizeCount("restaurantCount", req.restaurantCount(), DEFAULT_RESTAURANT_COUNT,
@@ -66,206 +67,17 @@ public class DummyDataSeedService {
 		int chatMessagePerRoom = normalizeCount("chatMessagePerRoom", req.chatMessagePerRoom(),
 			DEFAULT_CHAT_MESSAGE_PER_ROOM, MAX_CHAT_MESSAGE_PER_ROOM);
 
-		// ── Step 1: Member 삽입 ──────────────────────────────────────────────
-		List<String> emails = new ArrayList<>(memberCount);
-		List<String> nicknames = new ArrayList<>(memberCount);
-		for (int i = 0; i < memberCount; i++) {
-			emails.add(UUID.randomUUID() + DUMMY_EMAIL_SUFFIX);
-			nicknames.add("더미유저" + (i + 1));
-		}
-		List<Long> memberIds = executeStep("member insert", () -> dummyRepo.insertMembers(emails, nicknames));
-		validateStepResult("member insert", memberIds, memberCount);
+		LongIdBuffer memberIds = executeStep("member insert", () -> insertMembers(memberCount, runToken));
+		LongIdBuffer restaurantIds = executeStep("restaurant insert",
+			() -> insertRestaurants(restaurantCount, runToken));
+		LongIdBuffer groupIds = executeStep("group insert", () -> insertGroups(groupCount, runToken));
 
-		// ── Step 2: Restaurant 삽입 ──────────────────────────────────────────
-		List<String> restaurantNames = new ArrayList<>(restaurantCount);
-		List<String> restaurantAddresses = new ArrayList<>(restaurantCount);
-		for (int i = 0; i < restaurantCount; i++) {
-			restaurantNames.add("더미식당-" + (i + 1));
-			restaurantAddresses.add("서울시 강남구 더미로 " + (i + 1) + "번길 1");
-		}
-		List<Long> restaurantIds = executeStep("restaurant insert",
-			() -> dummyRepo.insertRestaurants(restaurantNames, restaurantAddresses));
-		validateStepResult("restaurant insert", restaurantIds, restaurantCount);
+		GroupSeedResult groupSeedResult = executeStep(
+			"group_member/subgroup/chat relation insert",
+			() -> insertGroupRelatedData(groupIds, memberIds, subgroupPerGroup, memberPerGroup, chatMessagePerRoom));
 
-		// ── Step 3: Group 삽입 ───────────────────────────────────────────────
-		List<String> groupNames = new ArrayList<>(groupCount);
-		List<String> groupAddresses = new ArrayList<>(groupCount);
-		for (int i = 0; i < groupCount; i++) {
-			groupNames.add("더미그룹-" + (i + 1));
-			groupAddresses.add("서울시 강남구 테스트로 " + (i + 1));
-		}
-		List<Long> groupIds = executeStep("group insert", () -> dummyRepo.insertGroups(groupNames, groupAddresses));
-		validateStepResult("group insert", groupIds, groupCount);
-
-		// ── Step 4: GroupMember 삽입 ─────────────────────────────────────────
-		Map<Long, List<Long>> groupToMembers = new HashMap<>();
-		List<long[]> groupMemberPairs = new ArrayList<>();
-
-		for (Long groupId : groupIds) {
-			List<Long> shuffled = new ArrayList<>(memberIds);
-			Collections.shuffle(shuffled, RANDOM);
-			int count = Math.min(memberPerGroup, shuffled.size());
-			List<Long> selected = new ArrayList<>(shuffled.subList(0, count));
-			groupToMembers.put(groupId, selected);
-
-			Set<String> seen = new HashSet<>();
-			for (Long memberId : selected) {
-				if (seen.add(groupId + ":" + memberId)) {
-					groupMemberPairs.add(new long[] {groupId, memberId});
-				}
-			}
-		}
-		executeStep("group_member insert", () -> {
-			dummyRepo.insertGroupMembers(groupMemberPairs);
-			return null;
-		});
-
-		// ── Step 5: Subgroup 삽입 ────────────────────────────────────────────
-		List<Long> subgroupGroupIds = new ArrayList<>();
-		List<String> subgroupNames = new ArrayList<>();
-		for (int g = 0; g < groupIds.size(); g++) {
-			for (int s = 0; s < subgroupPerGroup; s++) {
-				subgroupGroupIds.add(groupIds.get(g));
-				subgroupNames.add("더미팀-" + (g + 1) + "-" + (s + 1));
-			}
-		}
-		List<Long> subgroupIds = executeStep("subgroup insert",
-			() -> dummyRepo.insertSubgroups(subgroupGroupIds, subgroupNames));
-		validateStepResult("subgroup insert", subgroupIds, subgroupGroupIds.size());
-
-		// subgroupId → groupId 역방향 맵
-		Map<Long, Long> subgroupToGroup = new HashMap<>();
-		for (int i = 0; i < subgroupIds.size(); i++) {
-			subgroupToGroup.put(subgroupIds.get(i), subgroupGroupIds.get(i));
-		}
-
-		Map<Long, Long> subgroupToChatRoom = new HashMap<>();
-		// ── Step 6: ChatRoom 삽입 (subgroup 1:1) ────────────────────────────
-		List<Long> chatRoomIds = executeStep("chat_room insert", () -> dummyRepo.insertChatRooms(subgroupIds));
-		validateStepResult("chat_room insert", chatRoomIds, subgroupIds.size());
-		for (int i = 0; i < subgroupIds.size(); i++) {
-			if (chatRoomIds.get(i) == null) {
-				throw new BusinessException(CommonErrorCode.INVALID_DOMAIN_STATE);
-			}
-			subgroupToChatRoom.put(subgroupIds.get(i), chatRoomIds.get(i));
-		}
-
-		// ── Step 7: SubgroupMember + ChatRoomMember 삽입 ────────────────────
-		Map<Long, List<Long>> subgroupToMembers = new HashMap<>();
-		List<long[]> subgroupMemberPairs = new ArrayList<>();
-		List<long[]> chatRoomMemberPairs = new ArrayList<>();
-		Map<Long, Integer> subgroupMemberCounts = new HashMap<>();
-
-		for (Long subgroupId : subgroupIds) {
-			Long groupId = subgroupToGroup.get(subgroupId);
-			List<Long> groupMembers = groupToMembers.get(groupId);
-			if (groupMembers == null || groupMembers.isEmpty()) {
-				continue;
-			}
-
-			List<Long> shuffled = new ArrayList<>(groupMembers);
-			Collections.shuffle(shuffled, RANDOM);
-			int count = Math.min(memberPerGroup, shuffled.size());
-			List<Long> selected = new ArrayList<>(shuffled.subList(0, count));
-
-			subgroupToMembers.put(subgroupId, selected);
-			subgroupMemberCounts.put(subgroupId, selected.size());
-
-			Long chatRoomId = subgroupToChatRoom.get(subgroupId);
-			if (chatRoomId == null) {
-				throw new BusinessException(CommonErrorCode.INVALID_DOMAIN_STATE);
-			}
-			Set<String> sgSeen = new HashSet<>();
-			Set<String> crSeen = new HashSet<>();
-
-			for (Long memberId : selected) {
-				if (sgSeen.add(subgroupId + ":" + memberId)) {
-					subgroupMemberPairs.add(new long[] {subgroupId, memberId});
-				}
-				if (crSeen.add(chatRoomId + ":" + memberId)) {
-					chatRoomMemberPairs.add(new long[] {chatRoomId, memberId});
-				}
-			}
-		}
-		executeStep("subgroup_member insert", () -> {
-			dummyRepo.insertSubgroupMembers(subgroupMemberPairs);
-			return null;
-		});
-		if (!subgroupMemberCounts.isEmpty()) {
-			executeStep("subgroup member count update", () -> {
-				dummyRepo.updateSubgroupMemberCounts(subgroupMemberCounts);
-				return null;
-			});
-		}
-		executeStep("chat_room_member insert", () -> {
-			dummyRepo.insertChatRoomMembers(chatRoomMemberPairs);
-			return null;
-		});
-
-		// ── Step 8: Review 삽입 ──────────────────────────────────────────────
-		int actualMemberCount = Math.max(1, memberIds.size());
-		int actualRestaurantCount = Math.max(1, restaurantIds.size());
-		int actualGroupCount = Math.max(1, groupIds.size());
-
-		List<long[]> reviewEntries = new ArrayList<>(reviewCount);
-		List<String> reviewContents = new ArrayList<>(reviewCount);
-		for (int r = 0; r < reviewCount; r++) {
-			Long memberId = memberIds.get(r % actualMemberCount);
-			Long restaurantId = restaurantIds.get(r % actualRestaurantCount);
-			Long groupId = groupIds.get(r % actualGroupCount);
-			int recommended = RANDOM.nextBoolean() ? 1 : 0;
-			reviewEntries.add(new long[] {memberId, restaurantId, groupId, recommended});
-			reviewContents.add("더미 리뷰 내용입니다. " + (r + 1));
-		}
-		List<Long> reviewIds = executeStep("review insert",
-			() -> dummyRepo.insertReviews(reviewEntries, reviewContents));
-		validateStepResult("review insert", reviewIds, reviewCount);
-
-		// ── Step 9: ReviewKeyword 삽입 ───────────────────────────────────────
-		List<Long> keywordIds = dummyRepo.queryKeywordIds();
-		if (!keywordIds.isEmpty() && !reviewIds.isEmpty()) {
-			List<long[]> reviewKeywordPairs = new ArrayList<>();
-			Set<String> rkSeen = new HashSet<>();
-			for (Long reviewId : reviewIds) {
-				int numKeywords = 1 + RANDOM.nextInt(3);
-				List<Long> shuffledKw = new ArrayList<>(keywordIds);
-				Collections.shuffle(shuffledKw, RANDOM);
-				for (int k = 0; k < Math.min(numKeywords, shuffledKw.size()); k++) {
-					String key = reviewId + ":" + shuffledKw.get(k);
-					if (rkSeen.add(key)) {
-						reviewKeywordPairs.add(new long[] {reviewId, shuffledKw.get(k)});
-					}
-				}
-			}
-			executeStep("review_keyword insert", () -> {
-				dummyRepo.insertReviewKeywords(reviewKeywordPairs);
-				return null;
-			});
-		}
-
-		// ── Step 10: ChatMessage 삽입 ────────────────────────────────────────
-		List<long[]> chatMessageEntries = new ArrayList<>();
-		List<String> chatMessageContents = new ArrayList<>();
-		int msgCounter = 0;
-		for (Long subgroupId : subgroupIds) {
-			Long chatRoomId = subgroupToChatRoom.get(subgroupId);
-			List<Long> members = subgroupToMembers.get(subgroupId);
-			if (members == null || members.isEmpty()) {
-				continue;
-			}
-			for (int m = 0; m < chatMessagePerRoom; m++) {
-				Long memberId = members.get(m % members.size());
-				chatMessageEntries.add(new long[] {chatRoomId, memberId});
-				chatMessageContents.add("더미 채팅 메시지 " + (++msgCounter));
-			}
-		}
-		int chatMessagesInserted = executeStep("chat_message insert",
-			() -> dummyRepo.insertChatMessages(chatMessageEntries, chatMessageContents));
-		if (chatMessageEntries.size() != chatMessagesInserted) {
-			log.warn("[DummySeed] chat_message insert count mismatch. expected={} actual={}",
-				chatMessageEntries.size(),
-				chatMessagesInserted);
-		}
+		int reviewsInserted = executeStep("review/review_keyword insert",
+			() -> insertReviewsWithKeywords(reviewCount, memberIds, restaurantIds, groupIds));
 
 		long elapsed = System.currentTimeMillis() - start;
 		log.info("[DummySeed] completed in {}ms", elapsed);
@@ -273,9 +85,9 @@ public class DummyDataSeedService {
 			memberIds.size(),
 			restaurantIds.size(),
 			groupIds.size(),
-			subgroupIds.size(),
-			reviewIds.size(),
-			chatMessagesInserted,
+			groupSeedResult.subgroupsInserted(),
+			reviewsInserted,
+			groupSeedResult.chatMessagesInserted(),
 			elapsed);
 	}
 
@@ -295,6 +107,296 @@ public class DummyDataSeedService {
 		dummyRepo.deleteDummyData();
 	}
 
+	private LongIdBuffer insertMembers(int memberCount, String runToken) {
+		LongIdBuffer ids = new LongIdBuffer(initialCapacity(memberCount));
+		for (int start = 0; start < memberCount; start += SERVICE_CHUNK_SIZE) {
+			int end = Math.min(start + SERVICE_CHUNK_SIZE, memberCount);
+			int size = end - start;
+			List<String> emails = new ArrayList<>(size);
+			List<String> nicknames = new ArrayList<>(size);
+
+			for (int i = 0; i < size; i++) {
+				int seq = start + i + 1;
+				emails.add("dummy-" + runToken + "-" + seq + DUMMY_EMAIL_SUFFIX);
+				nicknames.add("더미유저-" + runToken + "-" + seq);
+			}
+			List<Long> chunkIds = dummyRepo.insertMembers(emails, nicknames);
+			validateStepResult("member insert", chunkIds, size);
+			ids.addAll(chunkIds);
+		}
+		validateInsertedCount("member insert", ids.size(), memberCount);
+		return ids;
+	}
+
+	private LongIdBuffer insertRestaurants(int restaurantCount, String runToken) {
+		LongIdBuffer ids = new LongIdBuffer(initialCapacity(restaurantCount));
+		for (int start = 0; start < restaurantCount; start += SERVICE_CHUNK_SIZE) {
+			int end = Math.min(start + SERVICE_CHUNK_SIZE, restaurantCount);
+			int size = end - start;
+			List<String> restaurantNames = new ArrayList<>(size);
+			List<String> restaurantAddresses = new ArrayList<>(size);
+
+			for (int i = 0; i < size; i++) {
+				int seq = start + i + 1;
+				restaurantNames.add("더미식당-" + runToken + "-" + seq);
+				restaurantAddresses.add("서울시 강남구 더미로 " + seq + "번길 1");
+			}
+			List<Long> chunkIds = dummyRepo.insertRestaurants(restaurantNames, restaurantAddresses);
+			validateStepResult("restaurant insert", chunkIds, size);
+			ids.addAll(chunkIds);
+		}
+		validateInsertedCount("restaurant insert", ids.size(), restaurantCount);
+		return ids;
+	}
+
+	private LongIdBuffer insertGroups(int groupCount, String runToken) {
+		LongIdBuffer ids = new LongIdBuffer(initialCapacity(groupCount));
+		for (int start = 0; start < groupCount; start += SERVICE_CHUNK_SIZE) {
+			int end = Math.min(start + SERVICE_CHUNK_SIZE, groupCount);
+			int size = end - start;
+			List<String> groupNames = new ArrayList<>(size);
+			List<String> groupAddresses = new ArrayList<>(size);
+
+			for (int i = 0; i < size; i++) {
+				int seq = start + i + 1;
+				groupNames.add("더미그룹-" + runToken + "-" + seq);
+				groupAddresses.add("서울시 강남구 테스트로 " + seq);
+			}
+			List<Long> chunkIds = dummyRepo.insertGroups(groupNames, groupAddresses);
+			validateStepResult("group insert", chunkIds, size);
+			ids.addAll(chunkIds);
+		}
+		validateInsertedCount("group insert", ids.size(), groupCount);
+		return ids;
+	}
+
+	private GroupSeedResult insertGroupRelatedData(
+		LongIdBuffer groupIds,
+		LongIdBuffer memberIds,
+		int subgroupPerGroup,
+		int memberPerGroup,
+		int chatMessagePerRoom) {
+
+		long subgroupsInserted = 0L;
+		long chatMessagesInserted = 0L;
+		long messageSerial = 0L;
+
+		List<long[]> groupMemberPairs = new ArrayList<>(RELATION_FLUSH_SIZE);
+		List<long[]> subgroupMemberPairs = new ArrayList<>(RELATION_FLUSH_SIZE);
+		List<long[]> chatRoomMemberPairs = new ArrayList<>(RELATION_FLUSH_SIZE);
+		Map<Long, Integer> subgroupMemberCounts = new HashMap<>(RELATION_FLUSH_SIZE);
+		List<long[]> chatMessageEntries = new ArrayList<>(RELATION_FLUSH_SIZE);
+		List<String> chatMessageContents = new ArrayList<>(RELATION_FLUSH_SIZE);
+
+		for (int groupIndex = 0; groupIndex < groupIds.size(); groupIndex++) {
+			long groupId = groupIds.get(groupIndex);
+			long[] selectedGroupMembers = selectCyclicMembers(memberIds, memberPerGroup, groupIndex + 1);
+
+			appendGroupMemberPairs(groupId, selectedGroupMembers, groupMemberPairs);
+			if (groupMemberPairs.size() >= RELATION_FLUSH_SIZE) {
+				flushGroupMemberPairs(groupMemberPairs);
+			}
+
+			List<Long> subgroupGroupIds = new ArrayList<>(subgroupPerGroup);
+			List<String> subgroupNames = new ArrayList<>(subgroupPerGroup);
+			for (int s = 0; s < subgroupPerGroup; s++) {
+				subgroupGroupIds.add(groupId);
+				subgroupNames.add("더미팀-" + (groupIndex + 1) + "-" + (s + 1));
+			}
+
+			List<Long> subgroupIds = dummyRepo.insertSubgroups(subgroupGroupIds, subgroupNames);
+			validateStepResult("subgroup insert", subgroupIds, subgroupPerGroup);
+			subgroupsInserted += subgroupIds.size();
+
+			List<Long> chatRoomIds = dummyRepo.insertChatRooms(subgroupIds);
+			validateStepResult("chat_room insert", chatRoomIds, subgroupIds.size());
+
+			for (int s = 0; s < subgroupIds.size(); s++) {
+				Long subgroupId = subgroupIds.get(s);
+				Long chatRoomId = chatRoomIds.get(s);
+				if (chatRoomId == null) {
+					throw new BusinessException(CommonErrorCode.INVALID_DOMAIN_STATE);
+				}
+
+				int subgroupMemberCount = selectedGroupMembers.length;
+				subgroupMemberCounts.put(subgroupId, subgroupMemberCount);
+				int memberOffset = subgroupMemberCount == 0
+					? 0
+					: Math.floorMod((groupIndex + 1) * 31 + (s + 1) * 17, subgroupMemberCount);
+
+				appendSubgroupAndChatRoomMembers(
+					subgroupId,
+					chatRoomId,
+					selectedGroupMembers,
+					memberOffset,
+					subgroupMemberPairs,
+					chatRoomMemberPairs);
+
+				for (int m = 0; m < chatMessagePerRoom; m++) {
+					if (subgroupMemberCount == 0) {
+						break;
+					}
+					long memberId = selectedGroupMembers[(memberOffset + (m % subgroupMemberCount)) % subgroupMemberCount];
+					chatMessageEntries.add(new long[] {chatRoomId, memberId});
+					chatMessageContents.add("더미 채팅 메시지 " + (++messageSerial));
+					if (chatMessageEntries.size() >= RELATION_FLUSH_SIZE) {
+						chatMessagesInserted += flushChatMessages(chatMessageEntries, chatMessageContents);
+					}
+				}
+
+				if (subgroupMemberPairs.size() >= RELATION_FLUSH_SIZE) {
+					flushSubgroupMemberPairs(subgroupMemberPairs);
+				}
+				if (chatRoomMemberPairs.size() >= RELATION_FLUSH_SIZE) {
+					flushChatRoomMemberPairs(chatRoomMemberPairs);
+				}
+				if (subgroupMemberCounts.size() >= RELATION_FLUSH_SIZE) {
+					flushSubgroupMemberCounts(subgroupMemberCounts);
+				}
+			}
+		}
+
+		flushGroupMemberPairs(groupMemberPairs);
+		flushSubgroupMemberPairs(subgroupMemberPairs);
+		flushChatRoomMemberPairs(chatRoomMemberPairs);
+		flushSubgroupMemberCounts(subgroupMemberCounts);
+		chatMessagesInserted += flushChatMessages(chatMessageEntries, chatMessageContents);
+
+		return new GroupSeedResult(subgroupsInserted, chatMessagesInserted);
+	}
+
+	private int insertReviewsWithKeywords(
+		int reviewCount,
+		LongIdBuffer memberIds,
+		LongIdBuffer restaurantIds,
+		LongIdBuffer groupIds) {
+
+		List<Long> keywordIds = dummyRepo.queryKeywordIds();
+		int reviewsInserted = 0;
+
+		for (int start = 0; start < reviewCount; start += SERVICE_CHUNK_SIZE) {
+			int end = Math.min(start + SERVICE_CHUNK_SIZE, reviewCount);
+			int size = end - start;
+			List<long[]> reviewEntries = new ArrayList<>(size);
+			List<String> reviewContents = new ArrayList<>(size);
+
+			for (int i = 0; i < size; i++) {
+				int seq = start + i;
+				long memberId = memberIds.get(seq % memberIds.size());
+				long restaurantId = restaurantIds.get(seq % restaurantIds.size());
+				long groupId = groupIds.get(seq % groupIds.size());
+				int recommended = RANDOM.nextBoolean() ? 1 : 0;
+				reviewEntries.add(new long[] {memberId, restaurantId, groupId, recommended});
+				reviewContents.add("더미 리뷰 내용입니다. " + (seq + 1));
+			}
+
+			List<Long> reviewIds = dummyRepo.insertReviews(reviewEntries, reviewContents);
+			validateStepResult("review insert", reviewIds, size);
+			reviewsInserted += reviewIds.size();
+
+			if (!keywordIds.isEmpty()) {
+				List<long[]> reviewKeywordPairs = new ArrayList<>(reviewIds.size() * 2);
+				int keywordSize = keywordIds.size();
+				int maxPerReview = Math.min(MAX_KEYWORDS_PER_REVIEW, keywordSize);
+
+				for (Long reviewId : reviewIds) {
+					int keywordCount = 1 + RANDOM.nextInt(maxPerReview);
+					int keywordStartIndex = Math.floorMod((int)(reviewId % keywordSize), keywordSize);
+					for (int k = 0; k < keywordCount; k++) {
+						long keywordId = keywordIds.get((keywordStartIndex + k) % keywordSize);
+						reviewKeywordPairs.add(new long[] {reviewId, keywordId});
+					}
+				}
+
+				if (!reviewKeywordPairs.isEmpty()) {
+					dummyRepo.insertReviewKeywords(reviewKeywordPairs);
+				}
+			}
+		}
+
+		validateInsertedCount("review insert", reviewsInserted, reviewCount);
+		return reviewsInserted;
+	}
+
+	private long[] selectCyclicMembers(LongIdBuffer pool, int requestedCount, int seed) {
+		int poolSize = pool.size();
+		int count = Math.min(requestedCount, poolSize);
+		long[] selected = new long[count];
+		if (count == 0) {
+			return selected;
+		}
+
+		int start = Math.floorMod(seed * 37, poolSize);
+		for (int i = 0; i < count; i++) {
+			selected[i] = pool.get((start + i) % poolSize);
+		}
+		return selected;
+	}
+
+	private void appendGroupMemberPairs(long groupId, long[] members, List<long[]> pairs) {
+		for (long memberId : members) {
+			pairs.add(new long[] {groupId, memberId});
+		}
+	}
+
+	private void appendSubgroupAndChatRoomMembers(
+		long subgroupId,
+		long chatRoomId,
+		long[] members,
+		int offset,
+		List<long[]> subgroupMemberPairs,
+		List<long[]> chatRoomMemberPairs) {
+
+		int count = members.length;
+		for (int i = 0; i < count; i++) {
+			long memberId = members[(offset + i) % count];
+			subgroupMemberPairs.add(new long[] {subgroupId, memberId});
+			chatRoomMemberPairs.add(new long[] {chatRoomId, memberId});
+		}
+	}
+
+	private void flushGroupMemberPairs(List<long[]> pairs) {
+		if (pairs.isEmpty()) {
+			return;
+		}
+		dummyRepo.insertGroupMembers(pairs);
+		pairs.clear();
+	}
+
+	private void flushSubgroupMemberPairs(List<long[]> pairs) {
+		if (pairs.isEmpty()) {
+			return;
+		}
+		dummyRepo.insertSubgroupMembers(pairs);
+		pairs.clear();
+	}
+
+	private void flushChatRoomMemberPairs(List<long[]> pairs) {
+		if (pairs.isEmpty()) {
+			return;
+		}
+		dummyRepo.insertChatRoomMembers(pairs);
+		pairs.clear();
+	}
+
+	private void flushSubgroupMemberCounts(Map<Long, Integer> counts) {
+		if (counts.isEmpty()) {
+			return;
+		}
+		dummyRepo.updateSubgroupMemberCounts(counts);
+		counts.clear();
+	}
+
+	private int flushChatMessages(List<long[]> entries, List<String> contents) {
+		if (entries.isEmpty()) {
+			return 0;
+		}
+		int inserted = dummyRepo.insertChatMessages(entries, contents);
+		entries.clear();
+		contents.clear();
+		return inserted;
+	}
+
 	private int normalizeCount(String fieldName, int value, int defaultValue, int maxValue) {
 		if (value <= 0) {
 			return defaultValue;
@@ -304,6 +406,17 @@ public class DummyDataSeedService {
 			throw new BusinessException(CommonErrorCode.INVALID_REQUEST);
 		}
 		return value;
+	}
+
+	private int initialCapacity(int expectedCount) {
+		return Math.min(expectedCount, SERVICE_CHUNK_SIZE);
+	}
+
+	private void validateInsertedCount(String stepName, int actual, int expected) {
+		if (actual != expected) {
+			log.error("[DummySeed] {} expected {} but got {}", stepName, expected, actual);
+			throw new BusinessException(CommonErrorCode.INVALID_DOMAIN_STATE);
+		}
 	}
 
 	private void validateStepResult(String stepName, List<?> values, int expectedSize) {
@@ -333,6 +446,48 @@ public class DummyDataSeedService {
 		} catch (Exception e) {
 			log.error("[DummySeed] {} failed", stepName, e);
 			throw e;
+		}
+	}
+
+	private record GroupSeedResult(long subgroupsInserted, long chatMessagesInserted) {
+	}
+
+	private static final class LongIdBuffer {
+
+		private long[] values;
+		private int size;
+
+		private LongIdBuffer(int initialCapacity) {
+			this.values = new long[Math.max(16, initialCapacity)];
+		}
+
+		private void addAll(List<Long> ids) {
+			ensureCapacity(size + ids.size());
+			for (Long id : ids) {
+				values[size++] = id;
+			}
+		}
+
+		private int size() {
+			return size;
+		}
+
+		private long get(int index) {
+			if (index < 0 || index >= size) {
+				throw new IndexOutOfBoundsException("index=" + index + ", size=" + size);
+			}
+			return values[index];
+		}
+
+		private void ensureCapacity(int required) {
+			if (required <= values.length) {
+				return;
+			}
+			int newCapacity = values.length;
+			while (newCapacity < required) {
+				newCapacity = newCapacity << 1;
+			}
+			values = Arrays.copyOf(values, newCapacity);
 		}
 	}
 }

--- a/app-api/src/main/java/com/tasteam/domain/admin/dto/request/AdminDummySeedRequest.java
+++ b/app-api/src/main/java/com/tasteam/domain/admin/dto/request/AdminDummySeedRequest.java
@@ -4,18 +4,18 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 
 public record AdminDummySeedRequest(
-	@Min(value = 0) @Max(value = 2000)
+	@Min(value = 0) @Max(value = 100000)
 	int memberCount,
-	@Min(value = 0) @Max(value = 2000)
+	@Min(value = 0) @Max(value = 50000000)
 	int restaurantCount,
-	@Min(value = 0) @Max(value = 200)
+	@Min(value = 0) @Max(value = 1000)
 	int groupCount,
-	@Min(value = 0) @Max(value = 50)
+	@Min(value = 0) @Max(value = 1000)
 	int subgroupPerGroup,
-	@Min(value = 0) @Max(value = 500)
+	@Min(value = 0) @Max(value = 1000)
 	int memberPerGroup,
-	@Min(value = 0) @Max(value = 10000)
+	@Min(value = 0) @Max(value = 100000000)
 	int reviewCount,
-	@Min(value = 0) @Max(value = 200)
+	@Min(value = 0) @Max(value = 1000000000)
 	int chatMessagePerRoom) {
 }

--- a/app-api/src/main/java/com/tasteam/domain/admin/dto/response/AdminDummySeedResponse.java
+++ b/app-api/src/main/java/com/tasteam/domain/admin/dto/response/AdminDummySeedResponse.java
@@ -1,11 +1,11 @@
 package com.tasteam.domain.admin.dto.response;
 
 public record AdminDummySeedResponse(
-	int membersInserted,
-	int restaurantsInserted,
-	int groupsInserted,
-	int subgroupsInserted,
-	int reviewsInserted,
-	int chatMessagesInserted,
+	long membersInserted,
+	long restaurantsInserted,
+	long groupsInserted,
+	long subgroupsInserted,
+	long reviewsInserted,
+	long chatMessagesInserted,
 	long elapsedMs) {
 }


### PR DESCRIPTION
## 📌 PR 요약

#### Summary
- 더미 데이터 시드 API 입력 상한을 요구치(멤버 10만/음식점 5천만/그룹 1천/하위그룹 1천/그룹당 멤버 1천/리뷰 1억/채팅 메시지 10억)로 반영했습니다.
- 더미 시드 로직을 청크 기반 스트리밍 삽입으로 재구성해 대량 입력 시 메모리 피크를 낮췄습니다.
- 삽입 결과 카운트 응답 타입을 `long`으로 변경해 대량 결과에서도 오버플로우를 방지했습니다.

### Issue
- close : #482

---

## ➕ 추가된 기능
1. 대량 더미 삽입을 위한 청크/플러시 기반 시딩 파이프라인 도입
2. 요청값 상한 검증 정책의 도메인 요구치 반영

## 🛠️ 수정/변경사항
1. `AdminDummySeedRequest`에 필드별 `@Max`를 재도입하고 상한을 조정했습니다.
2. `DummyDataSeedService`에 서비스 레벨 상한 검증 및 대용량 삽입 경로를 반영했습니다.
3. `AdminDummySeedResponse` 카운트 필드를 `long`으로 변경했습니다.
4. 검증: `./gradlew :app-api:compileJava`

---

## ✅ 남은 작업
* [ ] 스테이징 DB에서 대량 시드(예: 100만/1000만) 실측 성능 검증
* [ ] 청크 크기(`SERVICE_CHUNK_SIZE`, `RELATION_FLUSH_SIZE`) 튜닝 필요 시 조정
