### PR TITLE
feat: dev Alloy에 Redis 메트릭·로그 수집 추가

### DIFF
--- a/app-api/src/main/java/com/tasteam/batch/dummy/service/DummyDataSeedService.java
+++ b/app-api/src/main/java/com/tasteam/batch/dummy/service/DummyDataSeedService.java
@@ -236,7 +236,8 @@ public class DummyDataSeedService {
 					if (subgroupMemberCount == 0) {
 						break;
 					}
-					long memberId = selectedGroupMembers[(memberOffset + (m % subgroupMemberCount)) % subgroupMemberCount];
+					long memberId = selectedGroupMembers[(memberOffset + (m % subgroupMemberCount))
+						% subgroupMemberCount];
 					chatMessageEntries.add(new long[] {chatRoomId, memberId});
 					chatMessageContents.add("더미 채팅 메시지 " + (++messageSerial));
 					if (chatMessageEntries.size() >= RELATION_FLUSH_SIZE) {

--- a/deploy/codedeploy/backend/alloy/alloy-app-dev.alloy
+++ b/deploy/codedeploy/backend/alloy/alloy-app-dev.alloy
@@ -1,0 +1,141 @@
+// ── 로그 수집: Spring JSON 파일 → Loki push ──
+
+local.file_match "spring_logs" {
+  path_targets = [{"__path__" = "/var/log/tasteam/*.log"}]
+}
+
+loki.source.file "spring_logs" {
+  targets    = local.file_match.spring_logs.targets
+  forward_to = [loki.process.spring_labels.receiver]
+}
+
+loki.process "spring_labels" {
+  stage.static_labels {
+    values = { job = "spring" }
+  }
+  forward_to = [loki.write.default.receiver]
+}
+
+loki.write "default" {
+  endpoint {
+    url = "http://" + sys.env("LOKI_HOST") + ":3100/loki/api/v1/push"
+  }
+  external_labels = {
+    environment = sys.env("ENVIRONMENT"),
+    role        = sys.env("ROLE"),
+    instance    = sys.env("HOSTNAME"),
+  }
+}
+
+// ── 호스트 메트릭: node_exporter ──
+
+prometheus.exporter.unix "node" {
+  set_collectors = ["cpu", "diskstats", "filesystem", "loadavg", "meminfo", "netdev"]
+  filesystem {
+    mount_points_exclude = "^/(sys|proc|dev|host|etc)($|/)"
+  }
+}
+
+// ── 컨테이너 메트릭: cAdvisor ──
+
+prometheus.exporter.cadvisor "containers" {
+  docker_host            = "unix:///var/run/docker.sock"
+  store_container_labels = false
+}
+
+// ── Spring Actuator 메트릭 ──
+// Spring 컨테이너가 호스트 포트로 바인딩 → host.docker.internal:8080으로 접근
+
+prometheus.relabel "spring" {
+  forward_to = [prometheus.remote_write.default.receiver]
+  rule {
+    target_label = "instance"
+    replacement  = sys.env("HOSTNAME")
+  }
+}
+
+prometheus.scrape "spring" {
+  targets = [{
+    __address__ = "host.docker.internal:8080",
+    job         = "spring",
+  }]
+  metrics_path    = "/actuator/prometheus"
+  forward_to      = [prometheus.relabel.spring.receiver]
+  scrape_interval = "30s"
+}
+
+// ── 호스트/컨테이너 메트릭 → remote_write push ──
+
+prometheus.relabel "node" {
+  forward_to = [prometheus.remote_write.default.receiver]
+  rule {
+    target_label = "job"
+    replacement  = "node"
+  }
+  rule {
+    target_label = "instance"
+    replacement  = sys.env("HOSTNAME")
+  }
+}
+
+prometheus.scrape "node" {
+  targets         = prometheus.exporter.unix.node.targets
+  forward_to      = [prometheus.relabel.node.receiver]
+  scrape_interval = "30s"
+}
+
+prometheus.relabel "cadvisor" {
+  forward_to = [prometheus.remote_write.default.receiver]
+  rule {
+    target_label = "job"
+    replacement  = "cadvisor"
+  }
+  rule {
+    target_label = "instance"
+    replacement  = sys.env("HOSTNAME")
+  }
+}
+
+prometheus.scrape "cadvisor" {
+  targets         = prometheus.exporter.cadvisor.containers.targets
+  forward_to      = [prometheus.relabel.cadvisor.receiver]
+  scrape_interval = "30s"
+}
+
+// ── Redis 메트릭 (dev 전용) ──
+// Dev EC2에서는 Redis가 같은 호스트에 실행됨
+
+prometheus.exporter.redis "redis" {
+  redis_addr = "host.docker.internal:6379"
+}
+
+prometheus.relabel "redis" {
+  forward_to = [prometheus.remote_write.default.receiver]
+  rule {
+    target_label = "job"
+    replacement  = "redis"
+  }
+  rule {
+    target_label = "instance"
+    replacement  = sys.env("HOSTNAME")
+  }
+}
+
+prometheus.scrape "redis" {
+  targets         = prometheus.exporter.redis.redis.targets
+  forward_to      = [prometheus.relabel.redis.receiver]
+  scrape_interval = "30s"
+}
+
+// ── remote_write push ──
+
+prometheus.remote_write "default" {
+  endpoint {
+    url = "http://" + sys.env("PROMETHEUS_HOST") + ":9090/api/v1/write"
+  }
+  external_labels = {
+    environment = sys.env("ENVIRONMENT"),
+    role        = sys.env("ROLE"),
+    instance    = sys.env("HOSTNAME"),
+  }
+}

--- a/deploy/codedeploy/backend/deploy.sh
+++ b/deploy/codedeploy/backend/deploy.sh
@@ -283,6 +283,9 @@ start_alloy() {
   fi
 
   local alloy_config="${SCRIPT_DIR}/alloy/alloy-app.alloy"
+  if [ "${ENV_NAME}" = "dev" ] && [ -f "${SCRIPT_DIR}/alloy/alloy-app-dev.alloy" ]; then
+    alloy_config="${SCRIPT_DIR}/alloy/alloy-app-dev.alloy"
+  fi
 
   log "start alloy (config=${alloy_config})"
   ALLOY_CONFIG_FILE="${alloy_config}" \


### PR DESCRIPTION
## Summary
- dev 전용 Alloy 설정 파일(`alloy-app-dev.alloy`) 신규 생성: 기존 `alloy-app.alloy` + Redis exporter + Redis 로그 수집
- `deploy.sh`의 `start_alloy()`에서 `ENV_NAME=dev`일 때 dev 전용 설정 파일을 자동 선택하도록 분기 추가
- prod 환경은 기존 `alloy-app.alloy`를 그대로 사용하므로 영향 없음

## 배경
- Dev EC2에서는 Redis가 같은 인스턴스에 실행되지만, Alloy에 Redis exporter가 없어 메트릭·로그 수집이 누락됨
- Prod에서는 Redis가 별도 EC2에 있어 `alloy-redis.alloy`가 담당하므로, 같은 설정을 공유할 수 없음

## 변경 사항
1. `alloy-app-dev.alloy` — Redis 메트릭 수집 (`prometheus.exporter.redis`) + Redis 컨테이너 로그 수집 (`loki.source.docker`)
2. `deploy.sh` — `ENV_NAME=dev`일 때 dev 전용 설정 파일 선택 분기

## Test plan
- [x] `alloy fmt`로 설정 파일 문법 검증 완료
- [x] Dev EC2 SSH 수동 테스트: Redis 메트릭 수집 확인 (`redis_*` 메트릭 정상 출력)
- [ ] develop 머지 후 자동 배포 → Alloy 컨테이너 정상 기동 확인
- [ ] Prometheus에서 `redis_up{environment="dev"}` 메트릭 조회 확인
- [ ] Loki에서 `{job="redis", environment="dev"}` 로그 조회 확인