### PR TITLE
test: MVC 컨트롤러 WebMvc 테스트 전수 작성 (#482)

### DIFF
--- a/app-api/src/main/java/com/tasteam/domain/admin/controller/docs/AdminReportControllerDocs.java
+++ b/app-api/src/main/java/com/tasteam/domain/admin/controller/docs/AdminReportControllerDocs.java
@@ -3,6 +3,7 @@ package com.tasteam.domain.admin.controller.docs;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import com.tasteam.domain.admin.dto.request.AdminReportStatusUpdateRequest;
@@ -16,6 +17,7 @@ import com.tasteam.global.swagger.annotation.SwaggerTagOrder;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 
 @SwaggerTagOrder(140)
 @Tag(name = "Admin - Report", description = "어드민 신고 관리 API")
@@ -38,5 +40,6 @@ public interface AdminReportControllerDocs {
 	void updateStatus(
 		@Parameter(description = "신고 ID", example = "1") @PathVariable
 		Long reportId,
+		@RequestBody @Valid
 		AdminReportStatusUpdateRequest request);
 }

--- a/app-api/src/main/java/com/tasteam/domain/report/controller/docs/ReportControllerDocs.java
+++ b/app-api/src/main/java/com/tasteam/domain/report/controller/docs/ReportControllerDocs.java
@@ -3,6 +3,7 @@ package com.tasteam.domain.report.controller.docs;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
 
 import com.tasteam.domain.report.dto.request.ReportCreateRequest;
 import com.tasteam.domain.report.dto.response.ReportCreateResponse;
@@ -13,6 +14,7 @@ import com.tasteam.global.swagger.annotation.SwaggerTagOrder;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 
 @SwaggerTagOrder(85)
 @Tag(name = "Report", description = "신고/피드백 API")
@@ -20,6 +22,7 @@ public interface ReportControllerDocs {
 
 	@Operation(summary = "신고 접수", description = "카테고리를 선택하고 신고를 접수합니다.")
 	ResponseEntity<SuccessResponse<ReportCreateResponse>> submit(
+		@RequestBody @Valid
 		ReportCreateRequest request,
 		@CurrentUser
 		Long memberId);

--- a/app-api/src/test/java/com/tasteam/domain/admin/controller/AdminAnnouncementControllerTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/admin/controller/AdminAnnouncementControllerTest.java
@@ -1,0 +1,222 @@
+package com.tasteam.domain.admin.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.doNothing;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.tasteam.config.annotation.ControllerWebMvcTest;
+import com.tasteam.domain.admin.dto.request.AdminAnnouncementCreateRequest;
+import com.tasteam.domain.admin.dto.request.AdminAnnouncementUpdateRequest;
+import com.tasteam.domain.admin.dto.response.AdminAnnouncementDetailResponse;
+import com.tasteam.domain.admin.dto.response.AdminAnnouncementListItem;
+import com.tasteam.domain.admin.service.AdminAnnouncementService;
+import com.tasteam.global.exception.business.BusinessException;
+import com.tasteam.global.exception.code.PromotionErrorCode;
+
+@ControllerWebMvcTest(AdminAnnouncementController.class)
+@DisplayName("[유닛](Admin) AdminAnnouncementController 단위 테스트")
+class AdminAnnouncementControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockitoBean
+	private AdminAnnouncementService adminAnnouncementService;
+
+	@Nested
+	@DisplayName("공지사항 목록 조회")
+	class GetAnnouncements {
+
+		@Test
+		@DisplayName("공개 전용 공지사항 목록 조회 시 페이징된 결과를 반환한다")
+		void 공지사항_목록_조회_성공() throws Exception {
+			// given
+			AdminAnnouncementListItem item = new AdminAnnouncementListItem(
+				1L,
+				"점검 안내",
+				Instant.parse("2026-02-01T10:00:00Z"),
+				Instant.parse("2026-02-01T10:10:00Z"));
+			Pageable pageable = PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "createdAt"));
+			Page<AdminAnnouncementListItem> page = new PageImpl<>(List.of(item), pageable, 1);
+			given(adminAnnouncementService.getAnnouncementList(any(Pageable.class))).willReturn(page);
+
+			// when & then
+			mockMvc.perform(get("/api/v1/admin/announcements"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.content").isArray())
+				.andExpect(jsonPath("$.data.content[0].id").value(1))
+				.andExpect(jsonPath("$.data.content[0].title").value("점검 안내"));
+		}
+
+		@Test
+		@DisplayName("페이지 파라미터가 숫자가 아니면 기본값으로 조회를 수행한다")
+		void 공지사항_목록_페이지타입_오류_실패() throws Exception {
+			// when & then
+			mockMvc.perform(get("/api/v1/admin/announcements").param("page", "abc"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true));
+		}
+	}
+
+	@Nested
+	@DisplayName("공지사항 상세 조회")
+	class GetAnnouncement {
+
+		@Test
+		@DisplayName("공지사항 ID로 상세 정보를 조회한다")
+		void 공지사항_상세_조회_성공() throws Exception {
+			// given
+			given(adminAnnouncementService.getAnnouncementDetail(1L)).willReturn(new AdminAnnouncementDetailResponse(
+				1L,
+				"점검 안내",
+				"새벽 2시 점검 예정입니다.",
+				Instant.parse("2026-02-01T10:00:00Z"),
+				Instant.parse("2026-02-01T10:10:00Z")));
+
+			// when & then
+			mockMvc.perform(get("/api/v1/admin/announcements/1"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.id").value(1))
+				.andExpect(jsonPath("$.data.title").value("점검 안내"))
+				.andExpect(jsonPath("$.data.content").value("새벽 2시 점검 예정입니다."));
+		}
+
+		@Test
+		@DisplayName("존재하지 않는 공지사항이면 404로 실패한다")
+		void 공지사항_상세_미존재_실패() throws Exception {
+			// given
+			given(adminAnnouncementService.getAnnouncementDetail(999L))
+				.willThrow(new BusinessException(PromotionErrorCode.ANNOUNCEMENT_NOT_FOUND));
+
+			// when & then
+			mockMvc.perform(get("/api/v1/admin/announcements/999"))
+				.andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.code").value(PromotionErrorCode.ANNOUNCEMENT_NOT_FOUND.name()));
+		}
+	}
+
+	@Nested
+	@DisplayName("공지사항 생성")
+	class CreateAnnouncement {
+
+		@Test
+		@DisplayName("유효한 요청이면 공지사항을 생성하고 ID를 반환한다")
+		void 공지사항_생성_성공() throws Exception {
+			// given
+			var request = new AdminAnnouncementCreateRequest("점검 안내", "서비스 점검이 진행됩니다.");
+			given(adminAnnouncementService.createAnnouncement(request)).willReturn(10L);
+
+			// when & then
+			mockMvc.perform(post("/api/v1/admin/announcements")
+				.contentType(APPLICATION_JSON)
+				.content(com.fasterxml.jackson.databind.json.JsonMapper.builder().build().writeValueAsString(request)))
+				.andExpect(status().isCreated())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data").value(10));
+		}
+
+		@Test
+		@DisplayName("제목 누락이면 400으로 실패한다")
+		void 공지사항_생성_제목_누락_실패() throws Exception {
+			// given
+			String body = "{\"content\":\"내용\"}";
+
+			// when & then
+			mockMvc.perform(post("/api/v1/admin/announcements")
+				.contentType(APPLICATION_JSON)
+				.content(body))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.code").value("INVALID_REQUEST"));
+		}
+	}
+
+	@Nested
+	@DisplayName("공지사항 수정")
+	class UpdateAnnouncement {
+
+		@Test
+		@DisplayName("수정 요청 시 성공적으로 업데이트한다")
+		void 공지사항_수정_성공() throws Exception {
+			// given
+			var request = new AdminAnnouncementUpdateRequest("수정 제목", "수정 내용");
+			doNothing().when(adminAnnouncementService).updateAnnouncement(1L, request);
+
+			// when & then
+			mockMvc.perform(patch("/api/v1/admin/announcements/1")
+				.contentType(APPLICATION_JSON)
+				.content(com.fasterxml.jackson.databind.json.JsonMapper.builder().build().writeValueAsString(request)))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true));
+		}
+
+		@Test
+		@DisplayName("존재하지 않는 공지사항은 수정할 수 없다")
+		void 공지사항_수정_미존재_실패() throws Exception {
+			// given
+			var request = new AdminAnnouncementUpdateRequest("제목", "내용");
+			willThrow(new BusinessException(PromotionErrorCode.ANNOUNCEMENT_NOT_FOUND))
+				.given(adminAnnouncementService)
+				.updateAnnouncement(999L, request);
+			// when & then
+			mockMvc.perform(patch("/api/v1/admin/announcements/999")
+				.contentType(APPLICATION_JSON)
+				.content(com.fasterxml.jackson.databind.json.JsonMapper.builder().build().writeValueAsString(request)))
+				.andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.code").value(PromotionErrorCode.ANNOUNCEMENT_NOT_FOUND.name()));
+		}
+	}
+
+	@Nested
+	@DisplayName("공지사항 삭제")
+	class DeleteAnnouncement {
+
+		@Test
+		@DisplayName("존재하는 공지사항을 삭제하면 본문 없이 204를 반환한다")
+		void 공지사항_삭제_성공() throws Exception {
+			// when & then
+			mockMvc.perform(delete("/api/v1/admin/announcements/1"))
+				.andExpect(status().isNoContent())
+				.andExpect(content().string(""));
+		}
+
+		@Test
+		@DisplayName("존재하지 않는 공지사항 삭제 시 404로 실패한다")
+		void 공지사항_삭제_미존재_실패() throws Exception {
+			// given
+			willThrow(new BusinessException(PromotionErrorCode.ANNOUNCEMENT_NOT_FOUND))
+				.given(adminAnnouncementService)
+				.deleteAnnouncement(999L);
+
+			// when & then
+			mockMvc.perform(delete("/api/v1/admin/announcements/999"))
+				.andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.code").value(PromotionErrorCode.ANNOUNCEMENT_NOT_FOUND.name()));
+		}
+	}
+}

--- a/app-api/src/test/java/com/tasteam/domain/admin/controller/AdminAuthControllerTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/admin/controller/AdminAuthControllerTest.java
@@ -1,0 +1,102 @@
+package com.tasteam.domain.admin.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tasteam.config.annotation.ControllerWebMvcTest;
+import com.tasteam.domain.admin.dto.request.AdminLoginRequest;
+import com.tasteam.global.exception.code.AuthErrorCode;
+import com.tasteam.global.security.jwt.provider.JwtCookieProvider;
+import com.tasteam.global.security.jwt.provider.JwtTokenProvider;
+
+import jakarta.servlet.http.HttpServletResponse;
+
+@TestPropertySource(properties = {
+	"tasteam.admin.username=admin",
+	"tasteam.admin.password=pass1234!"
+})
+@ControllerWebMvcTest(AdminAuthController.class)
+@DisplayName("[유닛](Admin) AdminAuthController 단위 테스트")
+class AdminAuthControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockitoBean
+	private JwtTokenProvider jwtTokenProvider;
+
+	@MockitoBean
+	private JwtCookieProvider jwtCookieProvider;
+
+	@Nested
+	@DisplayName("관리자 로그인")
+	class Login {
+
+		@Test
+		@DisplayName("관리자 계정 정보가 정확하면 토큰을 반환한다")
+		void 로그인_성공() throws Exception {
+			// given
+			var request = new AdminLoginRequest("admin", "pass1234!");
+			given(jwtTokenProvider.generateAccessToken(0L, "ADMIN")).willReturn("access-token");
+			doNothing().when(jwtCookieProvider).addAdminAccessTokenCookie(any(HttpServletResponse.class),
+				eq("access-token"));
+
+			// when & then
+			mockMvc.perform(post("/api/v1/admin/auth/login")
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.accessToken").value("access-token"));
+
+			verify(jwtCookieProvider).addAdminAccessTokenCookie(any(HttpServletResponse.class), eq("access-token"));
+		}
+
+		@Test
+		@DisplayName("필수 필드 누락이면 400으로 실패한다")
+		void 로그인_요청_누락_실패() throws Exception {
+			// given
+			String body = "{\"username\":\"admin\"}";
+
+			// when & then
+			mockMvc.perform(post("/api/v1/admin/auth/login")
+				.contentType(APPLICATION_JSON)
+				.content(body))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.code").value("INVALID_REQUEST"));
+		}
+
+		@Test
+		@DisplayName("관리자 계정 정보가 다르면 401로 실패한다")
+		void 로그인_자격증명_불일치_실패() throws Exception {
+			// given
+			var request = new AdminLoginRequest("admin", "wrong");
+
+			// when & then
+			mockMvc.perform(post("/api/v1/admin/auth/login")
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isUnauthorized())
+				.andExpect(jsonPath("$.code").value(AuthErrorCode.INVALID_ADMIN_CREDENTIALS.name()));
+		}
+	}
+}

--- a/app-api/src/test/java/com/tasteam/domain/admin/controller/AdminDummyControllerTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/admin/controller/AdminDummyControllerTest.java
@@ -1,0 +1,131 @@
+package com.tasteam.domain.admin.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tasteam.batch.dummy.service.DummyDataSeedService;
+import com.tasteam.config.annotation.ControllerWebMvcTest;
+import com.tasteam.domain.admin.dto.request.AdminDummySeedRequest;
+import com.tasteam.domain.admin.dto.response.AdminDataCountResponse;
+import com.tasteam.domain.admin.dto.response.AdminDummySeedResponse;
+
+@ControllerWebMvcTest(AdminDummyController.class)
+@DisplayName("[유닛](Admin) AdminDummyController 단위 테스트")
+class AdminDummyControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockitoBean
+	private DummyDataSeedService dummyDataSeedService;
+
+	@Nested
+	@DisplayName("더미 데이터 생성")
+	class Seed {
+
+		@Test
+		@DisplayName("요청한 양의 수량이 유효하면 더미 생성 결과를 반환한다")
+		void 더미_시드_성공() throws Exception {
+			// given
+			var request = new AdminDummySeedRequest(1, 2, 0, 0, 0, 0, 0);
+			given(dummyDataSeedService.seed(request)).willReturn(new AdminDummySeedResponse(
+				1,
+				2,
+				0,
+				0,
+				0,
+				0,
+				120L));
+
+			// when & then
+			mockMvc.perform(post("/api/v1/admin/dummy/seed")
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.membersInserted").value(1))
+				.andExpect(jsonPath("$.data.restaurantsInserted").value(2));
+		}
+
+		@Test
+		@DisplayName("음수 값이 들어오면 400으로 실패한다")
+		void 더미_시드_음수값_실패() throws Exception {
+			// given
+			var request = new AdminDummySeedRequest(-1, 0, 0, 0, 0, 0, 0);
+
+			// when & then
+			mockMvc.perform(post("/api/v1/admin/dummy/seed")
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.code").value("INVALID_REQUEST"));
+		}
+	}
+
+	@Nested
+	@DisplayName("더미 데이터 카운트")
+	class Count {
+
+		@Test
+		@DisplayName("현재 더미 데이터 집계를 정상 조회한다")
+		void 더미_카운트_성공() throws Exception {
+			// given
+			given(dummyDataSeedService.count()).willReturn(new AdminDataCountResponse(1, 2, 3, 4, 5, 6));
+
+			// when & then
+			mockMvc.perform(get("/api/v1/admin/dummy/count"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.memberCount").value(1))
+				.andExpect(jsonPath("$.data.restaurantCount").value(2))
+				.andExpect(jsonPath("$.data.groupCount").value(3))
+				.andExpect(jsonPath("$.data.subgroupCount").value(4));
+		}
+	}
+
+	@Nested
+	@DisplayName("더미 데이터 삭제")
+	class DeleteDummy {
+
+		@Test
+		@DisplayName("더미 데이터 삭제 시 본문 없이 204를 반환한다")
+		void 더미_삭제_성공() throws Exception {
+			// when & then
+			mockMvc.perform(delete("/api/v1/admin/dummy"))
+				.andExpect(status().isNoContent())
+				.andExpect(content().string(""));
+		}
+
+		@Test
+		@DisplayName("삭제 처리 중 예외가 발생하면 500으로 실패한다")
+		void 더미_삭제_실패() throws Exception {
+			// given
+			willThrow(new RuntimeException("seed cleanup failed"))
+				.given(dummyDataSeedService)
+				.deleteDummyData();
+
+			// when & then
+			mockMvc.perform(delete("/api/v1/admin/dummy"))
+				.andExpect(status().isInternalServerError())
+				.andExpect(jsonPath("$.success").value(false));
+		}
+	}
+}

--- a/app-api/src/test/java/com/tasteam/domain/admin/controller/AdminFoodCategoryControllerTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/admin/controller/AdminFoodCategoryControllerTest.java
@@ -1,0 +1,68 @@
+package com.tasteam.domain.admin.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tasteam.config.annotation.ControllerWebMvcTest;
+import com.tasteam.domain.admin.dto.request.AdminFoodCategoryCreateRequest;
+import com.tasteam.domain.restaurant.service.FoodCategoryService;
+
+@ControllerWebMvcTest(AdminFoodCategoryController.class)
+@DisplayName("[유닛](Admin) AdminFoodCategoryController 단위 테스트")
+class AdminFoodCategoryControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockitoBean
+	private FoodCategoryService foodCategoryService;
+
+	@Nested
+	@DisplayName("음식 카테고리 생성")
+	class CreateFoodCategory {
+
+		@Test
+		@DisplayName("유효한 요청이면 카테고리 ID를 반환한다")
+		void 카테고리_생성_성공() throws Exception {
+			// given
+			var request = new AdminFoodCategoryCreateRequest("한식");
+			given(foodCategoryService.createFoodCategory(request.name())).willReturn(10L);
+
+			// when & then
+			mockMvc.perform(post("/api/v1/admin/food-categories")
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isCreated())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data").value(10));
+		}
+
+		@Test
+		@DisplayName("이름이 비면 400으로 실패한다")
+		void 카테고리_생성_이름_누락_실패() throws Exception {
+			// given
+			var request = new AdminFoodCategoryCreateRequest("");
+
+			// when & then
+			mockMvc.perform(post("/api/v1/admin/food-categories")
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.code").value("INVALID_REQUEST"));
+		}
+	}
+}

--- a/app-api/src/test/java/com/tasteam/domain/admin/controller/AdminGeocodingControllerTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/admin/controller/AdminGeocodingControllerTest.java
@@ -1,0 +1,57 @@
+package com.tasteam.domain.admin.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.tasteam.config.annotation.ControllerWebMvcTest;
+import com.tasteam.domain.restaurant.dto.GeocodingResult;
+import com.tasteam.domain.restaurant.geocoding.NaverGeocodingClient;
+
+@ControllerWebMvcTest(AdminGeocodingController.class)
+@DisplayName("[유닛](Admin) AdminGeocodingController 단위 테스트")
+class AdminGeocodingControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockitoBean
+	private NaverGeocodingClient naverGeocodingClient;
+
+	@Nested
+	@DisplayName("관리자 지오코딩")
+	class Geocode {
+
+		@Test
+		@DisplayName("유효한 주소 문자열이면 위도/경도를 반환한다")
+		void 지오코딩_성공() throws Exception {
+			// given
+			GeocodingResult result = new GeocodingResult("서울특별시", "강남구", "역삼동", "06200", 127.0, 37.5);
+			given(naverGeocodingClient.geocode("서울시 강남구")).willReturn(result);
+
+			// when & then
+			mockMvc.perform(get("/api/v1/admin/geocoding").param("query", "서울시 강남구"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.latitude").value(37.5))
+				.andExpect(jsonPath("$.data.longitude").value(127.0));
+		}
+
+		@Test
+		@DisplayName("필수 쿼리 누락 시 내부 처리 오류로 실패한다")
+		void 지오코딩_쿼리_누락_실패() throws Exception {
+			// when & then
+			mockMvc.perform(get("/api/v1/admin/geocoding"))
+				.andExpect(status().isInternalServerError())
+				.andExpect(jsonPath("$.success").value(false));
+		}
+	}
+}

--- a/app-api/src/test/java/com/tasteam/domain/admin/controller/AdminGroupControllerTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/admin/controller/AdminGroupControllerTest.java
@@ -1,0 +1,124 @@
+package com.tasteam.domain.admin.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tasteam.config.annotation.ControllerWebMvcTest;
+import com.tasteam.domain.admin.dto.request.AdminGroupCreateRequest;
+import com.tasteam.domain.admin.dto.response.AdminGroupListItem;
+import com.tasteam.domain.admin.service.AdminGroupService;
+import com.tasteam.domain.group.type.GroupJoinType;
+import com.tasteam.domain.group.type.GroupType;
+import com.tasteam.fixture.AdminGroupRequestFixture;
+
+@ControllerWebMvcTest(AdminGroupController.class)
+@DisplayName("[유닛](Admin) AdminGroupController 단위 테스트")
+class AdminGroupControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockitoBean
+	private AdminGroupService adminGroupService;
+
+	@Nested
+	@DisplayName("그룹 목록 조회")
+	class GetGroups {
+
+		@Test
+		@DisplayName("그룹 목록 조회 시 페이징된 결과를 반환한다")
+		void 그룹_목록_조회_성공() throws Exception {
+			// given
+			Pageable pageable = PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "createdAt"));
+			Page<AdminGroupListItem> page = new PageImpl<>(List.of(
+				new AdminGroupListItem(
+					1L,
+					"강남동호회",
+					GroupType.UNOFFICIAL,
+					"서울 강남구",
+					GroupJoinType.PASSWORD,
+					null,
+					com.tasteam.domain.group.type.GroupStatus.ACTIVE,
+					null)),
+				pageable,
+				1);
+			given(adminGroupService.getGroups(any(Pageable.class))).willReturn(page);
+
+			// when & then
+			mockMvc.perform(get("/api/v1/admin/groups").param("page", "0").param("size", "20"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.content").isArray())
+				.andExpect(jsonPath("$.data.content[0].id").value(1))
+				.andExpect(jsonPath("$.data.content[0].name").value("강남동호회"));
+		}
+
+		@Test
+		@DisplayName("페이지 파라미터가 숫자가 아니어도 기본값으로 목록을 조회한다")
+		void 그룹_목록_조회_페이지타입_오류_기본값_조회() throws Exception {
+			// when & then
+			mockMvc.perform(get("/api/v1/admin/groups").param("page", "abc"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true));
+		}
+	}
+
+	@Nested
+	@DisplayName("그룹 생성")
+	class CreateGroup {
+
+		@Test
+		@DisplayName("유효한 요청이면 그룹 ID를 반환한다")
+		void 그룹_생성_성공() throws Exception {
+			// given
+			var request = AdminGroupRequestFixture.createRequest();
+			given(adminGroupService.createGroup(any(AdminGroupCreateRequest.class))).willReturn(10L);
+
+			// when & then
+			mockMvc.perform(post("/api/v1/admin/groups")
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isCreated())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data").value(10));
+		}
+
+		@Test
+		@DisplayName("필수 값이 누락되면 400으로 실패한다")
+		void 그룹_생성_필수값_누락_실패() throws Exception {
+			// given
+			var request = new AdminGroupCreateRequest("", null, GroupType.UNOFFICIAL, "", null, GroupJoinType.PASSWORD,
+				null);
+
+			// when & then
+			mockMvc.perform(post("/api/v1/admin/groups")
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.code").value("INVALID_REQUEST"));
+		}
+	}
+}

--- a/app-api/src/test/java/com/tasteam/domain/admin/controller/AdminJobControllerTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/admin/controller/AdminJobControllerTest.java
@@ -1,0 +1,221 @@
+package com.tasteam.domain.admin.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.tasteam.batch.image.optimization.service.ImageOptimizationService;
+import com.tasteam.config.annotation.ControllerWebMvcTest;
+import com.tasteam.domain.file.service.FileService;
+
+@ControllerWebMvcTest(AdminJobController.class)
+@DisplayName("[유닛](Admin) AdminJobController 단위 테스트")
+class AdminJobControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockitoBean
+	private ImageOptimizationService imageOptimizationService;
+
+	@MockitoBean
+	private FileService fileService;
+
+	@Nested
+	@DisplayName("최적화 대상 탐색")
+	class DiscoverOptimizationTargets {
+
+		@Test
+		@DisplayName("대상 탐색이 성공하면 요청 처리 통계를 반환한다")
+		void 최적화_대상탐색_성공() throws Exception {
+			// given
+			given(imageOptimizationService.discoverOptimizationTargets()).willReturn(2);
+
+			// when & then
+			mockMvc.perform(post("/api/v1/admin/jobs/image-optimization/discover"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.jobName").value("image-optimization-discover"))
+				.andExpect(jsonPath("$.data.successCount").value(2));
+		}
+
+		@Test
+		@DisplayName("대상 탐색 중 예외가 발생하면 500으로 실패한다")
+		void 최적화_대상탐색_실패() throws Exception {
+			// given
+			given(imageOptimizationService.discoverOptimizationTargets())
+				.willThrow(new RuntimeException("discover error"));
+
+			// when & then
+			mockMvc.perform(post("/api/v1/admin/jobs/image-optimization/discover"))
+				.andExpect(status().isInternalServerError())
+				.andExpect(jsonPath("$.success").value(false));
+		}
+	}
+
+	@Nested
+	@DisplayName("대기 중인 최적화 작업 조회")
+	class GetPendingOptimizationJobs {
+
+		@Test
+		@DisplayName("대기 중인 작업 목록을 조회하면 빈 목록을 반환한다")
+		void 대기_작업_조회_성공() throws Exception {
+			// given
+			given(imageOptimizationService.findPendingJobs(100)).willReturn(List.of());
+
+			// when & then
+			mockMvc.perform(get("/api/v1/admin/jobs/image-optimization/pending").param("limit", "100"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data").isArray())
+				.andExpect(jsonPath("$.data.length()").value(0));
+		}
+
+		@Test
+		@DisplayName("조회 중 오류가 발생하면 500으로 실패한다")
+		void 대기_작업_조회_실패() throws Exception {
+			// given
+			given(imageOptimizationService.findPendingJobs(100)).willThrow(new RuntimeException("db error"));
+
+			// when & then
+			mockMvc.perform(get("/api/v1/admin/jobs/image-optimization/pending").param("limit", "100"))
+				.andExpect(status().isInternalServerError())
+				.andExpect(jsonPath("$.success").value(false));
+		}
+	}
+
+	@Nested
+	@DisplayName("최적화 배치 실행")
+	class RunOptimization {
+
+		@Test
+		@DisplayName("배치 실행이 성공하면 결과 집계를 반환한다")
+		void 최적화_배치_성공() throws Exception {
+			// given
+			var result = new ImageOptimizationService.OptimizationResult(3, 1, 0);
+			given(imageOptimizationService.processOptimizationBatch(100)).willReturn(result);
+
+			// when & then
+			mockMvc.perform(post("/api/v1/admin/jobs/image-optimization").param("batchSize", "100"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.jobName").value("image-optimization"))
+				.andExpect(jsonPath("$.data.successCount").value(3))
+				.andExpect(jsonPath("$.data.failedCount").value(1));
+		}
+
+		@Test
+		@DisplayName("배치 실행 중 오류가 발생하면 500으로 실패한다")
+		void 최적화_배치_실패() throws Exception {
+			// given
+			given(imageOptimizationService.processOptimizationBatch(100)).willThrow(new RuntimeException("batch fail"));
+
+			// when & then
+			mockMvc.perform(post("/api/v1/admin/jobs/image-optimization").param("batchSize", "100"))
+				.andExpect(status().isInternalServerError())
+				.andExpect(jsonPath("$.success").value(false));
+		}
+	}
+
+	@Nested
+	@DisplayName("최적화 작업 삭제")
+	class DeleteOptimizationJobs {
+
+		@Test
+		@DisplayName("최적화 작업 삭제 시 본문 없이 204를 반환한다")
+		void 최적화_작업_삭제_성공() throws Exception {
+			// when & then
+			mockMvc.perform(delete("/api/v1/admin/jobs/image-optimization"))
+				.andExpect(status().isNoContent())
+				.andExpect(content().string(""));
+		}
+
+		@Test
+		@DisplayName("삭제 로직 실패 시 500으로 실패한다")
+		void 최적화_작업_삭제_실패() throws Exception {
+			// given
+			org.mockito.Mockito.doThrow(new RuntimeException("delete failed")).when(imageOptimizationService)
+				.deleteAllJobs();
+
+			// when & then
+			mockMvc.perform(delete("/api/v1/admin/jobs/image-optimization"))
+				.andExpect(status().isInternalServerError())
+				.andExpect(jsonPath("$.success").value(false));
+		}
+	}
+
+	@Nested
+	@DisplayName("이미지 정리 대기 목록 조회")
+	class GetCleanupPendingImages {
+
+		@Test
+		@DisplayName("정리 대기 이미지 목록을 조회하면 목록을 반환한다")
+		void 정리_이미지_조회_성공() throws Exception {
+			// given
+			given(fileService.findCleanupPendingImages()).willReturn(List.of());
+
+			// when & then
+			mockMvc.perform(get("/api/v1/admin/jobs/image-cleanup/pending"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data").isArray())
+				.andExpect(jsonPath("$.data.length()").value(0));
+		}
+
+		@Test
+		@DisplayName("정리 대상 조회 실패 시 500으로 실패한다")
+		void 정리_이미지_조회_실패() throws Exception {
+			// given
+			given(fileService.findCleanupPendingImages()).willThrow(new RuntimeException("cleanup query fail"));
+
+			// when & then
+			mockMvc.perform(get("/api/v1/admin/jobs/image-cleanup/pending"))
+				.andExpect(status().isInternalServerError())
+				.andExpect(jsonPath("$.success").value(false));
+		}
+	}
+
+	@Nested
+	@DisplayName("이미지 정리 실행")
+	class RunImageCleanup {
+
+		@Test
+		@DisplayName("이미지 정리가 성공하면 처리 개수를 반환한다")
+		void 이미지_정리_성공() throws Exception {
+			// given
+			given(fileService.cleanupPendingDeletedImages()).willReturn(5);
+
+			// when & then
+			mockMvc.perform(post("/api/v1/admin/jobs/image-cleanup"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.jobName").value("image-cleanup"))
+				.andExpect(jsonPath("$.data.successCount").value(5));
+		}
+
+		@Test
+		@DisplayName("이미지 정리 실패 시 500으로 실패한다")
+		void 이미지_정리_실패() throws Exception {
+			// given
+			given(fileService.cleanupPendingDeletedImages()).willThrow(new RuntimeException("cleanup fail"));
+
+			// when & then
+			mockMvc.perform(post("/api/v1/admin/jobs/image-cleanup"))
+				.andExpect(status().isInternalServerError())
+				.andExpect(jsonPath("$.success").value(false));
+		}
+	}
+}

--- a/app-api/src/test/java/com/tasteam/domain/admin/controller/AdminMenuControllerTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/admin/controller/AdminMenuControllerTest.java
@@ -1,0 +1,179 @@
+package com.tasteam.domain.admin.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tasteam.config.annotation.ControllerWebMvcTest;
+import com.tasteam.domain.restaurant.dto.request.MenuBulkCreateRequest;
+import com.tasteam.domain.restaurant.dto.request.MenuCategoryCreateRequest;
+import com.tasteam.domain.restaurant.dto.request.MenuCreateRequest;
+import com.tasteam.domain.restaurant.dto.response.MenuCategoryResponse;
+import com.tasteam.domain.restaurant.dto.response.MenuItemResponse;
+import com.tasteam.domain.restaurant.dto.response.RestaurantMenuResponse;
+import com.tasteam.domain.restaurant.service.MenuService;
+
+@ControllerWebMvcTest(AdminMenuController.class)
+@DisplayName("[유닛](Admin) AdminMenuController 단위 테스트")
+class AdminMenuControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockitoBean
+	private MenuService menuService;
+
+	@Nested
+	@DisplayName("메뉴 조회")
+	class GetMenus {
+
+		@Test
+		@DisplayName("식당 메뉴를 조회하면 카테고리와 메뉴 목록을 반환한다")
+		void 메뉴_조회_성공() throws Exception {
+			// given
+			var response = new RestaurantMenuResponse(1L, List.of(
+				new MenuCategoryResponse(11L, "메인", 0, List.of(
+					new MenuItemResponse(101L, 1L, "된장찌개", "구수한 국물", 9000, null, true, 0)))));
+			given(menuService.getRestaurantMenus(1L, true, false)).willReturn(response);
+
+			// when & then
+			mockMvc.perform(get("/api/v1/admin/restaurants/1/menus"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.restaurantId").value(1))
+				.andExpect(jsonPath("$.data.categories").isArray())
+				.andExpect(jsonPath("$.data.categories[0].id").value(11))
+				.andExpect(jsonPath("$.data.categories[0].menus[0].name").value("된장찌개"));
+		}
+
+		@Test
+		@DisplayName("식당 ID가 숫자가 아니면 400으로 실패한다")
+		void 메뉴_조회_경로변수_유형_실패() throws Exception {
+			// when & then
+			mockMvc.perform(get("/api/v1/admin/restaurants/abc/menus"))
+				.andExpect(status().isBadRequest());
+		}
+	}
+
+	@Nested
+	@DisplayName("메뉴 카테고리 생성")
+	class CreateCategory {
+
+		@Test
+		@DisplayName("유효한 요청이면 메뉴 카테고리 ID를 반환한다")
+		void 메뉴카테고리_생성_성공() throws Exception {
+			// given
+			var request = new MenuCategoryCreateRequest("메인", 0);
+			given(menuService.createMenuCategory(1L, request)).willReturn(10L);
+
+			// when & then
+			mockMvc.perform(post("/api/v1/admin/restaurants/1/menus/categories")
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isCreated())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data").value(10));
+		}
+
+		@Test
+		@DisplayName("이름이 비면 400으로 실패한다")
+		void 메뉴카테고리_생성_이름_누락_실패() throws Exception {
+			// given
+			var request = new MenuCategoryCreateRequest("", 0);
+
+			// when & then
+			mockMvc.perform(post("/api/v1/admin/restaurants/1/menus/categories")
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.code").value("INVALID_REQUEST"));
+		}
+	}
+
+	@Nested
+	@DisplayName("메뉴 생성")
+	class CreateMenu {
+
+		@Test
+		@DisplayName("유효한 요청이면 메뉴 ID를 반환한다")
+		void 메뉴_생성_성공() throws Exception {
+			// given
+			var request = new MenuCreateRequest(1L, "된장찌개", "구수한 된장", 9000, null, null, true, 0);
+			given(menuService.createMenu(1L, request)).willReturn(20L);
+
+			// when & then
+			mockMvc.perform(post("/api/v1/admin/restaurants/1/menus")
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isCreated())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data").value(20));
+		}
+
+		@Test
+		@DisplayName("카테고리 ID가 없으면 400으로 실패한다")
+		void 메뉴_생성_카테고리누락_실패() throws Exception {
+			// given
+			var request = new MenuCreateRequest(null, "된장찌개", "구수한 된장", 9000, null, null, true, 0);
+
+			// when & then
+			mockMvc.perform(post("/api/v1/admin/restaurants/1/menus")
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.code").value("INVALID_REQUEST"));
+		}
+	}
+
+	@Nested
+	@DisplayName("메뉴 일괄 생성")
+	class CreateMenusBulk {
+
+		@Test
+		@DisplayName("유효한 다건 요청이면 성공 응답을 반환한다")
+		void 메뉴_일괄_생성_성공() throws Exception {
+			// given
+			var request = new MenuBulkCreateRequest(List.of(
+				new MenuCreateRequest(1L, "된장찌개", "구수한 된장", 9000, null, null, true, 0),
+				new MenuCreateRequest(1L, "김치찌개", "매운 김치", 8000, null, null, false, 1)));
+			given(menuService.createMenusBulk(1L, request)).willReturn(List.of(30L, 31L));
+
+			// when & then
+			mockMvc.perform(post("/api/v1/admin/restaurants/1/menus/bulk")
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isCreated())
+				.andExpect(jsonPath("$.success").value(true));
+		}
+
+		@Test
+		@DisplayName("메뉴 목록이 비면 400으로 실패한다")
+		void 메뉴_일괄_생성_목록_누락_실패() throws Exception {
+			// given
+			var request = new MenuBulkCreateRequest(List.of());
+
+			// when & then
+			mockMvc.perform(post("/api/v1/admin/restaurants/1/menus/bulk")
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.code").value("INVALID_REQUEST"));
+		}
+	}
+}

--- a/app-api/src/test/java/com/tasteam/domain/admin/controller/AdminPromotionControllerTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/admin/controller/AdminPromotionControllerTest.java
@@ -1,0 +1,294 @@
+package com.tasteam.domain.admin.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.doNothing;
+import static org.mockito.BDDMockito.doThrow;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tasteam.config.annotation.ControllerWebMvcTest;
+import com.tasteam.domain.admin.dto.request.AdminPromotionCreateRequest;
+import com.tasteam.domain.admin.dto.request.AdminPromotionUpdateRequest;
+import com.tasteam.domain.admin.dto.response.AdminPromotionDetailResponse;
+import com.tasteam.domain.admin.dto.response.AdminPromotionListItem;
+import com.tasteam.domain.admin.service.AdminPromotionService;
+import com.tasteam.domain.promotion.entity.DisplayChannel;
+import com.tasteam.domain.promotion.entity.DisplayStatus;
+import com.tasteam.domain.promotion.entity.PromotionStatus;
+import com.tasteam.domain.promotion.entity.PublishStatus;
+import com.tasteam.global.exception.business.BusinessException;
+import com.tasteam.global.exception.code.PromotionErrorCode;
+
+@ControllerWebMvcTest(AdminPromotionController.class)
+@DisplayName("[유닛](Admin) AdminPromotionController 단위 테스트")
+class AdminPromotionControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockitoBean
+	private AdminPromotionService adminPromotionService;
+
+	@Nested
+	@DisplayName("프로모션 목록 조회")
+	class GetPromotions {
+
+		@Test
+		@DisplayName("프로모션 목록을 조회하면 페이징 결과를 반환한다")
+		void 프로모션_목록_조회_성공() throws Exception {
+			// given
+			AdminPromotionListItem item = new AdminPromotionListItem(
+				1L,
+				"신규 가입 이벤트",
+				PromotionStatus.ONGOING,
+				DisplayStatus.DISPLAYING,
+				PublishStatus.PUBLISHED,
+				Instant.parse("2026-02-01T00:00:00Z"),
+				Instant.parse("2026-02-02T00:00:00Z"),
+				DisplayChannel.MAIN_BANNER,
+				"https://cdn.example.com/banner.png",
+				Instant.parse("2026-01-31T00:00:00Z"));
+			Pageable pageable = PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "createdAt"));
+			Page<AdminPromotionListItem> page = new PageImpl<>(List.of(item), pageable, 1);
+			given(adminPromotionService.getPromotionList(any(), any(), any(), any(Pageable.class))).willReturn(page);
+
+			// when & then
+			mockMvc.perform(get("/api/v1/admin/promotions"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.content").isArray())
+				.andExpect(jsonPath("$.data.content[0].id").value(1))
+				.andExpect(jsonPath("$.data.content[0].title").value("신규 가입 이벤트"));
+		}
+
+		@Test
+		@DisplayName("페이지 파라미터가 숫자가 아니어도 기본값으로 조회를 수행한다")
+		void 프로모션_목록_페이지타입_오류_실패() throws Exception {
+			// when & then
+			mockMvc.perform(get("/api/v1/admin/promotions").param("page", "abc"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true));
+		}
+	}
+
+	@Nested
+	@DisplayName("프로모션 상세 조회")
+	class GetPromotion {
+
+		@Test
+		@DisplayName("프로모션 ID로 상세 정보를 조회한다")
+		void 프로모션_상세_조회_성공() throws Exception {
+			// given
+			given(adminPromotionService.getPromotionDetail(1L)).willReturn(new AdminPromotionDetailResponse(
+				1L,
+				"신규 가입 이벤트",
+				"지금 가입하면 쿠폰 지급",
+				"https://example.com/event",
+				Instant.parse("2026-02-01T00:00:00Z"),
+				Instant.parse("2026-03-01T00:00:00Z"),
+				PublishStatus.PUBLISHED,
+				com.tasteam.domain.promotion.entity.PromotionStatus.ONGOING,
+				true,
+				Instant.parse("2026-01-31T00:00:00Z"),
+				Instant.parse("2026-02-01T00:00:00Z"),
+				DisplayChannel.BOTH,
+				1,
+				DisplayStatus.DISPLAYING,
+				"https://cdn.example.com/banner.png",
+				"https://cdn.example.com/splash.png",
+				"배너",
+				List.of("https://cdn.example.com/detail-1.png"),
+				Instant.parse("2026-01-01T00:00:00Z"),
+				Instant.parse("2026-01-02T00:00:00Z")));
+
+			// when & then
+			mockMvc.perform(get("/api/v1/admin/promotions/1"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.id").value(1))
+				.andExpect(jsonPath("$.data.title").value("신규 가입 이벤트"));
+		}
+
+		@Test
+		@DisplayName("프로모션이 없으면 404로 실패한다")
+		void 프로모션_상세_미존재_실패() throws Exception {
+			// given
+			given(adminPromotionService.getPromotionDetail(999L))
+				.willThrow(new BusinessException(PromotionErrorCode.PROMOTION_NOT_FOUND));
+
+			// when & then
+			mockMvc.perform(get("/api/v1/admin/promotions/999"))
+				.andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.code").value(PromotionErrorCode.PROMOTION_NOT_FOUND.name()));
+		}
+	}
+
+	@Nested
+	@DisplayName("프로모션 등록")
+	class CreatePromotion {
+
+		@Test
+		@DisplayName("필수 값을 넣으면 프로모션을 생성하고 ID를 반환한다")
+		void 프로모션_생성_성공() throws Exception {
+			// given
+			var request = new AdminPromotionCreateRequest(
+				"신규 가입 이벤트",
+				"지금 가입하면 혜택",
+				"https://example.com",
+				Instant.parse("2026-02-01T00:00:00Z"),
+				Instant.parse("2026-03-01T00:00:00Z"),
+				PublishStatus.PUBLISHED,
+				true,
+				Instant.parse("2026-02-01T00:00:00Z"),
+				Instant.parse("2026-02-05T00:00:00Z"),
+				DisplayChannel.MAIN_BANNER,
+				1,
+				"https://cdn.example.com/banner.png",
+				"https://cdn.example.com/splash.png",
+				"배너 이미지",
+				List.of("https://cdn.example.com/detail.png"));
+			given(adminPromotionService.createPromotion(request)).willReturn(10L);
+
+			// when & then
+			mockMvc.perform(post("/api/v1/admin/promotions")
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isCreated())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data").value(10));
+		}
+
+		@Test
+		@DisplayName("필수 값이 비면 400으로 실패한다")
+		void 프로모션_생성_필수값_누락_실패() throws Exception {
+			// given
+			String body = "{}";
+
+			// when & then
+			mockMvc.perform(post("/api/v1/admin/promotions")
+				.contentType(APPLICATION_JSON)
+				.content(body))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.code").value("INVALID_REQUEST"));
+		}
+	}
+
+	@Nested
+	@DisplayName("프로모션 수정")
+	class UpdatePromotion {
+
+		@Test
+		@DisplayName("수정 요청이 정상이면 200을 반환한다")
+		void 프로모션_수정_성공() throws Exception {
+			// given
+			var request = new AdminPromotionUpdateRequest(
+				"변경 제목",
+				"변경 내용",
+				null,
+				null,
+				null,
+				null,
+				null,
+				null,
+				null,
+				null,
+				1,
+				null,
+				null,
+				null,
+				null);
+			doNothing().when(adminPromotionService).updatePromotion(1L, request);
+
+			// when & then
+			mockMvc.perform(patch("/api/v1/admin/promotions/1")
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true));
+		}
+
+		@Test
+		@DisplayName("프로모션이 없으면 404로 실패한다")
+		void 프로모션_수정_미존재_실패() throws Exception {
+			// given
+			var request = new AdminPromotionUpdateRequest(
+				null,
+				null,
+				null,
+				null,
+				null,
+				null,
+				null,
+				null,
+				null,
+				null,
+				null,
+				null,
+				null,
+				null,
+				null);
+			doThrow(new BusinessException(PromotionErrorCode.PROMOTION_NOT_FOUND))
+				.when(adminPromotionService).updatePromotion(999L, request);
+
+			// when & then
+			mockMvc.perform(patch("/api/v1/admin/promotions/999")
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.code").value(PromotionErrorCode.PROMOTION_NOT_FOUND.name()));
+		}
+	}
+
+	@Nested
+	@DisplayName("프로모션 삭제")
+	class DeletePromotion {
+
+		@Test
+		@DisplayName("프로모션이 존재하면 204로 삭제 응답을 반환한다")
+		void 프로모션_삭제_성공() throws Exception {
+			// when & then
+			mockMvc.perform(delete("/api/v1/admin/promotions/1"))
+				.andExpect(status().isNoContent())
+				.andExpect(content().string(""));
+		}
+
+		@Test
+		@DisplayName("프로모션이 없으면 404로 실패한다")
+		void 프로모션_삭제_미존재_실패() throws Exception {
+			// given
+			doThrow(new BusinessException(PromotionErrorCode.PROMOTION_NOT_FOUND))
+				.when(adminPromotionService).deletePromotion(999L);
+
+			// when & then
+			mockMvc.perform(delete("/api/v1/admin/promotions/999"))
+				.andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.code").value(PromotionErrorCode.PROMOTION_NOT_FOUND.name()));
+		}
+	}
+}

--- a/app-api/src/test/java/com/tasteam/domain/admin/controller/AdminReportControllerTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/admin/controller/AdminReportControllerTest.java
@@ -1,0 +1,159 @@
+package com.tasteam.domain.admin.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.doNothing;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.tasteam.config.annotation.ControllerWebMvcTest;
+import com.tasteam.domain.admin.dto.request.AdminReportStatusUpdateRequest;
+import com.tasteam.domain.admin.dto.response.AdminReportDetailResponse;
+import com.tasteam.domain.admin.dto.response.AdminReportListItem;
+import com.tasteam.domain.admin.service.AdminReportService;
+import com.tasteam.domain.report.entity.ReportCategory;
+import com.tasteam.domain.report.entity.ReportStatus;
+import com.tasteam.global.exception.business.BusinessException;
+import com.tasteam.global.exception.code.ReportErrorCode;
+
+@ControllerWebMvcTest(AdminReportController.class)
+@DisplayName("[유닛](Admin) AdminReportController 단위 테스트")
+class AdminReportControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockitoBean
+	private AdminReportService adminReportService;
+
+	@Nested
+	@DisplayName("신고 목록 조회")
+	class GetReports {
+
+		@Test
+		@DisplayName("신고 목록을 조회하면 페이징 결과를 반환한다")
+		void 신고_목록_조회_성공() throws Exception {
+			// given
+			AdminReportListItem item = new AdminReportListItem(
+				1L,
+				"사용자A",
+				ReportCategory.BUG,
+				"지도 좌표가 누락되었습니다.",
+				ReportStatus.PENDING,
+				Instant.parse("2026-02-01T10:00:00Z"));
+			Pageable pageable = PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "createdAt"));
+			Page<AdminReportListItem> page = new PageImpl<>(List.of(item), pageable, 1);
+			given(adminReportService.getReports(any(), any(), any())).willReturn(page);
+
+			// when & then
+			mockMvc.perform(get("/api/v1/admin/reports"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.content").isArray())
+				.andExpect(jsonPath("$.data.content[0].id").value(1))
+				.andExpect(jsonPath("$.data.content[0].category").value("BUG"));
+		}
+
+		@Test
+		@DisplayName("페이지 파라미터 타입이 잘못되어도 기본값으로 목록 조회를 성공한다")
+		void 신고_목록_페이지타입_오류_실패() throws Exception {
+			// when & then
+			mockMvc.perform(get("/api/v1/admin/reports").param("page", "abc"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true));
+		}
+	}
+
+	@Nested
+	@DisplayName("신고 상세 조회")
+	class GetReportDetail {
+
+		@Test
+		@DisplayName("신고 ID로 상세 정보를 조회한다")
+		void 신고_상세_조회_성공() throws Exception {
+			// given
+			given(adminReportService.getDetail(1L)).willReturn(new AdminReportDetailResponse(
+				1L,
+				100L,
+				"사용자A",
+				"user@example.com",
+				ReportCategory.BUG,
+				"지도 표시가 틀립니다.",
+				ReportStatus.PENDING,
+				Instant.parse("2026-02-01T10:00:00Z"),
+				Instant.parse("2026-02-01T10:10:00Z")));
+
+			// when & then
+			mockMvc.perform(get("/api/v1/admin/reports/1"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.id").value(1))
+				.andExpect(jsonPath("$.data.status").value("PENDING"));
+		}
+
+		@Test
+		@DisplayName("신고가 없으면 404로 실패한다")
+		void 신고_상세_미존재_실패() throws Exception {
+			// given
+			given(adminReportService.getDetail(999L))
+				.willThrow(new BusinessException(ReportErrorCode.REPORT_NOT_FOUND));
+
+			// when & then
+			mockMvc.perform(get("/api/v1/admin/reports/999"))
+				.andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.code").value(ReportErrorCode.REPORT_NOT_FOUND.name()));
+		}
+	}
+
+	@Nested
+	@DisplayName("신고 처리 상태 변경")
+	class UpdateStatus {
+
+		@Test
+		@DisplayName("신고 처리 상태를 업데이트하면 204를 반환한다")
+		void 신고_상태_변경_성공() throws Exception {
+			// given
+			var request = new AdminReportStatusUpdateRequest(ReportStatus.RESOLVED);
+			doNothing().when(adminReportService).updateStatus(1L, request.status());
+
+			// when & then
+			mockMvc.perform(patch("/api/v1/admin/reports/1/status")
+				.contentType(APPLICATION_JSON)
+				.content("""
+					{"status":"RESOLVED"}
+					"""))
+				.andExpect(status().isNoContent())
+				.andExpect(content().string(""));
+		}
+
+		@Test
+		@DisplayName("요청 바디가 비면 400으로 실패한다")
+		void 신고_상태_변경_요청_누락_실패() throws Exception {
+			// when & then
+			mockMvc.perform(patch("/api/v1/admin/reports/1/status")
+				.contentType(APPLICATION_JSON)
+				.content("{}"))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.code").value("INVALID_REQUEST"));
+		}
+	}
+}

--- a/app-api/src/test/java/com/tasteam/domain/admin/controller/AdminRestaurantControllerTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/admin/controller/AdminRestaurantControllerTest.java
@@ -1,0 +1,246 @@
+package com.tasteam.domain.admin.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.doNothing;
+import static org.mockito.BDDMockito.doThrow;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tasteam.config.annotation.ControllerWebMvcTest;
+import com.tasteam.domain.admin.dto.request.AdminRestaurantCreateRequest;
+import com.tasteam.domain.admin.dto.request.AdminRestaurantSearchCondition;
+import com.tasteam.domain.admin.dto.request.AdminRestaurantUpdateRequest;
+import com.tasteam.domain.admin.dto.response.AdminRestaurantDetailResponse;
+import com.tasteam.domain.admin.dto.response.AdminRestaurantListItem;
+import com.tasteam.domain.admin.service.AdminRestaurantService;
+import com.tasteam.domain.restaurant.dto.response.RestaurantImageDto;
+import com.tasteam.global.exception.business.BusinessException;
+import com.tasteam.global.exception.code.RestaurantErrorCode;
+
+@ControllerWebMvcTest(AdminRestaurantController.class)
+@DisplayName("[유닛](Admin) AdminRestaurantController 단위 테스트")
+class AdminRestaurantControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockitoBean
+	private AdminRestaurantService adminRestaurantService;
+
+	@Nested
+	@DisplayName("음식점 목록 조회")
+	class GetRestaurants {
+
+		@Test
+		@DisplayName("검색 조건으로 음식점 목록을 조회한다")
+		void 음식점_목록_조회_성공() throws Exception {
+			// given
+			var item = new AdminRestaurantListItem(
+				1L,
+				"맛집이야기",
+				"서울 강남구",
+				List.of("한식", "분식"),
+				Instant.parse("2026-02-01T10:00:00Z"),
+				null);
+			Pageable pageable = PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "createdAt"));
+			given(adminRestaurantService.getRestaurants(any(AdminRestaurantSearchCondition.class), any(Pageable.class)))
+				.willReturn(new PageImpl<>(List.of(item), pageable, 1));
+
+			// when & then
+			mockMvc.perform(get("/api/v1/admin/restaurants"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.content").isArray())
+				.andExpect(jsonPath("$.data.content[0].id").value(1))
+				.andExpect(jsonPath("$.data.content[0].name").value("맛집이야기"));
+		}
+
+		@Test
+		@DisplayName("페이지 파라미터가 숫자가 아니어도 기본값으로 목록을 조회한다")
+		void 음식점_목록_페이지타입_오류_실패() throws Exception {
+			// when & then
+			mockMvc.perform(get("/api/v1/admin/restaurants").param("page", "abc"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true));
+		}
+	}
+
+	@Nested
+	@DisplayName("음식점 상세 조회")
+	class GetRestaurant {
+
+		@Test
+		@DisplayName("ID로 음식점 상세 정보를 조회한다")
+		void 음식점_상세_조회_성공() throws Exception {
+			// given
+			var response = new AdminRestaurantDetailResponse(
+				1L,
+				"맛집이야기",
+				"서울 강남구",
+				37.5,
+				127.0,
+				List.of(new AdminRestaurantDetailResponse.FoodCategoryInfo(10L, "한식", null)),
+				List.of(new RestaurantImageDto(100L, "https://cdn.example.com/image.png")),
+				Instant.parse("2026-01-01T10:00:00Z"),
+				Instant.parse("2026-01-02T10:00:00Z"),
+				null);
+			given(adminRestaurantService.getRestaurantDetail(1L)).willReturn(response);
+
+			// when & then
+			mockMvc.perform(get("/api/v1/admin/restaurants/1"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.id").value(1))
+				.andExpect(jsonPath("$.data.name").value("맛집이야기"));
+		}
+
+		@Test
+		@DisplayName("음식점이 없으면 404로 실패한다")
+		void 음식점_상세_미존재_실패() throws Exception {
+			// given
+			given(adminRestaurantService.getRestaurantDetail(999L))
+				.willThrow(new BusinessException(RestaurantErrorCode.RESTAURANT_NOT_FOUND));
+
+			// when & then
+			mockMvc.perform(get("/api/v1/admin/restaurants/999"))
+				.andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.code").value(RestaurantErrorCode.RESTAURANT_NOT_FOUND.name()));
+		}
+	}
+
+	@Nested
+	@DisplayName("음식점 등록")
+	class CreateRestaurant {
+
+		@Test
+		@DisplayName("필수 정보로 음식점을 등록하면 ID를 반환한다")
+		void 음식점_등록_성공() throws Exception {
+			// given
+			var request = new AdminRestaurantCreateRequest(
+				"새 맛집",
+				"서울시 강남구",
+				"02-1234-5678",
+				List.of(1L),
+				List.of(UUID.fromString("6aa5f9e1-6f8f-4e2e-95c6-5f9d5de8e2e1")),
+				List.of());
+			given(adminRestaurantService.createRestaurant(request)).willReturn(10L);
+
+			// when & then
+			mockMvc.perform(post("/api/v1/admin/restaurants")
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isCreated())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data").value(10));
+		}
+
+		@Test
+		@DisplayName("이름이 비면 400으로 실패한다")
+		void 음식점_등록_이름_누락_실패() throws Exception {
+			// given
+			var request = new AdminRestaurantCreateRequest("", "서울시 강남구", null, List.of(), List.of(), List.of());
+
+			// when & then
+			mockMvc.perform(post("/api/v1/admin/restaurants")
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.code").value("INVALID_REQUEST"));
+		}
+	}
+
+	@Nested
+	@DisplayName("음식점 정보 수정")
+	class UpdateRestaurant {
+
+		@Test
+		@DisplayName("수정 요청을 보내면 204를 반환한다")
+		void 음식점_수정_성공() throws Exception {
+			// given
+			var request = new AdminRestaurantUpdateRequest(
+				"수정 맛집",
+				"서울시 서초구",
+				List.of(2L),
+				List.of(UUID.fromString("f2d3e4ad-98f8-4ce2-a1fd-8aafccfd3f6b")));
+			doNothing().when(adminRestaurantService).updateRestaurant(1L, request);
+
+			// when & then
+			mockMvc.perform(patch("/api/v1/admin/restaurants/1")
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isNoContent())
+				.andExpect(content().string(""));
+		}
+
+		@Test
+		@DisplayName("음식점이 없으면 404로 실패한다")
+		void 음식점_수정_미존재_실패() throws Exception {
+			// given
+			var request = new AdminRestaurantUpdateRequest("수정 맛집", null, List.of(), List.of());
+			doThrow(new BusinessException(RestaurantErrorCode.RESTAURANT_NOT_FOUND))
+				.when(adminRestaurantService)
+				.updateRestaurant(999L, request);
+
+			// when & then
+			mockMvc.perform(patch("/api/v1/admin/restaurants/999")
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.code").value(RestaurantErrorCode.RESTAURANT_NOT_FOUND.name()));
+		}
+	}
+
+	@Nested
+	@DisplayName("음식점 삭제")
+	class DeleteRestaurant {
+
+		@Test
+		@DisplayName("음식점 삭제하면 본문 없이 204를 반환한다")
+		void 음식점_삭제_성공() throws Exception {
+			// when & then
+			mockMvc.perform(delete("/api/v1/admin/restaurants/1"))
+				.andExpect(status().isNoContent())
+				.andExpect(content().string(""));
+		}
+
+		@Test
+		@DisplayName("음식점이 없으면 404로 실패한다")
+		void 음식점_삭제_미존재_실패() throws Exception {
+			// given
+			doThrow(new BusinessException(RestaurantErrorCode.RESTAURANT_NOT_FOUND))
+				.when(adminRestaurantService)
+				.deleteRestaurant(999L);
+
+			// when & then
+			mockMvc.perform(delete("/api/v1/admin/restaurants/999"))
+				.andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.code").value(RestaurantErrorCode.RESTAURANT_NOT_FOUND.name()));
+		}
+	}
+}

--- a/app-api/src/test/java/com/tasteam/domain/admin/controller/AdminReviewControllerTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/admin/controller/AdminReviewControllerTest.java
@@ -1,0 +1,113 @@
+package com.tasteam.domain.admin.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.doThrow;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.tasteam.config.annotation.ControllerWebMvcTest;
+import com.tasteam.domain.admin.dto.response.AdminReviewListItem;
+import com.tasteam.domain.admin.service.AdminReviewService;
+import com.tasteam.global.exception.business.BusinessException;
+import com.tasteam.global.exception.code.ReviewErrorCode;
+
+@ControllerWebMvcTest(AdminReviewController.class)
+@DisplayName("[유닛](Admin) AdminReviewController 단위 테스트")
+class AdminReviewControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockitoBean
+	private AdminReviewService adminReviewService;
+
+	@Nested
+	@DisplayName("리뷰 목록 조회")
+	class GetReviews {
+
+		@Test
+		@DisplayName("리뷰 목록을 조회하면 페이지 결과를 반환한다")
+		void 리뷰_목록_조회_성공() throws Exception {
+			// given
+			var item = new AdminReviewListItem(
+				1L,
+				2L,
+				"테스트 식당",
+				10L,
+				"작성자",
+				"좋아요",
+				true,
+				Instant.parse("2026-02-01T09:00:00Z"));
+			Pageable pageable = PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "createdAt"));
+			Page<AdminReviewListItem> reviews = new PageImpl<>(List.of(item), pageable, 1);
+			given(adminReviewService.getReviews(any(), any(Pageable.class))).willReturn(reviews);
+
+			// when & then
+			mockMvc.perform(get("/api/v1/admin/reviews")
+				.param("restaurantId", "2")
+				.param("page", "0")
+				.param("size", "20"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.content").isArray())
+				.andExpect(jsonPath("$.data.content[0].id").value(1))
+				.andExpect(jsonPath("$.data.content[0].restaurantName").value("테스트 식당"));
+		}
+
+		@Test
+		@DisplayName("레스토랑 ID 타입이 잘못되면 400으로 실패한다")
+		void 리뷰_목록_레스토랑_타입_실패() throws Exception {
+			// when & then
+			mockMvc.perform(get("/api/v1/admin/reviews").param("restaurantId", "abc"))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.code").value("INVALID_REQUEST"));
+		}
+	}
+
+	@Nested
+	@DisplayName("리뷰 삭제")
+	class DeleteReview {
+
+		@Test
+		@DisplayName("리뷰가 존재하면 204를 반환한다")
+		void 리뷰_삭제_성공() throws Exception {
+			// when & then
+			mockMvc.perform(delete("/api/v1/admin/reviews/1"))
+				.andExpect(status().isNoContent())
+				.andExpect(content().string(""));
+		}
+
+		@Test
+		@DisplayName("리뷰가 없으면 404로 실패한다")
+		void 리뷰_삭제_미존재_실패() throws Exception {
+			// given
+			doThrow(new BusinessException(ReviewErrorCode.REVIEW_NOT_FOUND))
+				.when(adminReviewService)
+				.deleteReview(999L);
+
+			// when & then
+			mockMvc.perform(delete("/api/v1/admin/reviews/999"))
+				.andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.code").value("REVIEW_NOT_FOUND"));
+		}
+	}
+}

--- a/app-api/src/test/java/com/tasteam/domain/admin/controller/AdminScheduleControllerTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/admin/controller/AdminScheduleControllerTest.java
@@ -1,0 +1,177 @@
+package com.tasteam.domain.admin.controller;
+
+import static org.mockito.BDDMockito.doNothing;
+import static org.mockito.BDDMockito.doThrow;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.tasteam.config.annotation.ControllerWebMvcTest;
+import com.tasteam.domain.restaurant.dto.request.WeeklyScheduleRequest;
+import com.tasteam.domain.restaurant.dto.response.BusinessHourWeekItem;
+import com.tasteam.domain.restaurant.service.RestaurantScheduleService;
+import com.tasteam.domain.restaurant.type.DayOfWeekCode;
+import com.tasteam.domain.restaurant.type.ScheduleSource;
+import com.tasteam.global.exception.business.BusinessException;
+import com.tasteam.global.exception.code.RestaurantErrorCode;
+
+@ControllerWebMvcTest(AdminScheduleController.class)
+@DisplayName("[유닛](Admin) AdminScheduleController 단위 테스트")
+class AdminScheduleControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockitoBean
+	private RestaurantScheduleService restaurantScheduleService;
+
+	@Nested
+	@DisplayName("영업 스케줄 조회")
+	class GetSchedules {
+
+		@Test
+		@DisplayName("음식점 스케줄을 조회하면 주간 스케줄을 반환한다")
+		void 스케줄_조회_성공() throws Exception {
+			// given
+			var item = BusinessHourWeekItem.from(
+				LocalDate.parse("2026-02-01"),
+				DayOfWeekCode.MON,
+				false,
+				LocalTime.parse("09:00"),
+				LocalTime.parse("22:00"),
+				ScheduleSource.WEEKLY,
+				null);
+			given(restaurantScheduleService.getBusinessHoursWeek(1L))
+				.willReturn(List.of(item));
+
+			// when & then
+			mockMvc.perform(get("/api/v1/admin/restaurants/1/schedules"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data").isArray())
+				.andExpect(jsonPath("$.data[0].dayOfWeek").value("MON"))
+				.andExpect(jsonPath("$.data[0].openTime").value("09:00"))
+				.andExpect(jsonPath("$.data[0].source").value("WEEKLY"));
+		}
+
+		@Test
+		@DisplayName("레스토랑 ID가 정수가 아니면 400으로 실패한다")
+		void 스케줄_조회_레스토랑_ID_타입_실패() throws Exception {
+			// when & then
+			mockMvc.perform(get("/api/v1/admin/restaurants/abc/schedules"))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.code").value("INVALID_REQUEST"));
+		}
+
+		@Test
+		@DisplayName("음식점이 없으면 404로 실패한다")
+		void 스케줄_조회_음식점_미존재_실패() throws Exception {
+			// given
+			given(restaurantScheduleService.getBusinessHoursWeek(999L))
+				.willThrow(new BusinessException(RestaurantErrorCode.RESTAURANT_NOT_FOUND));
+
+			// when & then
+			mockMvc.perform(get("/api/v1/admin/restaurants/999/schedules"))
+				.andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.code").value("RESTAURANT_NOT_FOUND"));
+		}
+	}
+
+	@Nested
+	@DisplayName("영업 스케줄 등록")
+	class CreateSchedules {
+
+		@Test
+		@DisplayName("유효한 스케줄 목록이면 생성하고 201을 반환한다")
+		void 스케줄_생성_성공() throws Exception {
+			// given
+			List<WeeklyScheduleRequest> request = List.of(
+				new WeeklyScheduleRequest(
+					1,
+					LocalTime.parse("09:00"),
+					LocalTime.parse("18:00"),
+					false,
+					LocalDate.parse("2026-02-01"),
+					LocalDate.parse("2026-02-07")));
+			doNothing().when(restaurantScheduleService).createWeeklySchedules(1L, request);
+
+			// when & then
+			mockMvc.perform(post("/api/v1/admin/restaurants/1/schedules")
+				.contentType(APPLICATION_JSON)
+				.content("""
+					[
+					  {
+					    "dayOfWeek": 1,
+					    "openTime": "09:00",
+					    "closeTime": "18:00",
+					    "isClosed": false,
+					    "effectiveFrom": "2026-02-01",
+					    "effectiveTo": "2026-02-07"
+					  }
+					]
+					"""))
+				.andExpect(status().isCreated())
+				.andExpect(jsonPath("$.success").value(true));
+		}
+
+		@Test
+		@DisplayName("요청 스키마가 잘못되면 내부 처리 오류로 실패한다")
+		void 스케줄_생성_요청형식_실패() throws Exception {
+			// when & then
+			mockMvc.perform(post("/api/v1/admin/restaurants/1/schedules")
+				.contentType(APPLICATION_JSON)
+				.content("not-json"))
+				.andExpect(status().isInternalServerError())
+				.andExpect(jsonPath("$.success").value(false));
+		}
+
+		@Test
+		@DisplayName("음식점이 없으면 404로 실패한다")
+		void 스케줄_생성_음식점_미존재_실패() throws Exception {
+			// given
+			List<WeeklyScheduleRequest> request = List.of(
+				new WeeklyScheduleRequest(
+					1,
+					LocalTime.parse("09:00"),
+					LocalTime.parse("18:00"),
+					false,
+					LocalDate.parse("2026-02-01"),
+					LocalDate.parse("2026-02-07")));
+			doThrow(new BusinessException(RestaurantErrorCode.RESTAURANT_NOT_FOUND))
+				.when(restaurantScheduleService)
+				.createWeeklySchedules(999L, request);
+
+			// when & then
+			mockMvc.perform(post("/api/v1/admin/restaurants/999/schedules")
+				.contentType(APPLICATION_JSON)
+				.content("""
+					[
+					  {
+					    "dayOfWeek": 1,
+					    "openTime": "09:00",
+					    "closeTime": "18:00",
+					    "isClosed": false,
+					    "effectiveFrom": "2026-02-01",
+					    "effectiveTo": "2026-02-07"
+					  }
+					]
+					"""))
+				.andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.code").value("RESTAURANT_NOT_FOUND"));
+		}
+	}
+}

--- a/app-api/src/test/java/com/tasteam/domain/admin/controller/AdminSpaFallbackControllerTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/admin/controller/AdminSpaFallbackControllerTest.java
@@ -1,0 +1,76 @@
+package com.tasteam.domain.admin.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.forwardedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.tasteam.config.annotation.ControllerWebMvcTest;
+
+@ControllerWebMvcTest(AdminSpaFallbackController.class)
+@DisplayName("[유닛](Admin) AdminSpaFallbackController 단위 테스트")
+class AdminSpaFallbackControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Nested
+	@DisplayName("관리자 SPA 직접 라우팅")
+	class AdminSpaRoutes {
+
+		@Test
+		@DisplayName("루트 경로는 admin/index.html로 포워드한다")
+		void 관리자_루트_경로_포워드() throws Exception {
+			// when & then
+			mockMvc.perform(get("/admin"))
+				.andExpect(status().isOk())
+				.andExpect(forwardedUrl("/admin/index.html"));
+		}
+
+		@Test
+		@DisplayName("admin/ 경로도 admin/index.html로 포워드한다")
+		void 관리자_루트_슬래시_포워드() throws Exception {
+			// when & then
+			mockMvc.perform(get("/admin/"))
+				.andExpect(status().isOk())
+				.andExpect(forwardedUrl("/admin/index.html"));
+		}
+
+		@Test
+		@DisplayName("admin/pages 경로는 admin/index.html로 포워드한다")
+		void 관리자_페이지_경로_포워드() throws Exception {
+			// when & then
+			mockMvc.perform(get("/admin/pages"))
+				.andExpect(status().isOk())
+				.andExpect(forwardedUrl("/admin/index.html"));
+		}
+	}
+
+	@Nested
+	@DisplayName("/admin/pages 하위 경로 포워드")
+	class AdminPageRoutes {
+
+		@Test
+		@DisplayName("admin/pages 이하 경로는 admin/index.html로 포워드한다")
+		void 페이지_하위경로_포워드() throws Exception {
+			// when & then
+			mockMvc.perform(get("/admin/pages/user/list"))
+				.andExpect(status().isOk())
+				.andExpect(forwardedUrl("/admin/index.html"));
+		}
+
+		@Test
+		@DisplayName("admin/pages/index.html도 admin/index.html로 포워드한다")
+		void 페이지_정적파일_포워드() throws Exception {
+			// when & then
+			mockMvc.perform(get("/admin/pages/index.html"))
+				.andExpect(status().isOk())
+				.andExpect(forwardedUrl("/admin/index.html"));
+		}
+	}
+}

--- a/app-api/src/test/java/com/tasteam/domain/analytics/ingest/ClientActivityIngestControllerWebMvcTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/analytics/ingest/ClientActivityIngestControllerWebMvcTest.java
@@ -1,0 +1,103 @@
+package com.tasteam.domain.analytics.ingest;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tasteam.config.annotation.ControllerWebMvcTest;
+import com.tasteam.domain.analytics.ingest.dto.request.ClientActivityEventItemRequest;
+import com.tasteam.domain.analytics.ingest.dto.request.ClientActivityEventsIngestRequest;
+import com.tasteam.global.exception.business.BusinessException;
+import com.tasteam.global.exception.code.AnalyticsErrorCode;
+
+@ControllerWebMvcTest(ClientActivityIngestController.class)
+@DisplayName("[유닛](Analytics) ClientActivityIngestController 단위 테스트")
+class ClientActivityIngestControllerWebMvcTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockitoBean
+	private ClientActivityIngestService clientActivityIngestService;
+
+	@Test
+	@DisplayName("이벤트 수집에 성공하면 수집 건수를 반환한다")
+	void 이벤트_수집_성공() throws Exception {
+		// given
+		ClientActivityEventsIngestRequest request = new ClientActivityEventsIngestRequest(
+			"anon-1",
+			List.of(new ClientActivityEventItemRequest(
+				"evt-1",
+				"ui.restaurant.viewed",
+				"v1",
+				Instant.parse("2026-02-01T12:00:00Z"),
+				Map.of("source", "mobile"))));
+		given(clientActivityIngestService.ingest(anyLong(), anyString(), any()))
+			.willReturn(1);
+
+		// when & then
+		mockMvc.perform(post("/api/v1/analytics/events")
+			.header("X-Anonymous-Id", "header-anon")
+			.contentType(APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.acceptedCount").value(1));
+	}
+
+	@Test
+	@DisplayName("이벤트가 비어 있으면 400으로 실패한다")
+	void 이벤트_수집_빈요청_실패() throws Exception {
+		// given
+		ClientActivityEventsIngestRequest request = new ClientActivityEventsIngestRequest("anon-1", List.of());
+
+		// when & then
+		mockMvc.perform(post("/api/v1/analytics/events")
+			.contentType(APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("INVALID_REQUEST"));
+	}
+
+	@Test
+	@DisplayName("수집 제한을 초과하면 429로 실패한다")
+	void 이벤트_수집_레이트리밋_실패() throws Exception {
+		// given
+		ClientActivityEventsIngestRequest request = new ClientActivityEventsIngestRequest(
+			"anon-1",
+			List.of(new ClientActivityEventItemRequest(
+				"evt-1",
+				"ui.restaurant.viewed",
+				"v1",
+				Instant.parse("2026-02-01T12:00:00Z"),
+				Map.of("source", "mobile"))));
+		given(clientActivityIngestService.ingest(anyLong(), anyString(), any()))
+			.willThrow(new BusinessException(AnalyticsErrorCode.ANALYTICS_INGEST_RATE_LIMIT_EXCEEDED));
+
+		// when & then
+		mockMvc.perform(post("/api/v1/analytics/events")
+			.contentType(APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isTooManyRequests())
+			.andExpect(jsonPath("$.code").value("ANALYTICS_INGEST_RATE_LIMIT_EXCEEDED"));
+	}
+}

--- a/app-api/src/test/java/com/tasteam/domain/auth/controller/LocalAuthControllerTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/auth/controller/LocalAuthControllerTest.java
@@ -1,0 +1,107 @@
+package com.tasteam.domain.auth.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tasteam.config.annotation.ControllerWebMvcTest;
+import com.tasteam.domain.auth.dto.request.LocalAuthTokenRequest;
+import com.tasteam.domain.auth.service.LocalAuthTokenService;
+import com.tasteam.global.security.jwt.provider.JwtCookieProvider;
+import com.tasteam.infra.ai.AiClient;
+
+@ActiveProfiles("local")
+@ControllerWebMvcTest(LocalAuthController.class)
+@DisplayName("[유닛](Auth) LocalAuthController 단위 테스트")
+class LocalAuthControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockitoBean
+	private LocalAuthTokenService localAuthTokenService;
+
+	@MockitoBean
+	private JwtCookieProvider jwtCookieProvider;
+
+	@MockitoBean
+	private AiClient aiClient;
+
+	@Nested
+	@DisplayName("로컬 토큰 발급")
+	class IssueLocalToken {
+
+		@Test
+		@DisplayName("유효한 요청이면 로컬 토큰을 발급하고 200을 반환한다")
+		void 로컬_토큰_발급_성공() throws Exception {
+			// given
+			var request = new LocalAuthTokenRequest("dev@example.com", "개발자");
+			given(localAuthTokenService.issueTokens(request.email(), request.nickname()))
+				.willReturn(new LocalAuthTokenService.TokenPair("access-token", "refresh-token", 1L));
+
+			// when & then
+			mockMvc.perform(post("/api/v1/auth/token")
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.accessToken").value("access-token"))
+				.andExpect(jsonPath("$.data.memberId").value(1));
+		}
+
+		@Test
+		@DisplayName("이메일 형식이 잘못되면 400으로 실패한다")
+		void 로컬_토큰_발급_잘못된_이메일_실패() throws Exception {
+			// given
+			var request = new LocalAuthTokenRequest("invalid-email", "개발자");
+
+			// when & then
+			mockMvc.perform(post("/api/v1/auth/token")
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.code").value("INVALID_REQUEST"));
+		}
+	}
+
+	@Nested
+	@DisplayName("AI 헬스체크")
+	class CheckAiHealth {
+
+		@Test
+		@DisplayName("AI 헬스체크가 성공하면 success 응답을 반환한다")
+		void ai_헬스체크_성공() throws Exception {
+			// given
+			// when & then
+			mockMvc.perform(post("/api/v1/auth/ai/health"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true));
+		}
+
+		@Test
+		@DisplayName("AI 헬스체크가 실패하면 500으로 실패한다")
+		void ai_헬스체크_실패() throws Exception {
+			// given
+			var failure = new RuntimeException("ai is down");
+			org.mockito.BDDMockito.willThrow(failure).given(aiClient).healthCheck();
+
+			// when & then
+			mockMvc.perform(post("/api/v1/auth/ai/health"))
+				.andExpect(status().isInternalServerError());
+		}
+	}
+}

--- a/app-api/src/test/java/com/tasteam/domain/auth/controller/TestAuthControllerTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/auth/controller/TestAuthControllerTest.java
@@ -1,0 +1,90 @@
+package com.tasteam.domain.auth.controller;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tasteam.config.annotation.ControllerWebMvcTest;
+import com.tasteam.domain.auth.dto.request.TestAuthTokenRequest;
+import com.tasteam.domain.auth.service.TestAuthTokenService;
+import com.tasteam.global.exception.business.BusinessException;
+import com.tasteam.global.exception.code.MemberErrorCode;
+import com.tasteam.global.security.jwt.provider.JwtCookieProvider;
+
+@ActiveProfiles("test")
+@ControllerWebMvcTest(TestAuthController.class)
+@DisplayName("[유닛](Auth) TestAuthController 단위 테스트")
+class TestAuthControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockitoBean
+	private TestAuthTokenService testAuthTokenService;
+
+	@MockitoBean
+	private JwtCookieProvider jwtCookieProvider;
+
+	@Test
+	@DisplayName("테스트 사용자 토큰 발급이 성공하면 액세스 토큰을 반환한다")
+	void 테스트_토큰_발급_성공() throws Exception {
+		// given
+		var request = new TestAuthTokenRequest("test-user-001", "부하테스트계정");
+		given(testAuthTokenService.issueTokens(request.identifier(), request.nickname()))
+			.willReturn(new TestAuthTokenService.TestTokenResult("access-token", "refresh-token", 7L, true));
+
+		// when & then
+		mockMvc.perform(post("/api/v1/auth/token/test")
+			.contentType(APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.accessToken").value("access-token"))
+			.andExpect(jsonPath("$.data.memberId").value(7))
+			.andExpect(jsonPath("$.data.isNew").value(true));
+	}
+
+	@Test
+	@DisplayName("식별자가 비면 400으로 실패한다")
+	void 테스트_토큰_발급_식별자_누락_실패() throws Exception {
+		// given
+		var request = new TestAuthTokenRequest("", "");
+
+		// when & then
+		mockMvc.perform(post("/api/v1/auth/token/test")
+			.contentType(APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("INVALID_REQUEST"));
+	}
+
+	@Test
+	@DisplayName("회원을 찾을 수 없으면 404으로 실패한다")
+	void 테스트_토큰_발급_회원_없음_실패() throws Exception {
+		// given
+		var request = new TestAuthTokenRequest("missing-user", "부하테스트계정");
+		given(testAuthTokenService.issueTokens(anyString(), anyString()))
+			.willThrow(new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+		// when & then
+		mockMvc.perform(post("/api/v1/auth/token/test")
+			.contentType(APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.code").value("MEMBER_NOT_FOUND"));
+	}
+}

--- a/app-api/src/test/java/com/tasteam/domain/chat/controller/ChatControllerTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/chat/controller/ChatControllerTest.java
@@ -1,0 +1,212 @@
+package com.tasteam.domain.chat.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tasteam.config.annotation.ControllerWebMvcTest;
+import com.tasteam.domain.chat.dto.request.ChatMessageSendRequest;
+import com.tasteam.domain.chat.dto.request.ChatReadCursorUpdateRequest;
+import com.tasteam.domain.chat.dto.response.ChatMessageFileItemResponse;
+import com.tasteam.domain.chat.dto.response.ChatMessageItemResponse;
+import com.tasteam.domain.chat.dto.response.ChatMessageListResponse;
+import com.tasteam.domain.chat.dto.response.ChatMessageSendResponse;
+import com.tasteam.domain.chat.dto.response.ChatReadCursorUpdateResponse;
+import com.tasteam.domain.chat.service.ChatService;
+import com.tasteam.domain.chat.type.ChatMessageFileType;
+import com.tasteam.domain.chat.type.ChatMessageListMode;
+import com.tasteam.domain.chat.type.ChatMessageType;
+import com.tasteam.global.exception.business.BusinessException;
+import com.tasteam.global.exception.code.ChatErrorCode;
+
+@ControllerWebMvcTest(ChatController.class)
+@DisplayName("[유닛](Chat) ChatController 단위 테스트")
+class ChatControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockitoBean
+	private ChatService chatService;
+
+	@Nested
+	@DisplayName("채팅 메시지 목록 조회")
+	class GetMessages {
+
+		@Test
+		@DisplayName("채팅방 메시지를 조회하면 메시지 목록을 반환한다")
+		void 채팅_메시지_목록_조회_성공() throws Exception {
+			// given
+			var item = new ChatMessageItemResponse(
+				10L,
+				20L,
+				"보내는이",
+				"https://example.com/profile.jpg",
+				"안녕하세요",
+				ChatMessageType.TEXT,
+				List.of(new ChatMessageFileItemResponse(ChatMessageFileType.IMAGE, "https://example.com/image.png")),
+				Instant.parse("2026-02-01T10:00:00Z"));
+			var response = new ChatMessageListResponse(
+				new ChatMessageListResponse.Meta(5L),
+				List.of(item),
+				new ChatMessageListResponse.Page("next-cursor", "after-cursor", 20, false));
+			given(chatService.getMessages(anyLong(), anyLong(), any(), any(), any())).willReturn(response);
+
+			// when & then
+			mockMvc.perform(get("/api/v1/chat-rooms/{chatRoomId}/messages", 1L)
+				.param("size", "20")
+				.param("cursor", "cursor-1")
+				.param("mode", ChatMessageListMode.BEFORE.name()))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.meta.lastReadMessageId").value(5))
+				.andExpect(jsonPath("$.data.data[0].id").value(10))
+				.andExpect(jsonPath("$.data.data[0].messageType").value("TEXT"))
+				.andExpect(jsonPath("$.data.page.nextCursor").value("next-cursor"));
+		}
+
+		@Test
+		@DisplayName("사이즈가 범위를 벗어나면 내부 처리 오류로 실패한다")
+		void 채팅_메시지_조회_사이즈_범위_오류_실패() throws Exception {
+			// when & then
+			mockMvc.perform(get("/api/v1/chat-rooms/{chatRoomId}/messages", 1L)
+				.param("size", "0"))
+				.andExpect(status().isInternalServerError())
+				.andExpect(jsonPath("$.success").value(false));
+		}
+
+		@Test
+		@DisplayName("채팅방이 존재하지 않으면 404로 실패한다")
+		void 채팅_메시지_조회_채팅방_없음_실패() throws Exception {
+			// given
+			given(chatService.getMessages(anyLong(), anyLong(), any(), any(), any()))
+				.willThrow(new BusinessException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
+
+			// when & then
+			mockMvc.perform(get("/api/v1/chat-rooms/{chatRoomId}/messages", 1L))
+				.andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.code").value("CHAT_ROOM_NOT_FOUND"));
+		}
+	}
+
+	@Nested
+	@DisplayName("채팅 메시지 전송")
+	class SendMessage {
+
+		@Test
+		@DisplayName("메시지를 전송하면 메시지 정보를 반환한다")
+		void 채팅_메시지_전송_성공() throws Exception {
+			// given
+			var request = new ChatMessageSendRequest(ChatMessageType.TEXT, "안녕하세요", List.of());
+			var response = new ChatMessageSendResponse(
+				new ChatMessageItemResponse(
+					100L,
+					2L,
+					"보낸이",
+					"https://example.com/avatar.jpg",
+					"안녕하세요",
+					ChatMessageType.TEXT,
+					List.of(),
+					Instant.parse("2026-02-01T11:00:00Z")));
+			given(chatService.sendMessage(anyLong(), anyLong(), any(ChatMessageSendRequest.class)))
+				.willReturn(response);
+
+			// when & then
+			mockMvc.perform(post("/api/v1/chat-rooms/{chatRoomId}/messages", 1L)
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isCreated())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.data.id").value(100))
+				.andExpect(jsonPath("$.data.data.content").value("안녕하세요"));
+		}
+
+		@Test
+		@DisplayName("채팅방 ID가 음수면 내부 처리 오류로 실패한다")
+		void 채팅_메시지_전송_방식_아이디_오류_실패() throws Exception {
+			// given
+			var request = new ChatMessageSendRequest(ChatMessageType.TEXT, "안녕하세요", List.of());
+
+			// when & then
+			mockMvc.perform(post("/api/v1/chat-rooms/{chatRoomId}/messages", -1L)
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isInternalServerError())
+				.andExpect(jsonPath("$.success").value(false));
+		}
+
+		@Test
+		@DisplayName("채팅방이 존재하지 않으면 404로 실패한다")
+		void 채팅_메시지_전송_채팅방_없음_실패() throws Exception {
+			// given
+			var request = new ChatMessageSendRequest(ChatMessageType.TEXT, "안녕하세요", List.of());
+			given(chatService.sendMessage(anyLong(), anyLong(), any(ChatMessageSendRequest.class)))
+				.willThrow(new BusinessException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
+
+			// when & then
+			mockMvc.perform(post("/api/v1/chat-rooms/{chatRoomId}/messages", 1L)
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.code").value("CHAT_ROOM_NOT_FOUND"));
+		}
+	}
+
+	@Nested
+	@DisplayName("채팅 읽음 포인터 업데이트")
+	class UpdateReadCursor {
+
+		@Test
+		@DisplayName("읽음 포인터를 갱신하면 최신 포인트 정보를 반환한다")
+		void 채팅_읽음포인터_업데이트_성공() throws Exception {
+			// given
+			var request = new ChatReadCursorUpdateRequest(30L);
+			var response = new ChatReadCursorUpdateResponse(1L, 1L, 30L, Instant.parse("2026-02-01T11:30:00Z"));
+			given(chatService.updateReadCursor(anyLong(), anyLong(), any(ChatReadCursorUpdateRequest.class)))
+				.willReturn(response);
+
+			// when & then
+			mockMvc.perform(patch("/api/v1/chat-rooms/{chatRoomId}/read-cursor", 1L)
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.lastReadMessageId").value(30))
+				.andExpect(jsonPath("$.data.roomId").value(1));
+		}
+
+		@Test
+		@DisplayName("읽음 메시지 ID가 올바르지 않으면 400으로 실패한다")
+		void 채팅_읽음포인터_메시지_ID_오류_실패() throws Exception {
+			// given
+			var request = new ChatReadCursorUpdateRequest(0L);
+
+			// when & then
+			mockMvc.perform(patch("/api/v1/chat-rooms/{chatRoomId}/read-cursor", 1L)
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.code").value("INVALID_REQUEST"));
+		}
+	}
+}

--- a/app-api/src/test/java/com/tasteam/domain/location/controller/GeocodeControllerTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/location/controller/GeocodeControllerTest.java
@@ -1,0 +1,55 @@
+package com.tasteam.domain.location.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.tasteam.config.annotation.ControllerWebMvcTest;
+import com.tasteam.domain.location.dto.response.ReverseGeocodeResponse;
+import com.tasteam.domain.location.service.GeocodeService;
+
+@ControllerWebMvcTest(GeocodeController.class)
+@DisplayName("[유닛](Location) GeocodeController 단위 테스트")
+class GeocodeControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockitoBean
+	private GeocodeService geocodeService;
+
+	@Test
+	@DisplayName("역지오코딩 요청에 대해 주소 결과를 반환한다")
+	void 역지오코딩_성공() throws Exception {
+		// given
+		given(geocodeService.reverseGeocode(37.5, 127.0))
+			.willReturn(new ReverseGeocodeResponse("서울특별시 강남구 역삼동", "강남구"));
+
+		// when & then
+		mockMvc.perform(get("/api/v1/geocode/reverse")
+			.param("lat", "37.5")
+			.param("lon", "127.0"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.address").value("서울특별시 강남구 역삼동"))
+			.andExpect(jsonPath("$.data.district").value("강남구"));
+	}
+
+	@Test
+	@DisplayName("위도 값 타입이 잘못되면 400으로 실패한다")
+	void 역지오코딩_위도타입_오류_실패() throws Exception {
+		// when & then
+		mockMvc.perform(get("/api/v1/geocode/reverse")
+			.param("lat", "abc")
+			.param("lon", "127.0"))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("INVALID_REQUEST"));
+	}
+}

--- a/app-api/src/test/java/com/tasteam/domain/notification/controller/AdminNotificationControllerTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/notification/controller/AdminNotificationControllerTest.java
@@ -1,0 +1,176 @@
+package com.tasteam.domain.notification.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tasteam.config.annotation.ControllerWebMvcTest;
+import com.tasteam.domain.notification.dto.request.AdminBroadcastEmailRequest;
+import com.tasteam.domain.notification.dto.request.AdminBroadcastPushRequest;
+import com.tasteam.domain.notification.dto.request.AdminPushNotificationRequest;
+import com.tasteam.domain.notification.dto.response.AdminBroadcastResultResponse;
+import com.tasteam.domain.notification.dto.response.AdminPushNotificationResponse;
+import com.tasteam.domain.notification.entity.NotificationType;
+import com.tasteam.domain.notification.service.FcmPushService;
+import com.tasteam.domain.notification.service.NotificationBroadcastService;
+
+@ControllerWebMvcTest(AdminNotificationController.class)
+@DisplayName("[유닛](Notification) AdminNotificationController 단위 테스트")
+class AdminNotificationControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockitoBean
+	private FcmPushService fcmPushService;
+
+	@MockitoBean
+	private NotificationBroadcastService notificationBroadcastService;
+
+	@Nested
+	@DisplayName("테스트 푸시 발송")
+	class SendTestPush {
+
+		@Test
+		@DisplayName("유효한 요청이면 푸시 발송 결과를 반환한다")
+		void 테스트푸시_성공() throws Exception {
+			// given
+			var request = new AdminPushNotificationRequest(
+				1L,
+				"테스트 제목",
+				"테스트 메시지",
+				"https://example.com/deeplink");
+			given(fcmPushService.sendToMember(request.memberId(), request.title(), request.body(), request.deepLink()))
+				.willReturn(new AdminPushNotificationResponse(2, 0, 0));
+
+			// when & then
+			mockMvc.perform(post("/api/v1/admin/notifications/push/test")
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.successCount").value(2))
+				.andExpect(jsonPath("$.data.failureCount").value(0))
+				.andExpect(jsonPath("$.data.invalidTokenCount").value(0));
+		}
+
+		@Test
+		@DisplayName("필수 필드 누락이면 400으로 실패한다")
+		void 테스트푸시_요청값_누락_실패() throws Exception {
+			// given
+			String body = "{}";
+
+			// when & then
+			mockMvc.perform(post("/api/v1/admin/notifications/push/test")
+				.contentType(APPLICATION_JSON)
+				.content(body))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.code").value("INVALID_REQUEST"));
+		}
+	}
+
+	@Nested
+	@DisplayName("푸시 브로드캐스트 발송")
+	class BroadcastPush {
+
+		@Test
+		@DisplayName("유효한 요청이면 브로드캐스트 푸시 결과를 반환한다")
+		void 푸시브로드캐스트_성공() throws Exception {
+			// given
+			var request = new AdminBroadcastPushRequest(
+				NotificationType.NOTICE,
+				"공지",
+				"새로운 공지사항이 등록되었습니다.",
+				"https://example.com/notice");
+			given(notificationBroadcastService.broadcastPush(
+				request.notificationType(),
+				request.title(),
+				request.body(),
+				request.deepLink())).willReturn(new AdminBroadcastResultResponse(2, 2, 0, 0));
+
+			// when & then
+			mockMvc.perform(post("/api/v1/admin/notifications/push/broadcast")
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.totalTargets").value(2))
+				.andExpect(jsonPath("$.data.successCount").value(2))
+				.andExpect(jsonPath("$.data.failureCount").value(0))
+				.andExpect(jsonPath("$.data.skippedCount").value(0));
+		}
+
+		@Test
+		@DisplayName("알림 타입이 잘못되면 내부 처리 오류로 실패한다")
+		void 푸시브로드캐스트_잘못된_요청_실패() throws Exception {
+			// given
+			String body = "{\"notificationType\":\"INVALID\",\"title\":\"공지\",\"body\":\"본문\"}";
+
+			// when & then
+			mockMvc.perform(post("/api/v1/admin/notifications/push/broadcast")
+				.contentType(APPLICATION_JSON)
+				.content(body))
+				.andExpect(status().isInternalServerError())
+				.andExpect(jsonPath("$.success").value(false));
+		}
+	}
+
+	@Nested
+	@DisplayName("이메일 브로드캐스트 발송")
+	class BroadcastEmail {
+
+		@Test
+		@DisplayName("유효한 요청이면 브로드캐스트 이메일 결과를 반환한다")
+		void 이메일브로드캐스트_성공() throws Exception {
+			// given
+			var request = new AdminBroadcastEmailRequest(
+				NotificationType.NOTICE,
+				"notice-template",
+				Map.of("name", "테스트"));
+			given(notificationBroadcastService.broadcastEmail(
+				request.notificationType(),
+				request.templateKey(),
+				request.variables())).willReturn(new AdminBroadcastResultResponse(1, 1, 0, 0));
+
+			// when & then
+			mockMvc.perform(post("/api/v1/admin/notifications/email/broadcast")
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.totalTargets").value(1))
+				.andExpect(jsonPath("$.data.successCount").value(1))
+				.andExpect(jsonPath("$.data.failureCount").value(0))
+				.andExpect(jsonPath("$.data.skippedCount").value(0));
+		}
+
+		@Test
+		@DisplayName("필수 값 누락이면 400으로 실패한다")
+		void 이메일브로드캐스트_요청값_누락_실패() throws Exception {
+			// given
+			String body = "{}";
+
+			// when & then
+			mockMvc.perform(post("/api/v1/admin/notifications/email/broadcast")
+				.contentType(APPLICATION_JSON)
+				.content(body))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.code").value("INVALID_REQUEST"));
+		}
+	}
+}

--- a/app-api/src/test/java/com/tasteam/domain/report/controller/ReportControllerTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/report/controller/ReportControllerTest.java
@@ -1,0 +1,140 @@
+package com.tasteam.domain.report.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tasteam.config.annotation.ControllerWebMvcTest;
+import com.tasteam.domain.report.dto.request.ReportCreateRequest;
+import com.tasteam.domain.report.dto.response.ReportCreateResponse;
+import com.tasteam.domain.report.dto.response.ReportListItem;
+import com.tasteam.domain.report.entity.ReportCategory;
+import com.tasteam.domain.report.entity.ReportStatus;
+import com.tasteam.domain.report.service.ReportService;
+import com.tasteam.global.exception.business.BusinessException;
+import com.tasteam.global.exception.code.MemberErrorCode;
+
+@ControllerWebMvcTest(ReportController.class)
+@DisplayName("[유닛](Report) ReportController 단위 테스트")
+class ReportControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockitoBean
+	private ReportService reportService;
+
+	@Nested
+	@DisplayName("신고 등록")
+	class Submit {
+
+		@Test
+		@DisplayName("신고를 등록하면 신고 정보가 생성되고 201을 반환한다")
+		void 신고_등록_성공() throws Exception {
+			// given
+			var request = new ReportCreateRequest(ReportCategory.BUG, "지도 위치가 잘못됨");
+			given(reportService.submit(anyLong(), any(ReportCreateRequest.class)))
+				.willReturn(new ReportCreateResponse(100L, Instant.parse("2026-02-01T10:00:00Z")));
+
+			// when & then
+			mockMvc.perform(post("/api/v1/reports")
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isCreated())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.id").value(100))
+				.andExpect(jsonPath("$.data.createdAt").value("2026-02-01T10:00:00Z"));
+		}
+
+		@Test
+		@DisplayName("카테고리가 없으면 400으로 요청 실패한다")
+		void 신고_카테고리_미입력시_400() throws Exception {
+			// given
+			String body = "{}";
+
+			// when & then
+			mockMvc.perform(post("/api/v1/reports")
+				.contentType(APPLICATION_JSON)
+				.content(body))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.code").value("INVALID_REQUEST"));
+		}
+
+		@Test
+		@DisplayName("회원 정보를 찾을 수 없으면 404로 실패한다")
+		void 신고_등록_사용자_없음시_실패() throws Exception {
+			// given
+			var request = new ReportCreateRequest(ReportCategory.BUG, "오류 신고");
+			given(reportService.submit(anyLong(), any()))
+				.willThrow(new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+			// when & then
+			mockMvc.perform(post("/api/v1/reports")
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.code").value("MEMBER_NOT_FOUND"));
+		}
+	}
+
+	@Nested
+	@DisplayName("내 신고 목록 조회")
+	class GetMyReports {
+
+		@Test
+		@DisplayName("신고 목록을 조회하면 페이징된 결과를 반환한다")
+		void 내_신고_목록_조회_성공() throws Exception {
+			// given
+			var item = new ReportListItem(
+				101L,
+				ReportCategory.BUG,
+				"지도 좌표 누락",
+				ReportStatus.PENDING,
+				Instant.parse("2026-02-01T10:10:00Z"));
+			Pageable pageable = PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "createdAt"));
+			given(reportService.getMyReports(anyLong(), any()))
+				.willReturn(new PageImpl<>(List.of(item), pageable, 1));
+
+			// when & then
+			mockMvc.perform(get("/api/v1/reports/me"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.content").isArray())
+				.andExpect(jsonPath("$.data.content[0].id").value(101))
+				.andExpect(jsonPath("$.data.content[0].category").value("BUG"))
+				.andExpect(jsonPath("$.data.content[0].status").value("PENDING"));
+		}
+
+		@Test
+		@DisplayName("페이지 파라미터가 숫자가 아니어도 기본값으로 목록을 조회한다")
+		void 내_신고_목록_페이지타입_오류_400() throws Exception {
+			// when & then
+			mockMvc.perform(get("/api/v1/reports/me").param("page", "abc"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true));
+		}
+	}
+}

--- a/app-api/src/test/java/com/tasteam/domain/restaurant/controller/FoodCategoryControllerTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/restaurant/controller/FoodCategoryControllerTest.java
@@ -1,0 +1,57 @@
+package com.tasteam.domain.restaurant.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.tasteam.config.annotation.ControllerWebMvcTest;
+import com.tasteam.domain.restaurant.dto.response.FoodCategoryResponse;
+import com.tasteam.domain.restaurant.service.FoodCategoryService;
+
+@ControllerWebMvcTest(FoodCategoryController.class)
+@DisplayName("[유닛](Restaurant) FoodCategoryController 단위 테스트")
+class FoodCategoryControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockitoBean
+	private FoodCategoryService foodCategoryService;
+
+	@Test
+	@DisplayName("음식 카테고리 목록을 조회하면 카테고리 목록을 반환한다")
+	void 음식카테고리_조회_성공() throws Exception {
+		// given
+		given(foodCategoryService.getFoodCategories())
+			.willReturn(List.of(new FoodCategoryResponse(1L, "한식"), new FoodCategoryResponse(2L, "중식")));
+
+		// when & then
+		mockMvc.perform(get("/api/v1/food-categories"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data").isArray())
+			.andExpect(jsonPath("$.data[0].id").value(1))
+			.andExpect(jsonPath("$.data[0].name").value("한식"));
+	}
+
+	@Test
+	@DisplayName("서비스 장애 시 500으로 실패한다")
+	void 음식카테고리_조회_서비스_오류_실패() throws Exception {
+		// given
+		given(foodCategoryService.getFoodCategories()).willThrow(new RuntimeException("service down"));
+
+		// when & then
+		mockMvc.perform(get("/api/v1/food-categories"))
+			.andExpect(status().isInternalServerError())
+			.andExpect(jsonPath("$.success").value(false));
+	}
+}

--- a/app-api/src/test/java/com/tasteam/domain/test/controller/WebhookTestControllerTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/test/controller/WebhookTestControllerTest.java
@@ -1,0 +1,117 @@
+package com.tasteam.domain.test.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.tasteam.config.annotation.ControllerWebMvcTest;
+import com.tasteam.domain.member.dto.response.MemberGroupSummaryResponse;
+import com.tasteam.domain.member.dto.response.MemberSubgroupSummaryResponse;
+import com.tasteam.domain.member.entity.Member;
+import com.tasteam.domain.member.repository.MemberRepository;
+import com.tasteam.domain.member.service.MemberService;
+import com.tasteam.fixture.MemberFixture;
+import com.tasteam.global.security.jwt.provider.JwtCookieProvider;
+import com.tasteam.global.security.jwt.provider.JwtTokenProvider;
+import com.tasteam.global.security.jwt.repository.RefreshTokenStore;
+
+@ControllerWebMvcTest(WebhookTestController.class)
+@DisplayName("[유닛](Test) WebhookTestController 단위 테스트")
+class WebhookTestControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockitoBean
+	private MemberRepository memberRepository;
+
+	@MockitoBean
+	private MemberService memberService;
+
+	@MockitoBean
+	private JwtTokenProvider jwtTokenProvider;
+
+	@MockitoBean
+	private JwtCookieProvider jwtCookieProvider;
+
+	@MockitoBean
+	private RefreshTokenStore refreshTokenStore;
+
+	@Nested
+	@DisplayName("에러 테스트")
+	class ErrorEndpoints {
+
+		@Test
+		@DisplayName("BusinessException 엔드포인트가 500이 아닌 오류 코드를 반환한다")
+		void businessException_테스트() throws Exception {
+			// when & then
+			mockMvc.perform(get("/api/v1/test/error/business"))
+				.andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.code").value("MEMBER_NOT_FOUND"));
+		}
+
+		@Test
+		@DisplayName("시스템 예외 엔드포인트가 500을 반환한다")
+		void systemException_테스트() throws Exception {
+			// when & then
+			mockMvc.perform(get("/api/v1/test/error/system"))
+				.andExpect(status().isInternalServerError())
+				.andExpect(jsonPath("$.success").value(false));
+		}
+	}
+
+	@Nested
+	@DisplayName("개발용 고정 멤버 조회")
+	class GetDevMember {
+
+		@Test
+		@DisplayName("DEV_MEMBER_ID를 기준으로 멤버 정보를 조회하고 토큰을 반환한다")
+		void devMember_조회_성공() throws Exception {
+			// given
+			Member member = MemberFixture.createWithId(1001L, "dev@example.com", "개발자");
+			MemberGroupSummaryResponse groupSummary = new MemberGroupSummaryResponse(
+				1L,
+				"테스트그룹",
+				List.of(new MemberSubgroupSummaryResponse(11L, "테스트하위그룹")));
+			given(memberRepository.findByIdAndDeletedAtIsNull(1001L)).willReturn(Optional.of(member));
+			given(memberService.getMyGroupSummaries(1001L)).willReturn(List.of(groupSummary));
+			given(jwtTokenProvider.generateAccessToken(1001L, member.getRole().name(), 3_600_000L))
+				.willReturn("access-token");
+			given(jwtTokenProvider.generateRefreshToken(1001L)).willReturn("refresh-token");
+			given(jwtTokenProvider.getExpiration("refresh-token"))
+				.willReturn(new Date());
+
+			// when & then
+			mockMvc.perform(get("/api/v1/test/dev/member"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.memberId").value(1001))
+				.andExpect(jsonPath("$.data.email").value("dev@example.com"))
+				.andExpect(jsonPath("$.data.accessToken").value("access-token"));
+		}
+
+		@Test
+		@DisplayName("고정 멤버가 없으면 404으로 실패한다")
+		void devMember_조회_실패_없음() throws Exception {
+			// given
+			given(memberRepository.findByIdAndDeletedAtIsNull(1001L)).willReturn(Optional.empty());
+
+			// when & then
+			mockMvc.perform(get("/api/v1/test/dev/member"))
+				.andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.code").value("MEMBER_NOT_FOUND"));
+		}
+	}
+}

--- a/app-api/src/test/java/com/tasteam/global/health/controller/HealthCheckControllerTest.java
+++ b/app-api/src/test/java/com/tasteam/global/health/controller/HealthCheckControllerTest.java
@@ -1,0 +1,58 @@
+package com.tasteam.global.health.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthComponent;
+import org.springframework.boot.actuate.health.HealthEndpoint;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.tasteam.config.annotation.ControllerWebMvcTest;
+
+@ControllerWebMvcTest(HealthCheckController.class)
+@DisplayName("[유닛](Health) HealthCheckController 단위 테스트")
+class HealthCheckControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockitoBean
+	private HealthEndpoint healthEndpoint;
+
+	@Test
+	@DisplayName("헬스체크 API가 상태 정보를 반환한다")
+	void 헬스체크_성공() throws Exception {
+		// given
+		HealthComponent health = Health.up()
+			.withDetails(Map.of("redis", "ok", "database", "connected"))
+			.build();
+		given(healthEndpoint.health()).willReturn(health);
+
+		// when & then
+		mockMvc.perform(get("/api/v1/health"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.status").value("UP"));
+	}
+
+	@Test
+	@DisplayName("헬스체크 수행 중 예외가 발생하면 500으로 실패한다")
+	void 헬스체크_예외_실패() throws Exception {
+		// given
+		given(healthEndpoint.health()).willThrow(new RuntimeException("health endpoint down"));
+
+		// when & then
+		mockMvc.perform(get("/api/v1/health"))
+			.andExpect(status().isInternalServerError())
+			.andExpect(jsonPath("$.success").value(false));
+	}
+}

--- a/app-api/src/test/java/com/tasteam/infra/messagequeue/UserActivityOutboxAdminControllerWebMvcTest.java
+++ b/app-api/src/test/java/com/tasteam/infra/messagequeue/UserActivityOutboxAdminControllerWebMvcTest.java
@@ -1,0 +1,120 @@
+package com.tasteam.infra.messagequeue;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.verify;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.tasteam.config.annotation.ControllerWebMvcTest;
+import com.tasteam.domain.analytics.resilience.UserActivityReplayResult;
+import com.tasteam.domain.analytics.resilience.UserActivityReplayService;
+import com.tasteam.domain.analytics.resilience.UserActivitySourceOutboxService;
+import com.tasteam.domain.analytics.resilience.UserActivitySourceOutboxSummary;
+
+@TestPropertySource(properties = "tasteam.message-queue.enabled=true")
+@ControllerWebMvcTest(UserActivityOutboxAdminController.class)
+@DisplayName("[유닛](MQ) UserActivityOutboxAdminController 단위 테스트")
+class UserActivityOutboxAdminControllerWebMvcTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockitoBean
+	private UserActivitySourceOutboxService outboxService;
+
+	@MockitoBean
+	private UserActivityReplayService replayService;
+
+	@Nested
+	@DisplayName("아웃박스 요약 조회")
+	class GetSummary {
+
+		@Test
+		@DisplayName("요약 조회에 성공하면 집계 데이터를 반환한다")
+		void 요약_조회_성공() throws Exception {
+			// given
+			given(outboxService.summarize())
+				.willReturn(new UserActivitySourceOutboxSummary(3, 2, 10, 4));
+
+			// when & then
+			mockMvc.perform(get("/api/v1/admin/user-activity/outbox/summary"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.pendingCount").value(3))
+				.andExpect(jsonPath("$.data.failedCount").value(2))
+				.andExpect(jsonPath("$.data.publishedCount").value(10))
+				.andExpect(jsonPath("$.data.maxRetryCount").value(4));
+		}
+
+		@Test
+		@DisplayName("요약 조회에 실패하면 500으로 실패한다")
+		void 요약_조회_실패() throws Exception {
+			// given
+			willThrow(new RuntimeException("summary fail")).given(outboxService).summarize();
+
+			// when & then
+			mockMvc.perform(get("/api/v1/admin/user-activity/outbox/summary"))
+				.andExpect(status().isInternalServerError())
+				.andExpect(jsonPath("$.success").value(false));
+		}
+	}
+
+	@Nested
+	@DisplayName("아웃박스 재처리")
+	class Replay {
+
+		@Test
+		@DisplayName("요청 제한값을 초과하면 500으로 클램프해서 재처리한다")
+		void 재처리_클램프_적용_성공() throws Exception {
+			// given
+			var result = new UserActivityReplayResult(5, 4, 1);
+			given(replayService.replayPending(500)).willReturn(result);
+
+			// when & then
+			mockMvc.perform(post("/api/v1/admin/user-activity/outbox/replay")
+				.contentType(APPLICATION_JSON)
+				.param("limit", "999"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.processedCount").value(5))
+				.andExpect(jsonPath("$.data.successCount").value(4))
+				.andExpect(jsonPath("$.data.failedCount").value(1));
+
+			verify(replayService).replayPending(500);
+		}
+
+		@Test
+		@DisplayName("limit가 숫자가 아니면 400으로 실패한다")
+		void 재처리_파라미터_타입_실패() throws Exception {
+			// when & then
+			mockMvc.perform(post("/api/v1/admin/user-activity/outbox/replay").param("limit", "abc"))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.code").value("INVALID_REQUEST"));
+		}
+
+		@Test
+		@DisplayName("재처리 실행 중 실패하면 500으로 실패한다")
+		void 재처리_실패() throws Exception {
+			// given
+			willThrow(new RuntimeException("replay fail")).given(replayService).replayPending(anyInt());
+
+			// when & then
+			mockMvc.perform(post("/api/v1/admin/user-activity/outbox/replay"))
+				.andExpect(status().isInternalServerError())
+				.andExpect(jsonPath("$.success").value(false));
+		}
+	}
+}

--- a/app-api/src/test/java/com/tasteam/infra/messagequeue/trace/MessageQueueTraceAdminControllerTest.java
+++ b/app-api/src/test/java/com/tasteam/infra/messagequeue/trace/MessageQueueTraceAdminControllerTest.java
@@ -1,0 +1,122 @@
+package com.tasteam.infra.messagequeue.trace;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.tasteam.config.annotation.ControllerWebMvcTest;
+
+@ControllerWebMvcTest(MessageQueueTraceAdminController.class)
+@DisplayName("[유닛](MQ) MessageQueueTraceAdminController 단위 테스트")
+class MessageQueueTraceAdminControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockitoBean
+	private MessageQueueTraceService traceService;
+
+	@Nested
+	@DisplayName("MQ 트레이스 조회")
+	class FindRecent {
+
+		@Test
+		@DisplayName("메시지 ID 필터가 없으면 조회 결과를 반환한다")
+		void 트레이스_조회_성공() throws Exception {
+			// given
+			var log = MessageQueueTraceLog.publish("msg-1", "topic-a", "kafka", "key-1");
+			given(traceService.findRecent(any(), anyInt())).willReturn(List.of(log));
+
+			// when & then
+			mockMvc.perform(get("/api/v1/admin/mq-traces").param("limit", "20"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data").isArray())
+				.andExpect(jsonPath("$.data[0].messageId").value("msg-1"))
+				.andExpect(jsonPath("$.data[0].topic").value("topic-a"))
+				.andExpect(jsonPath("$.data[0].stage").value("PUBLISH"));
+		}
+
+		@Test
+		@DisplayName("messageId로 필터링해 조회한 결과를 반환한다")
+		void 트레이스_조회_메시지필터_성공() throws Exception {
+			// given
+			var log = MessageQueueTraceLog.consumeSuccess(
+				"msg-2",
+				"topic-b",
+				"kafka",
+				"key-2",
+				"group-a",
+				123);
+			given(traceService.findRecent("msg-2", 50)).willReturn(List.of(log));
+
+			// when & then
+			mockMvc.perform(get("/api/v1/admin/mq-traces")
+				.param("messageId", "msg-2")
+				.param("limit", "50"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data[0].messageId").value("msg-2"))
+				.andExpect(jsonPath("$.data[0].consumerGroup").value("group-a"));
+		}
+
+		@Test
+		@DisplayName("limit 타입이 잘못되면 400으로 실패한다")
+		void 트레이스_조회_제한값_타입실패() throws Exception {
+			// when & then
+			mockMvc.perform(get("/api/v1/admin/mq-traces").param("limit", "abc"))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.code").value("INVALID_REQUEST"));
+		}
+
+		@Test
+		@DisplayName("limit 상한을 넘으면 200으로 결과를 반환하고 상한으로 클램프한다")
+		void 트레이스_조회_클램프_적용() throws Exception {
+			// given
+			var log = MessageQueueTraceLog.consumeFail(
+				"msg-3",
+				"topic-c",
+				"kafka",
+				"key-3",
+				"group-b",
+				50,
+				"error");
+			given(traceService.findRecent(isNull(), eq(200))).willReturn(List.of(log));
+
+			// when & then
+			mockMvc.perform(get("/api/v1/admin/mq-traces").param("limit", "1000"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true));
+
+			verify(traceService).findRecent(isNull(), eq(200));
+		}
+
+		@Test
+		@DisplayName("조회 중 예외가 발생하면 500으로 실패한다")
+		void 트레이스_조회_실패() throws Exception {
+			// given
+			willThrow(new RuntimeException("trace fail")).given(traceService).findRecent(isNull(), anyInt());
+
+			// when & then
+			mockMvc.perform(get("/api/v1/admin/mq-traces").param("limit", "20"))
+				.andExpect(status().isInternalServerError())
+				.andExpect(jsonPath("$.success").value(false));
+		}
+	}
+}


### PR DESCRIPTION
## 📌 PR 요약

#### Summary
- HTTP MVC 컨트롤러 누락 구간에 대해 `@ControllerWebMvcTest + MockMvc` 기반 테스트를 전수 추가했습니다.
- 성공 응답 계약과 실패(Validation/타입 불일치/BusinessException) 시나리오를 컨트롤러별로 최소 2개 이상 구성했습니다.
- `WebSocket ChatMessageWsController`는 범위에서 제외했습니다.

### Issue
- close : #482

---

## ➕ 추가된 기능
1. 공용/도메인 컨트롤러 WebMvc 테스트 추가
2. Admin 계열 컨트롤러 WebMvc 테스트 추가
3. MQ Admin 컨트롤러 WebMvc 테스트 추가

## 🛠️ 수정/변경사항
1. `UserActivityOutboxAdminControllerWebMvcTest`에 `tasteam.message-queue.enabled=true` 테스트 속성을 적용해 조건부 빈 활성화 환경을 반영했습니다.
2. `LocalAuthControllerTest`는 `@ActiveProfiles("local")`, `TestAuthControllerTest`는 `@ActiveProfiles("test")`를 적용했습니다.
3. `AdminSpaFallbackControllerTest`에서 `/admin`, `/admin/pages/**` 경로의 `forward:/admin/index.html` 매핑을 검증했습니다.
4. `204` 응답 API는 상태코드와 빈 바디를 함께 검증하도록 테스트를 작성했습니다.
5. 클램프 로직이 있는 컨트롤러는 서비스 호출 인자까지 검증해 상한 적용 여부를 확인했습니다.
6. 컨트롤러/Docs 시그니처 불일치로 WebMvc 컨텍스트 초기화가 깨지는 지점을 정리하기 위해 Docs 인터페이스 파라미터 애노테이션을 구현부와 동일하게 맞췄습니다.

---

## ✅ 남은 작업
* [ ] CI 결과 확인 후 Draft 해제
* [ ] 리뷰 코멘트 반영

---

## 검증 로그
- `./gradlew :app-api:test --tests '*ControllerTest' --tests '*WebMvcTest'` ✅
- `./gradlew :app-api:test` ✅
