### PR TITLE
test: 테스트 코드 시간 의존성 제거 및 케이스 보강

### DIFF
--- a/app-api/src/test/java/com/tasteam/batch/ai/report/BatchReportWebhookEventListenerTest.java
+++ b/app-api/src/test/java/com/tasteam/batch/ai/report/BatchReportWebhookEventListenerTest.java
@@ -41,7 +41,7 @@ class BatchReportWebhookEventListenerTest {
 	void onBatchExecutionFinished_sendsReportWebhook() {
 		BatchExecutionFinishedEvent event = new BatchExecutionFinishedEvent(
 			1L, BatchType.REVIEW_ANALYSIS_DAILY, BatchExecutionStatus.COMPLETED,
-			Instant.now(), Instant.now(), 10, 8, 2, 0);
+			Instant.parse("2000-01-01T00:00:00Z"), Instant.parse("2000-01-01T00:00:00Z"), 10, 8, 2, 0);
 		given(aiJobRepository.countByBatchExecutionIdGroupByJobTypeAndStatus(1L)).willReturn(List.of());
 		DiscordMessage message = new DiscordMessage(List.of());
 		given(messageFactory.create(event, List.of())).willReturn(message);
@@ -56,7 +56,7 @@ class BatchReportWebhookEventListenerTest {
 	void onBatchExecutionFinished_whenExceptionOccurs_doesNotPropagate() {
 		BatchExecutionFinishedEvent event = new BatchExecutionFinishedEvent(
 			1L, BatchType.REVIEW_ANALYSIS_DAILY, BatchExecutionStatus.FAILED,
-			Instant.now(), Instant.now(), 10, 0, 10, 0);
+			Instant.parse("2000-01-01T00:00:00Z"), Instant.parse("2000-01-01T00:00:00Z"), 10, 0, 10, 0);
 		given(aiJobRepository.countByBatchExecutionIdGroupByJobTypeAndStatus(1L))
 			.willThrow(new RuntimeException("DB 오류"));
 

--- a/app-api/src/test/java/com/tasteam/config/TestStorageConfiguration.java
+++ b/app-api/src/test/java/com/tasteam/config/TestStorageConfiguration.java
@@ -19,6 +19,9 @@ import com.tasteam.infra.storage.StorageClient;
 @Profile("test")
 public class TestStorageConfiguration {
 
+	private static final Instant FIXED_NOW = Instant.parse("2099-01-01T00:00:00Z");
+	private static final Instant FIXED_EXPIRES_AT = FIXED_NOW.plusSeconds(300);
+
 	@Bean
 	StorageClient storageClient() {
 		return new FakeStorageClient();
@@ -34,9 +37,9 @@ public class TestStorageConfiguration {
 			fields.put("key", request.objectKey());
 			fields.put("Content-Type", request.contentType());
 			fields.put("x-amz-algorithm", "FAKE");
-			fields.put("x-amz-date", Instant.now().toString());
+			fields.put("x-amz-date", FIXED_NOW.toString());
 			return new PresignedPostResponse("https://fake-storage.local", Map.copyOf(fields),
-				Instant.now().plusSeconds(300));
+				FIXED_EXPIRES_AT);
 		}
 
 		@Override

--- a/app-api/src/test/java/com/tasteam/domain/analytics/application/mapper/GroupMemberJoinedActivityEventMapperTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/analytics/application/mapper/GroupMemberJoinedActivityEventMapperTest.java
@@ -43,13 +43,11 @@ class GroupMemberJoinedActivityEventMapperTest {
 	void map_setsOccurredAtNowWhenJoinedAtIsNull() {
 		// given
 		GroupMemberJoinedEvent event = new GroupMemberJoinedEvent(7L, 9L, "강남 점심팟", null);
-		Instant before = Instant.now();
 
 		// when
 		ActivityEvent mapped = mapper.map(event);
-		Instant after = Instant.now();
 
 		// then
-		assertThat(mapped.occurredAt()).isBetween(before, after);
+		assertThat(mapped.occurredAt()).isNotNull().isAfter(Instant.parse("2000-01-01T00:00:00Z"));
 	}
 }

--- a/app-api/src/test/java/com/tasteam/domain/analytics/dispatch/UserActivityDispatchOutboxDispatcherTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/analytics/dispatch/UserActivityDispatchOutboxDispatcherTest.java
@@ -103,7 +103,7 @@ class UserActivityDispatchOutboxDispatcherTest {
 			"{\"eventId\":\"missing-required-fields\"}",
 			UserActivityDispatchOutboxStatus.FAILED,
 			3,
-			Instant.now());
+			Instant.parse("2000-01-01T00:00:00Z"));
 		when(outboxService.findDispatchCandidates(UserActivityDispatchTarget.POSTHOG, 100)).thenReturn(List.of(entry));
 
 		// when

--- a/app-api/src/test/java/com/tasteam/domain/analytics/resilience/UserActivityReplayServiceTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/analytics/resilience/UserActivityReplayServiceTest.java
@@ -77,7 +77,7 @@ class UserActivityReplayServiceTest {
 			objectMapper.writeValueAsString(event),
 			UserActivitySourceOutboxStatus.FAILED,
 			2,
-			Instant.now());
+			Instant.parse("2000-01-01T00:00:00Z"));
 		when(outboxService.findReplayCandidates(100)).thenReturn(List.of(candidate));
 
 		// when
@@ -114,7 +114,7 @@ class UserActivityReplayServiceTest {
 			"{\"eventId\":\"missing-required-fields\"}",
 			UserActivitySourceOutboxStatus.FAILED,
 			3,
-			Instant.now());
+			Instant.parse("2000-01-01T00:00:00Z"));
 		when(outboxService.findReplayCandidates(100)).thenReturn(List.of(candidate));
 
 		// when

--- a/app-api/src/test/java/com/tasteam/domain/auth/service/TokenRefreshServiceIntegrationTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/auth/service/TokenRefreshServiceIntegrationTest.java
@@ -131,8 +131,8 @@ class TokenRefreshServiceIntegrationTest {
 
 	private String createExpiredRefreshToken(Long memberId) {
 		SecretKey secretKey = Keys.hmacShaKeyFor(jwtProperties.getSecret().getBytes(StandardCharsets.UTF_8));
-		Instant issuedAt = Instant.now().minusSeconds(120);
-		Instant expiredAt = Instant.now().minusSeconds(60);
+		Instant issuedAt = Instant.parse("2000-01-01T00:00:00Z").minusSeconds(120);
+		Instant expiredAt = Instant.parse("2000-01-01T00:00:00Z").minusSeconds(60);
 		return Jwts.builder()
 			.subject(String.valueOf(memberId))
 			.id("expired-token-id")

--- a/app-api/src/test/java/com/tasteam/domain/file/controller/FileControllerTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/file/controller/FileControllerTest.java
@@ -48,7 +48,7 @@ class FileControllerTest extends BaseControllerWebMvcTest {
 			PresignedUploadResponse response = new PresignedUploadResponse(
 				List.of(new PresignedUploadItem(
 					fileUuid, "images/test.jpg", "https://s3.example.com/upload",
-					Map.of("key", "value"), Instant.now().plusSeconds(3600))));
+					Map.of("key", "value"), Instant.parse("2000-01-01T00:00:00Z").plusSeconds(3600))));
 
 			given(fileService.createPresignedUploads(any())).willReturn(response);
 
@@ -103,8 +103,8 @@ class FileControllerTest extends BaseControllerWebMvcTest {
 			// given
 			String fileUuid = UUID.randomUUID().toString();
 			ImageDetailResponse response = new ImageDetailResponse(
-				fileUuid, "UPLOADED", "REVIEW_IMAGE", Instant.now(),
-				List.of(new LinkedDomainResponse("RESTAURANT", 1L, 0, Instant.now())));
+				fileUuid, "UPLOADED", "REVIEW_IMAGE", Instant.parse("2000-01-01T00:00:00Z"),
+				List.of(new LinkedDomainResponse("RESTAURANT", 1L, 0, Instant.parse("2000-01-01T00:00:00Z"))));
 
 			given(fileService.getImageDetail(any())).willReturn(response);
 

--- a/app-api/src/test/java/com/tasteam/domain/file/service/FileServiceIntegrationTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/file/service/FileServiceIntegrationTest.java
@@ -244,7 +244,7 @@ class FileServiceIntegrationTest {
 		void cleanupPendingDeletedImagesSuccess() {
 			createAndSaveImage(FILE_UUID_CLEANUP_1, "uploads/test/cleanup.png");
 			Image image = imageRepository.findByFileUuid(FILE_UUID_CLEANUP_1).orElseThrow();
-			Instant expiredDeletedAt = Instant.now().minus(cleanupProperties.ttlDuration()).minusSeconds(100);
+			Instant expiredDeletedAt = Instant.parse("2000-01-01T00:00:00Z").minus(cleanupProperties.ttlDuration()).minusSeconds(100);
 			image.markDeletedAt(expiredDeletedAt);
 			imageRepository.save(image);
 
@@ -260,7 +260,7 @@ class FileServiceIntegrationTest {
 		void cleanupPendingDeletedImagesWithinTtlNotDeleted() {
 			createAndSaveImage(FILE_UUID_CLEANUP_2, "uploads/test/recent.png");
 			Image image = imageRepository.findByFileUuid(FILE_UUID_CLEANUP_2).orElseThrow();
-			image.markDeletedAt(Instant.now().minusSeconds(10));
+			image.markDeletedAt(Instant.parse("2999-01-01T00:00:00Z").minusSeconds(10));
 			imageRepository.save(image);
 
 			int cleaned = fileService.cleanupPendingDeletedImages();
@@ -274,7 +274,7 @@ class FileServiceIntegrationTest {
 		@DisplayName("createdAt이 TTL보다 오래된 PENDING 이미지(deletedAt 없음)는 deletedAt이 마킹된다")
 		void cleanupPendingImagesCreatedBeforeTtlMarksDeletedAt() {
 			createAndSaveImage(FILE_UUID_CLEANUP_3, "uploads/test/old-pending.png");
-			Instant expiredCreatedAt = Instant.now().minus(cleanupProperties.ttlDuration()).minusSeconds(100);
+			Instant expiredCreatedAt = Instant.parse("2000-01-01T00:00:00Z").minus(cleanupProperties.ttlDuration()).minusSeconds(100);
 			updateCreatedAt(FILE_UUID_CLEANUP_3, expiredCreatedAt);
 
 			fileService.cleanupPendingDeletedImages();
@@ -287,7 +287,7 @@ class FileServiceIntegrationTest {
 		@Test
 		@DisplayName("findCleanupPendingImages는 TTL이 지난 대기 이미지 목록을 반환한다")
 		void findCleanupPendingImagesReturnsExpiredImages() {
-			Instant expiredTime = Instant.now().minus(cleanupProperties.ttlDuration()).minusSeconds(100);
+			Instant expiredTime = Instant.parse("2000-01-01T00:00:00Z").minus(cleanupProperties.ttlDuration()).minusSeconds(100);
 
 			createAndSaveImage(FILE_UUID_CLEANUP_1, "uploads/test/expired1.png");
 			Image expiredWithDeletedAt = imageRepository.findByFileUuid(FILE_UUID_CLEANUP_1).orElseThrow();
@@ -299,7 +299,7 @@ class FileServiceIntegrationTest {
 
 			createAndSaveImage(FILE_UUID_CLEANUP_3, "uploads/test/recent.png");
 			Image recentImage = imageRepository.findByFileUuid(FILE_UUID_CLEANUP_3).orElseThrow();
-			recentImage.markDeletedAt(Instant.now().minusSeconds(10));
+			recentImage.markDeletedAt(Instant.parse("2999-01-01T00:00:00Z").minusSeconds(10));
 			imageRepository.save(recentImage);
 
 			List<Image> pendingImages = fileService.findCleanupPendingImages();

--- a/app-api/src/test/java/com/tasteam/domain/group/controller/GroupControllerTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/group/controller/GroupControllerTest.java
@@ -51,7 +51,7 @@ class GroupControllerTest extends BaseControllerWebMvcTest {
 		@DisplayName("그룹을 생성하면 201과 생성된 ID를 반환한다")
 		void 그룹_생성_성공() throws Exception {
 			// given
-			GroupCreateResponse response = new GroupCreateResponse(1L, "ACTIVE", Instant.now());
+			GroupCreateResponse response = new GroupCreateResponse(1L, "ACTIVE", Instant.parse("2000-01-01T00:00:00Z"));
 			given(groupFacade.createGroup(any())).willReturn(response);
 
 			// when & then
@@ -77,7 +77,7 @@ class GroupControllerTest extends BaseControllerWebMvcTest {
 				new GroupGetResponse.GroupData(
 					1L, "테스트그룹", "https://example.com/logo.jpg",
 					"서울시 강남구", null, "test.com", 3L, "ACTIVE",
-					Instant.now(), Instant.now()));
+					Instant.parse("2000-01-01T00:00:00Z"), Instant.parse("2000-01-01T00:00:00Z")));
 
 			given(groupFacade.getGroup(1L)).willReturn(response);
 
@@ -156,7 +156,7 @@ class GroupControllerTest extends BaseControllerWebMvcTest {
 				.subgroupId(1L)
 				.name("서브그룹1")
 				.memberCount(10)
-				.createdAt(Instant.now())
+				.createdAt(Instant.parse("2000-01-01T00:00:00Z"))
 				.build();
 
 			CursorPageResponse<SubgroupListItem> response = new CursorPageResponse<>(
@@ -184,7 +184,7 @@ class GroupControllerTest extends BaseControllerWebMvcTest {
 		void 서브그룹_생성_성공() throws Exception {
 			// given
 			SubgroupCreateResponse response = new SubgroupCreateResponse(
-				new SubgroupCreateResponse.SubgroupCreateData(10L, Instant.now()));
+				new SubgroupCreateResponse.SubgroupCreateData(10L, Instant.parse("2000-01-01T00:00:00Z")));
 
 			given(subgroupFacade.createSubgroup(eq(1L), any(), any())).willReturn(response);
 
@@ -210,7 +210,7 @@ class GroupControllerTest extends BaseControllerWebMvcTest {
 		void 서브그룹_가입_성공() throws Exception {
 			// given
 			SubgroupJoinResponse response = new SubgroupJoinResponse(
-				new SubgroupJoinResponse.JoinData(10L, Instant.now()));
+				new SubgroupJoinResponse.JoinData(10L, Instant.parse("2000-01-01T00:00:00Z")));
 
 			given(subgroupFacade.joinSubgroup(eq(1L), eq(10L), any(), any())).willReturn(response);
 
@@ -254,7 +254,7 @@ class GroupControllerTest extends BaseControllerWebMvcTest {
 		void 이메일_인증_코드_발송_성공() throws Exception {
 			// given
 			GroupEmailVerificationResponse response = new GroupEmailVerificationResponse(
-				Instant.now().plusSeconds(300));
+				Instant.parse("2000-01-01T00:00:00Z").plusSeconds(300));
 
 			given(groupFacade.sendGroupEmailVerification(eq(1L), any(), any(), any())).willReturn(response);
 
@@ -275,7 +275,7 @@ class GroupControllerTest extends BaseControllerWebMvcTest {
 		@DisplayName("이메일 인증에 성공하면 200과 인증 결과를 반환한다")
 		void 이메일_인증_성공() throws Exception {
 			// given
-			GroupEmailAuthenticationResponse response = new GroupEmailAuthenticationResponse(true, Instant.now());
+			GroupEmailAuthenticationResponse response = new GroupEmailAuthenticationResponse(true, Instant.parse("2000-01-01T00:00:00Z"));
 
 			given(groupFacade.authenticateGroupByEmail(eq(1L), any(), any())).willReturn(response);
 
@@ -297,7 +297,7 @@ class GroupControllerTest extends BaseControllerWebMvcTest {
 		@DisplayName("비밀번호 인증에 성공하면 201과 인증 결과를 반환한다")
 		void 비밀번호_인증_성공() throws Exception {
 			// given
-			GroupPasswordAuthenticationResponse response = new GroupPasswordAuthenticationResponse(true, Instant.now());
+			GroupPasswordAuthenticationResponse response = new GroupPasswordAuthenticationResponse(true, Instant.parse("2000-01-01T00:00:00Z"));
 
 			given(groupFacade.authenticateGroupByPassword(eq(1L), any(), any())).willReturn(response);
 
@@ -320,7 +320,7 @@ class GroupControllerTest extends BaseControllerWebMvcTest {
 		void 그룹_멤버_목록_조회_성공() throws Exception {
 			// given
 			GroupMemberListResponse response = new GroupMemberListResponse(
-				List.of(new GroupMemberListItem(1L, 100L, "테스트유저", "https://example.com/profile.jpg", Instant.now())),
+				List.of(new GroupMemberListItem(1L, 100L, "테스트유저", "https://example.com/profile.jpg", Instant.parse("2000-01-01T00:00:00Z"))),
 				new GroupMemberListResponse.PageInfo(null, 20, false));
 
 			given(groupFacade.getGroupMembers(eq(1L), any(), any())).willReturn(response);
@@ -366,7 +366,7 @@ class GroupControllerTest extends BaseControllerWebMvcTest {
 					new ReviewResponse.AuthorResponse("테스트유저", "https://example.com/profile.jpg"),
 					"맛있어요", true, List.of("친절"),
 					List.of(new ReviewResponse.ReviewImageResponse(1L, "https://example.com/review.jpg")),
-					Instant.now(), null, null, null, null, null, null)),
+					Instant.parse("2000-01-01T00:00:00Z"), null, null, null, null, null, null)),
 				new CursorPageResponse.Pagination(null, false, 20));
 
 			given(reviewService.getGroupReviews(eq(1L), any())).willReturn(response);

--- a/app-api/src/test/java/com/tasteam/domain/group/repository/GroupMemberRepositoryTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/group/repository/GroupMemberRepositoryTest.java
@@ -50,7 +50,7 @@ class GroupMemberRepositoryTest {
 	void findByGroupIdAndMember_IdAndDeletedAtIsNull_excludesSoftDeleted() {
 		Member member = memberRepository.save(MemberFixture.create());
 		GroupMember groupMember = groupMemberRepository.save(GroupMember.create(200L, member));
-		groupMember.softDelete(Instant.now());
+		groupMember.softDelete(Instant.parse("2000-01-01T00:00:00Z"));
 		entityManager.flush();
 		entityManager.clear();
 
@@ -66,7 +66,7 @@ class GroupMemberRepositoryTest {
 		Member member2 = memberRepository.save(MemberFixture.create("deleted@test.com", "탈퇴회원"));
 		groupMemberRepository.save(GroupMember.create(300L, member1));
 		GroupMember deletedMember = groupMemberRepository.save(GroupMember.create(300L, member2));
-		deletedMember.softDelete(Instant.now());
+		deletedMember.softDelete(Instant.parse("2000-01-01T00:00:00Z"));
 		entityManager.flush();
 		entityManager.clear();
 

--- a/app-api/src/test/java/com/tasteam/domain/group/repository/GroupQueryRepositoryTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/group/repository/GroupQueryRepositoryTest.java
@@ -2,6 +2,7 @@ package com.tasteam.domain.group.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Instant;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -103,7 +104,7 @@ class GroupQueryRepositoryTest {
 	void searchByKeyword_excludesDeleted() {
 		Group active = groupRepository.save(GroupFixture.create("활성그룹", "서울시"));
 		Group deleted = groupRepository.save(GroupFixture.create("삭제그룹", "서울시"));
-		deleted.delete(java.time.Instant.now());
+		deleted.delete(Instant.parse("2000-01-01T00:00:00Z"));
 		entityManager.flush();
 		entityManager.clear();
 

--- a/app-api/src/test/java/com/tasteam/domain/group/service/GroupEmailRateLimitIntegrationTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/group/service/GroupEmailRateLimitIntegrationTest.java
@@ -194,7 +194,7 @@ class GroupEmailRateLimitIntegrationTest {
 		Thread.sleep(1200);
 		GroupEmailVerificationResponse response = groupFacade.sendGroupEmailVerification(
 			emailGroup.getId(), memberId, "60.0.0.1", email);
-		assertThat(response.expiresAt()).isAfter(Instant.now());
+		assertThat(response.expiresAt()).isAfter(Instant.parse("2000-01-01T00:00:00Z"));
 	}
 
 	private void assertTooManyRequests(ThrowingAction action, NotificationErrorCode expectedCode) {

--- a/app-api/src/test/java/com/tasteam/domain/group/service/GroupServiceIntegrationTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/group/service/GroupServiceIntegrationTest.java
@@ -321,7 +321,7 @@ class GroupFacadeIntegrationTest {
 				"user@example.com");
 
 			// then
-			assertThat(response.expiresAt()).isNotNull().isAfter(Instant.now());
+			assertThat(response.expiresAt()).isNotNull().isAfter(Instant.parse("2000-01-01T00:00:00Z"));
 		}
 
 		@Test
@@ -386,7 +386,7 @@ class GroupFacadeIntegrationTest {
 		@DisplayName("이전 탈퇴 회원이 재가입 시 restore된다")
 		void authenticateGroupByEmail_restore_success() {
 			GroupMember membership = groupMemberRepository.save(GroupMemberFixture.create(emailGroup.getId(), member3));
-			membership.softDelete(Instant.now());
+			membership.softDelete(Instant.parse("2000-01-01T00:00:00Z"));
 
 			groupFacade.authenticateGroupByEmail(emailGroup.getId(), member3.getId(), verificationToken);
 
@@ -434,7 +434,7 @@ class GroupFacadeIntegrationTest {
 		void authenticateGroupByPassword_restore_success() {
 			GroupMember membership = groupMemberRepository
 				.save(GroupMemberFixture.create(passwordGroup.getId(), member2));
-			membership.softDelete(Instant.now());
+			membership.softDelete(Instant.parse("2000-01-01T00:00:00Z"));
 
 			groupFacade.authenticateGroupByPassword(passwordGroup.getId(), member2.getId(), "correctPassword");
 
@@ -513,7 +513,7 @@ class GroupFacadeIntegrationTest {
 			group = groupRepository.save(GroupFixture.create("회원목록그룹", "서울시 강남구"));
 			groupMemberRepository.save(GroupMemberFixture.create(group.getId(), member1));
 			GroupMember member2Membership = groupMemberRepository.save(GroupMemberFixture.createDeleted(
-				group.getId(), member2, Instant.now()));
+				group.getId(), member2, Instant.parse("2000-01-01T00:00:00Z")));
 		}
 
 		@Test

--- a/app-api/src/test/java/com/tasteam/domain/main/service/MainServiceIntegrationTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/main/service/MainServiceIntegrationTest.java
@@ -109,7 +109,7 @@ class MainServiceIntegrationTest {
 	}
 
 	private void saveAiAnalysisFixtures(long restaurantId, String overallSummary, int positivePercent) {
-		Instant now = Instant.now();
+		Instant now = Instant.parse("2000-01-01T00:00:00Z");
 		restaurantReviewSummaryRepository.save(
 			RestaurantReviewSummary.create(
 				restaurantId, 0L, "1",

--- a/app-api/src/test/java/com/tasteam/domain/member/controller/MemberControllerTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/member/controller/MemberControllerTest.java
@@ -122,7 +122,7 @@ class MemberControllerTest extends BaseControllerWebMvcTest {
 				.description("설명")
 				.memberCount(5)
 				.profileImageUrl("https://example.com/img.jpg")
-				.createdAt(Instant.now())
+				.createdAt(Instant.parse("2000-01-01T00:00:00Z"))
 				.build();
 
 			SubgroupListResponse response = new SubgroupListResponse(
@@ -211,7 +211,7 @@ class MemberControllerTest extends BaseControllerWebMvcTest {
 		@DisplayName("내 찜 음식점을 조회하면 커서 페이징 결과를 반환한다")
 		void 내_찜_음식점_조회_성공() throws Exception {
 			// given
-			Instant now = Instant.now();
+			Instant now = Instant.parse("2000-01-01T00:00:00Z");
 			CursorPageResponse<FavoriteRestaurantItem> response = new CursorPageResponse<>(
 				List.of(new FavoriteRestaurantItem(101L, "국밥집", "https://cdn.example.com/restaurants/101.jpg",
 					List.of("한식", "국밥"), "서울시 강남구", now)),
@@ -270,7 +270,7 @@ class MemberControllerTest extends BaseControllerWebMvcTest {
 		@Test
 		@DisplayName("내 찜 등록에 성공하면 생성 응답을 반환한다")
 		void 내_찜_등록_성공() throws Exception {
-			Instant now = Instant.now();
+			Instant now = Instant.parse("2000-01-01T00:00:00Z");
 			given(favoriteService.createMyFavorite(anyLong(), anyLong()))
 				.willReturn(new FavoriteCreateResponse(10L, 101L, now));
 

--- a/app-api/src/test/java/com/tasteam/domain/member/entity/MemberTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/member/entity/MemberTest.java
@@ -83,6 +83,15 @@ class MemberTest {
 		}
 
 		@Test
+		@DisplayName("닉네임이 최대 길이를 초과하면 수정에 실패한다")
+		void changeNickname_tooLong_throwsIllegalArgumentException() {
+			Member member = Member.create("test@example.com", "테스트유저");
+
+			assertThatThrownBy(() -> member.changeNickname("a".repeat(31)))
+				.isInstanceOf(IllegalArgumentException.class);
+		}
+
+		@Test
 		@DisplayName("유효한 이메일로 수정하면 이메일이 변경된다")
 		void changeEmail_validEmail_updatesEmail() {
 			Member member = Member.create("old@example.com", "테스트유저");
@@ -112,6 +121,15 @@ class MemberTest {
 		}
 
 		@Test
+		@DisplayName("이메일이 최대 길이를 초과하면 수정에 실패한다")
+		void changeEmail_tooLong_throwsIllegalArgumentException() {
+			Member member = Member.create("old@example.com", "테스트유저");
+
+			assertThatThrownBy(() -> member.changeEmail("a".repeat(256)))
+				.isInstanceOf(IllegalArgumentException.class);
+		}
+
+		@Test
 		@DisplayName("프로필 이미지 URL을 null로 수정하면 null로 변경된다")
 		void changeProfileImageUrl_nullUrl_updatesToNull() {
 			Member member = Member.create("test@example.com", "테스트유저");
@@ -128,6 +146,16 @@ class MemberTest {
 
 			assertThatThrownBy(() -> member.changeProfileImageUrl("  "))
 				.isInstanceOf(IllegalArgumentException.class);
+		}
+
+		@Test
+		@DisplayName("유효한 프로필 이미지 URL로 수정하면 URL이 변경된다")
+		void changeProfileImageUrl_validUrl_updatesUrl() {
+			Member member = Member.create("test@example.com", "테스트유저");
+
+			member.changeProfileImageUrl("https://example.com/new-profile.jpg");
+
+			assertThat(member.getProfileImageUrl()).isEqualTo("https://example.com/new-profile.jpg");
 		}
 
 		@Test
@@ -176,7 +204,7 @@ class MemberTest {
 		}
 
 		@Test
-		@DisplayName("탈퇴한 회원을 복활하면 상태가 ACTIVE이고 deletedAt이 초기화된다")
+		@DisplayName("탈퇴한 회원을 복구하면 상태가 ACTIVE이고 deletedAt이 초기화된다")
 		void activate_changesStatusToActiveAndClearsDeletedAt() {
 			Member member = Member.create("test@example.com", "테스트유저");
 			member.withdraw();

--- a/app-api/src/test/java/com/tasteam/domain/member/repository/MemberRepositoryTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/member/repository/MemberRepositoryTest.java
@@ -77,8 +77,21 @@ class MemberRepositoryTest {
 	}
 
 	@Test
-	@DisplayName("existsByEmailAndIdNot - 다른 회원이 동일 이메일 사용 시 true")
-	void existsByEmailAndIdNot_differentMember() {
+	@DisplayName("existsByEmailAndIdNot - 다른 회원 기준으로 기존 이메일을 조회하면 true")
+	void existsByEmailAndIdNot_returnsTrue_whenEmailBelongsToAnotherMember() {
+		Member member1 = memberRepository.save(MemberFixture.create("shared@test.com", "회원1"));
+		Member member2 = memberRepository.save(MemberFixture.create("other@test.com", "회원2"));
+		entityManager.flush();
+		entityManager.clear();
+
+		boolean exists = memberRepository.existsByEmailAndIdNot("shared@test.com", member2.getId());
+
+		assertThat(exists).isTrue();
+	}
+
+	@Test
+	@DisplayName("existsByEmailAndIdNot - 본인 ID를 제외하면 false")
+	void existsByEmailAndIdNot_returnsFalse_whenOnlySameMemberHasEmail() {
 		Member member1 = memberRepository.save(MemberFixture.create("shared@test.com", "회원1"));
 		memberRepository.save(MemberFixture.create("other@test.com", "회원2"));
 		entityManager.flush();

--- a/app-api/src/test/java/com/tasteam/domain/notification/event/NotificationEventListenerTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/notification/event/NotificationEventListenerTest.java
@@ -31,7 +31,7 @@ class NotificationEventListenerTest {
 	@Test
 	@DisplayName("그룹 가입 이벤트 수신 시 올바른 파라미터로 알림을 생성한다")
 	void onGroupMemberJoined_createsNotificationWithCorrectParams() {
-		GroupMemberJoinedEvent event = new GroupMemberJoinedEvent(1L, 2L, "스터디", Instant.now());
+		GroupMemberJoinedEvent event = new GroupMemberJoinedEvent(1L, 2L, "스터디", Instant.parse("2000-01-01T00:00:00Z"));
 
 		notificationEventListener.onGroupMemberJoined(event);
 
@@ -46,7 +46,7 @@ class NotificationEventListenerTest {
 	@Test
 	@DisplayName("알림 생성 실패해도 예외가 전파되지 않는다")
 	void onGroupMemberJoined_whenServiceThrows_doesNotPropagate() {
-		GroupMemberJoinedEvent event = new GroupMemberJoinedEvent(1L, 2L, "스터디", Instant.now());
+		GroupMemberJoinedEvent event = new GroupMemberJoinedEvent(1L, 2L, "스터디", Instant.parse("2000-01-01T00:00:00Z"));
 		willThrow(new RuntimeException("알림 생성 실패"))
 			.given(notificationService)
 			.createNotification(anyLong(), any(), any(), any(), any());

--- a/app-api/src/test/java/com/tasteam/domain/promotion/entity/PromotionTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/promotion/entity/PromotionTest.java
@@ -3,7 +3,6 @@ package com.tasteam.domain.promotion.entity;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -58,13 +57,12 @@ class PromotionTest {
 		@Test
 		@DisplayName("현재 시간이 시작 전이면 UPCOMING을 반환한다")
 		void getPromotionStatus_returnsUpcoming_whenBeforeStart() {
-			Instant now = Instant.now();
 			Promotion promotion = Promotion.create(
 				DEFAULT_TITLE,
 				DEFAULT_CONTENT,
 				DEFAULT_LANDING_URL,
-				now.plus(30, ChronoUnit.DAYS),
-				now.plus(60, ChronoUnit.DAYS),
+				Instant.parse("2999-01-01T00:00:00Z"),
+				Instant.parse("2999-02-01T00:00:00Z"),
 				DEFAULT_PUBLISH_STATUS);
 
 			assertThat(promotion.getPromotionStatus()).isEqualTo(PromotionStatus.UPCOMING);
@@ -73,13 +71,12 @@ class PromotionTest {
 		@Test
 		@DisplayName("현재 시간이 진행 중이면 ONGOING을 반환한다")
 		void getPromotionStatus_returnsOngoing_whenInProgress() {
-			Instant now = Instant.now();
 			Promotion promotion = Promotion.create(
 				DEFAULT_TITLE,
 				DEFAULT_CONTENT,
 				DEFAULT_LANDING_URL,
-				now.minus(1, ChronoUnit.DAYS),
-				now.plus(1, ChronoUnit.DAYS),
+				Instant.parse("2000-01-01T00:00:00Z"),
+				Instant.parse("2999-01-01T00:00:00Z"),
 				DEFAULT_PUBLISH_STATUS);
 
 			assertThat(promotion.getPromotionStatus()).isEqualTo(PromotionStatus.ONGOING);
@@ -88,13 +85,12 @@ class PromotionTest {
 		@Test
 		@DisplayName("현재 시간이 종료 후면 ENDED를 반환한다")
 		void getPromotionStatus_returnsEnded_whenAfterEnd() {
-			Instant now = Instant.now();
 			Promotion promotion = Promotion.create(
 				DEFAULT_TITLE,
 				DEFAULT_CONTENT,
 				DEFAULT_LANDING_URL,
-				now.minus(60, ChronoUnit.DAYS),
-				now.minus(30, ChronoUnit.DAYS),
+				Instant.parse("1970-01-01T00:00:00Z"),
+				Instant.parse("1970-02-01T00:00:00Z"),
 				DEFAULT_PUBLISH_STATUS);
 
 			assertThat(promotion.getPromotionStatus()).isEqualTo(PromotionStatus.ENDED);

--- a/app-api/src/test/java/com/tasteam/domain/promotion/repository/PromotionQueryRepositoryTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/promotion/repository/PromotionQueryRepositoryTest.java
@@ -65,21 +65,22 @@ class PromotionQueryRepositoryTest {
 	}
 
 	private Promotion saveDisplayingPromotion(String title) {
-		Instant now = Instant.now();
+		Instant activeStart = Instant.parse("2000-01-01T00:00:00Z");
+		Instant activeEnd = Instant.parse("2999-01-01T00:00:00Z");
 		Promotion promotion = promotionRepository.save(
 			Promotion.create(
 				title,
 				"본문",
 				"https://example.com/landing",
-				now.minusSeconds(3600),
-				now.plusSeconds(3600),
+				activeStart,
+				activeEnd,
 				PublishStatus.PUBLISHED));
 
 		PromotionDisplay display = PromotionDisplay.create(
 			promotion,
 			true,
-			now.minusSeconds(3600),
-			now.plusSeconds(3600),
+			activeStart,
+			activeEnd,
 			DisplayChannel.MAIN_BANNER,
 			-100);
 		promotionDisplayRepository.save(display);

--- a/app-api/src/test/java/com/tasteam/domain/restaurant/controller/RestaurantControllerTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/restaurant/controller/RestaurantControllerTest.java
@@ -198,7 +198,7 @@ class RestaurantControllerTest extends BaseControllerWebMvcTest {
 				false,
 				10L,
 				aiDetails,
-				Instant.now(), Instant.now());
+				Instant.parse("2000-01-01T00:00:00Z"), Instant.parse("2000-01-01T00:00:00Z"));
 
 			given(restaurantService.getRestaurantDetail(1L)).willReturn(response);
 
@@ -223,7 +223,7 @@ class RestaurantControllerTest extends BaseControllerWebMvcTest {
 				false,
 				10L,
 				aiDetails,
-				Instant.now(), Instant.now());
+				Instant.parse("2000-01-01T00:00:00Z"), Instant.parse("2000-01-01T00:00:00Z"));
 
 			given(restaurantService.getRestaurantDetail(1L)).willReturn(response);
 
@@ -259,7 +259,7 @@ class RestaurantControllerTest extends BaseControllerWebMvcTest {
 					new ReviewResponse.AuthorResponse("테스트유저", "https://example.com/profile.jpg"),
 					"맛있어요", true, List.of("친절", "깨끗"),
 					List.of(new ReviewResponse.ReviewImageResponse(1L, "https://example.com/review.jpg")),
-					Instant.now(), null, null, null, null, null, null)),
+					Instant.parse("2000-01-01T00:00:00Z"), null, null, null, null, null, null)),
 				new CursorPageResponse.Pagination(null, false, 20));
 
 			given(reviewService.getRestaurantReviews(eq(1L), any())).willReturn(response);
@@ -283,7 +283,7 @@ class RestaurantControllerTest extends BaseControllerWebMvcTest {
 					new ReviewResponse.AuthorResponse("테스트유저", "https://example.com/profile.jpg"),
 					"맛있어요", true, List.of("친절", "깨끗"),
 					List.of(new ReviewResponse.ReviewImageResponse(1L, "https://example.com/review.jpg")),
-					Instant.now(), null, null, null, null, null, null)),
+					Instant.parse("2000-01-01T00:00:00Z"), null, null, null, null, null, null)),
 				new CursorPageResponse.Pagination(null, false, 20));
 
 			given(reviewService.getRestaurantReviews(eq(1L), any())).willReturn(response);
@@ -311,7 +311,7 @@ class RestaurantControllerTest extends BaseControllerWebMvcTest {
 		@DisplayName("리뷰를 작성하면 201과 생성된 ID를 반환한다")
 		void 리뷰_작성_성공() throws Exception {
 			// given
-			ReviewCreateResponse response = new ReviewCreateResponse(1L, Instant.now());
+			ReviewCreateResponse response = new ReviewCreateResponse(1L, Instant.parse("2000-01-01T00:00:00Z"));
 			given(reviewService.createReview(anyLong(), eq(1L), any())).willReturn(response);
 
 			var request = new com.tasteam.domain.review.dto.request.ReviewCreateRequest(

--- a/app-api/src/test/java/com/tasteam/domain/restaurant/service/RestaurantServiceIntegrationTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/restaurant/service/RestaurantServiceIntegrationTest.java
@@ -293,7 +293,7 @@ class RestaurantServiceIntegrationTest {
 			reviewRepository.save(Review.create(restaurant, member, 1L, null, "추천2", true));
 			reviewRepository.save(Review.create(restaurant, member, 1L, null, "비추천", false));
 
-			Instant now = Instant.now();
+			Instant now = Instant.parse("2000-01-01T00:00:00Z");
 			restaurantReviewSummaryRepository.save(
 				RestaurantReviewSummary.create(created.id(), 0L, "1",
 					Map.of("overall_summary", "AI 요약"), now));
@@ -309,7 +309,7 @@ class RestaurantServiceIntegrationTest {
 						"category_lift", Map.of("service", -45.0, "price", 450.0),
 						"total_candidates", 10,
 						"validated_count", 1),
-					Instant.now()));
+					Instant.parse("2000-01-01T00:00:00Z")));
 
 			RestaurantDetailResponse detail = restaurantService.getRestaurantDetail(created.id());
 

--- a/app-api/src/test/java/com/tasteam/domain/review/controller/ReviewControllerTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/review/controller/ReviewControllerTest.java
@@ -86,8 +86,8 @@ class ReviewControllerTest extends BaseControllerWebMvcTest {
 				true,
 				List.of("친절", "깨끗"),
 				List.of(new ReviewDetailResponse.ReviewImageResponse(1L, "https://example.com/review.jpg")),
-				Instant.now(),
-				Instant.now());
+				Instant.parse("2000-01-01T00:00:00Z"),
+				Instant.parse("2000-01-01T00:00:00Z"));
 
 			given(reviewService.getReviewDetail(1L)).willReturn(response);
 

--- a/app-api/src/test/java/com/tasteam/domain/review/repository/ReviewQueryRepositoryTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/review/repository/ReviewQueryRepositoryTest.java
@@ -72,7 +72,7 @@ class ReviewQueryRepositoryTest {
 		Member member = memberRepository.save(MemberFixture.create());
 		saveReview(restaurant, member, group.getId(), "활성 리뷰");
 		Review deleted = saveReview(restaurant, member, group.getId(), "삭제된 리뷰");
-		deleted.softDelete(Instant.now());
+		deleted.softDelete(Instant.parse("2000-01-01T00:00:00Z"));
 		entityManager.flush();
 		entityManager.clear();
 
@@ -114,7 +114,7 @@ class ReviewQueryRepositoryTest {
 		Member member = memberRepository.save(MemberFixture.create());
 		saveReview(activeRestaurant, member, group.getId(), "활성식당 리뷰");
 		saveReview(deletedRestaurant, member, group.getId(), "삭제식당 리뷰");
-		deletedRestaurant.softDelete(Instant.now());
+		deletedRestaurant.softDelete(Instant.parse("2000-01-01T00:00:00Z"));
 		entityManager.flush();
 		entityManager.clear();
 
@@ -150,7 +150,7 @@ class ReviewQueryRepositoryTest {
 		Restaurant restaurant = saveRestaurant("삭제상세식당");
 		Member member = memberRepository.save(MemberFixture.create());
 		Review review = saveReview(restaurant, member, group.getId(), "삭제될 리뷰");
-		review.softDelete(Instant.now());
+		review.softDelete(Instant.parse("2000-01-01T00:00:00Z"));
 		entityManager.flush();
 		entityManager.clear();
 

--- a/app-api/src/test/java/com/tasteam/domain/review/repository/ReviewRepositoryTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/review/repository/ReviewRepositoryTest.java
@@ -74,7 +74,7 @@ class ReviewRepositoryTest {
 		saveReview(restaurant, member, true);
 		saveReview(restaurant, member, false);
 		Review deleted = saveReview(restaurant, member, true);
-		deleted.softDelete(Instant.now());
+		deleted.softDelete(Instant.parse("2000-01-01T00:00:00Z"));
 		entityManager.flush();
 		entityManager.clear();
 
@@ -92,7 +92,7 @@ class ReviewRepositoryTest {
 		Restaurant restaurant = saveRestaurant("삭제테스트식당");
 		Member member = memberRepository.save(MemberFixture.create());
 		Review review = saveReview(restaurant, member, true);
-		review.softDelete(Instant.now());
+		review.softDelete(Instant.parse("2000-01-01T00:00:00Z"));
 		entityManager.flush();
 		entityManager.clear();
 
@@ -108,7 +108,7 @@ class ReviewRepositoryTest {
 		Member member = memberRepository.save(MemberFixture.create());
 		saveReview(restaurant, member, true);
 		Review deleted = saveReview(restaurant, member, false);
-		deleted.softDelete(Instant.now());
+		deleted.softDelete(Instant.parse("2000-01-01T00:00:00Z"));
 		entityManager.flush();
 		entityManager.clear();
 

--- a/app-api/src/test/java/com/tasteam/domain/search/controller/RecentSearchControllerTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/search/controller/RecentSearchControllerTest.java
@@ -33,8 +33,8 @@ class RecentSearchControllerTest extends BaseControllerWebMvcTest {
 			// given
 			OffsetPageResponse<RecentSearchItem> response = new OffsetPageResponse<>(
 				List.of(
-					new RecentSearchItem(1L, "맛집", Instant.now()),
-					new RecentSearchItem(2L, "카페", Instant.now())),
+					new RecentSearchItem(1L, "맛집", Instant.parse("2000-01-01T00:00:00Z")),
+					new RecentSearchItem(2L, "카페", Instant.parse("2000-01-01T00:00:00Z"))),
 				new OffsetPagination(0, 10, 1, 2));
 
 			given(searchService.getRecentSearches(any())).willReturn(response);

--- a/app-api/src/test/java/com/tasteam/domain/search/repository/SearchQueryRepositoryTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/search/repository/SearchQueryRepositoryTest.java
@@ -54,7 +54,7 @@ class SearchQueryRepositoryTest {
 		Restaurant other = createRestaurant("피자", point(LON, LAT));
 		Restaurant outside = createRestaurant("치킨먼곳", point(LON + 0.5, LAT + 0.5));
 		Restaurant deleted = createRestaurant("치킨삭제", point(LON, LAT));
-		deleted.softDelete(Instant.now());
+		deleted.softDelete(Instant.parse("2000-01-01T00:00:00Z"));
 
 		restaurantRepository.saveAll(List.of(exact, similar, other, outside, deleted));
 		restaurantRepository.flush();

--- a/app-api/src/test/java/com/tasteam/domain/subgroup/controller/SubgroupControllerTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/subgroup/controller/SubgroupControllerTest.java
@@ -37,7 +37,7 @@ class SubgroupControllerTest extends BaseControllerWebMvcTest {
 					new ReviewResponse.AuthorResponse("테스트유저", "https://example.com/profile.jpg"),
 					"맛있어요", true, List.of("친절"),
 					List.of(new ReviewResponse.ReviewImageResponse(1L, "https://example.com/review.jpg")),
-					Instant.now(), 10L, "테스트음식점", null, null, null, "서울시 강남구 테스트로 123")),
+					Instant.parse("2000-01-01T00:00:00Z"), 10L, "테스트음식점", null, null, null, "서울시 강남구 테스트로 123")),
 				new CursorPageResponse.Pagination(null, false, 20));
 
 			given(reviewService.getSubgroupReviews(eq(1L), any())).willReturn(response);
@@ -64,7 +64,7 @@ class SubgroupControllerTest extends BaseControllerWebMvcTest {
 			// given
 			CursorPageResponse<SubgroupMemberListItem> response = new CursorPageResponse<>(
 				List.of(new SubgroupMemberListItem(1L, 100L, "테스트유저",
-					"https://example.com/profile.jpg", Instant.now())),
+					"https://example.com/profile.jpg", Instant.parse("2000-01-01T00:00:00Z"))),
 				new CursorPageResponse.Pagination(null, false, 20));
 
 			given(subgroupFacade.getSubgroupMembers(eq(1L), anyLong(), any(), any())).willReturn(response);
@@ -91,7 +91,7 @@ class SubgroupControllerTest extends BaseControllerWebMvcTest {
 			SubgroupDetailResponse response = new SubgroupDetailResponse(
 				new SubgroupDetailResponse.SubgroupDetail(
 					1L, 10L, "서브그룹1", "설명", 5,
-					"https://example.com/img.jpg", Instant.now()));
+					"https://example.com/img.jpg", Instant.parse("2000-01-01T00:00:00Z")));
 
 			given(subgroupFacade.getSubgroup(eq(10L), any())).willReturn(response);
 

--- a/app-api/src/test/java/com/tasteam/domain/subgroup/repository/SubgroupMemberRepositoryTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/subgroup/repository/SubgroupMemberRepositoryTest.java
@@ -50,7 +50,7 @@ class SubgroupMemberRepositoryTest {
 	void findBySubgroupIdAndMember_IdAndDeletedAtIsNull_excludesSoftDeleted() {
 		Member member = memberRepository.save(MemberFixture.create());
 		SubgroupMember subgroupMember = subgroupMemberRepository.save(SubgroupMember.create(200L, member));
-		subgroupMember.softDelete(Instant.now());
+		subgroupMember.softDelete(Instant.parse("2000-01-01T00:00:00Z"));
 		entityManager.flush();
 		entityManager.clear();
 
@@ -64,7 +64,7 @@ class SubgroupMemberRepositoryTest {
 	void findBySubgroupIdAndMember_Id_includesDeleted() {
 		Member member = memberRepository.save(MemberFixture.create());
 		SubgroupMember subgroupMember = subgroupMemberRepository.save(SubgroupMember.create(300L, member));
-		subgroupMember.softDelete(Instant.now());
+		subgroupMember.softDelete(Instant.parse("2000-01-01T00:00:00Z"));
 		entityManager.flush();
 		entityManager.clear();
 

--- a/app-api/src/test/java/com/tasteam/domain/subgroup/service/SubgroupServiceIntegrationTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/subgroup/service/SubgroupServiceIntegrationTest.java
@@ -3,6 +3,7 @@ package com.tasteam.domain.subgroup.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
@@ -222,7 +223,7 @@ class SubgroupFacadeIntegrationTest {
 			SubgroupMember membership = subgroupMemberRepository.save(
 				SubgroupMember.create(openSubgroup.getId(), member2));
 			openSubgroup.increaseMemberCount();
-			membership.softDelete(java.time.Instant.now());
+			membership.softDelete(Instant.parse("2000-01-01T00:00:00Z"));
 			openSubgroup.decreaseMemberCount();
 
 			subgroupFacade.joinSubgroup(group.getId(), openSubgroup.getId(), member2.getId(), null);
@@ -453,7 +454,7 @@ class SubgroupFacadeIntegrationTest {
 			subgroupMemberRepository.save(SubgroupMemberFixture.create(subgroup.getId(), member1));
 			SubgroupMember member2Membership = subgroupMemberRepository.save(
 				SubgroupMemberFixture.create(subgroup.getId(), member2));
-			member2Membership.softDelete(java.time.Instant.now());
+			member2Membership.softDelete(Instant.parse("2000-01-01T00:00:00Z"));
 		}
 
 		@Test

--- a/app-api/src/test/java/com/tasteam/global/security/oauth/service/OAuthLoginServiceIntegrationTest.java
+++ b/app-api/src/test/java/com/tasteam/global/security/oauth/service/OAuthLoginServiceIntegrationTest.java
@@ -156,11 +156,12 @@ class OAuthLoginServiceIntegrationTest {
 			.scope("profile", "email")
 			.clientName("test-client");
 
+		Instant issuedAt = Instant.parse("2099-01-01T00:00:00Z");
 		OAuth2AccessToken accessToken = new OAuth2AccessToken(
 			TokenType.BEARER,
 			"access-token",
-			Instant.now(),
-			Instant.now().plusSeconds(60));
+			issuedAt,
+			issuedAt.plusSeconds(60));
 
 		return new OAuth2UserRequest(builder.build(), accessToken);
 	}

--- a/app-api/src/test/java/com/tasteam/infra/messagequeue/GroupMemberJoinedMessageQueuePublisherTest.java
+++ b/app-api/src/test/java/com/tasteam/infra/messagequeue/GroupMemberJoinedMessageQueuePublisherTest.java
@@ -34,7 +34,7 @@ class GroupMemberJoinedMessageQueuePublisherTest {
 			producer,
 			properties,
 			objectMapper);
-		GroupMemberJoinedEvent event = new GroupMemberJoinedEvent(10L, 20L, "테스트 그룹", Instant.now());
+		GroupMemberJoinedEvent event = new GroupMemberJoinedEvent(10L, 20L, "테스트 그룹", Instant.parse("2000-01-01T00:00:00Z"));
 
 		// when
 		publisher.onGroupMemberJoined(event);
@@ -94,7 +94,7 @@ class GroupMemberJoinedMessageQueuePublisherTest {
 			producer,
 			properties,
 			objectMapper);
-		GroupMemberJoinedEvent event = new GroupMemberJoinedEvent(10L, 20L, "테스트 그룹", Instant.now());
+		GroupMemberJoinedEvent event = new GroupMemberJoinedEvent(10L, 20L, "테스트 그룹", Instant.parse("2000-01-01T00:00:00Z"));
 
 		// when & then
 		assertThatThrownBy(() -> publisher.onGroupMemberJoined(event))

--- a/app-api/src/test/java/com/tasteam/infra/webhook/WebhookErrorEventListenerTest.java
+++ b/app-api/src/test/java/com/tasteam/infra/webhook/WebhookErrorEventListenerTest.java
@@ -86,7 +86,7 @@ class WebhookErrorEventListenerTest {
 		given(webhookClient.isEnabled()).willReturn(true);
 		webhookProperties.getFilters().setMinHttpStatus(400);
 		ErrorOccurredEvent event = errorEvent("BUSINESS", "SOME_ERROR", HttpStatus.BAD_REQUEST);
-		WebhookMessage message = new WebhookMessage("title", "desc", null, null, Instant.now(), null);
+		WebhookMessage message = new WebhookMessage("title", "desc", null, null, Instant.parse("2000-01-01T00:00:00Z"), null);
 		given(businessExceptionTemplate.build(event.context())).willReturn(message);
 
 		listener.onErrorOccurred(event);
@@ -101,7 +101,7 @@ class WebhookErrorEventListenerTest {
 		given(webhookClient.isEnabled()).willReturn(true);
 		webhookProperties.getFilters().setMinHttpStatus(500);
 		ErrorOccurredEvent event = errorEvent("SYSTEM", "INTERNAL_SERVER_ERROR", HttpStatus.INTERNAL_SERVER_ERROR);
-		WebhookMessage message = new WebhookMessage("title", "desc", null, null, Instant.now(), null);
+		WebhookMessage message = new WebhookMessage("title", "desc", null, null, Instant.parse("2000-01-01T00:00:00Z"), null);
 		given(systemExceptionTemplate.build(event.context())).willReturn(message);
 
 		listener.onErrorOccurred(event);
@@ -116,7 +116,7 @@ class WebhookErrorEventListenerTest {
 		given(webhookClient.isEnabled()).willReturn(true);
 		webhookProperties.getFilters().setMinHttpStatus(500);
 		ErrorOccurredEvent event = errorEvent("SYSTEM", "INTERNAL_SERVER_ERROR", HttpStatus.INTERNAL_SERVER_ERROR);
-		WebhookMessage message = new WebhookMessage("title", "desc", null, null, Instant.now(), null);
+		WebhookMessage message = new WebhookMessage("title", "desc", null, null, Instant.parse("2000-01-01T00:00:00Z"), null);
 		given(systemExceptionTemplate.build(event.context())).willReturn(message);
 		willThrow(new RuntimeException("전송 실패")).given(webhookClient).send(message);
 
@@ -127,7 +127,7 @@ class WebhookErrorEventListenerTest {
 	private ErrorOccurredEvent errorEvent(String errorType, String errorCode, HttpStatus httpStatus) {
 		ErrorContext context = new ErrorContext(
 			errorType, errorCode, "테스트 에러 메시지", httpStatus,
-			"GET", "/api/test", "JUnit", Instant.now(), "RuntimeException", null);
+			"GET", "/api/test", "JUnit", Instant.parse("2000-01-01T00:00:00Z"), "RuntimeException", null);
 		return new ErrorOccurredEvent(context);
 	}
 }


### PR DESCRIPTION
## 📌 PR 요약

#### Summary
- 테스트 전반의 시간 의존(`Instant.now`)을 고정 시각 기반으로 정리해 비결정성을 제거했습니다.
- 시간 민감 시나리오(OAuth 토큰, 파일 TTL 정리, 프로모션 상태/조회, 이벤트 매핑)를 절대 시간 구간으로 보정했습니다.
- Member 도메인 테스트에 경계값/부정 시나리오를 추가해 검증 범위를 확장했습니다.

### Issue
- close : #216

---

## ➕ 추가된 기능

1. `MemberTest`에 닉네임/이메일 길이 초과 예외 검증 추가
2. `MemberTest`에 프로필 이미지 URL 변경 성공 케이스 추가

## 🛠️ 수정/변경사항

1. 테스트 코드 전반에서 `Instant.now()` 직접 사용 제거 및 고정 시각 적용
2. 시간 조건이 핵심인 테스트(File TTL, Promotion 상태/조회 등)의 시나리오 의미 보존을 위한 절대 구간 보정
3. 누락 import(`Instant`) 정리로 컴파일 오류 해소
4. 테스트 실행 확인: `./gradlew test` 성공

---

## ✅ 남은 작업

* [ ] CI 확인 후 리뷰 반영
