### PR TITLE
feat: dev Alloy에 Redis 로그 수집 추가

### DIFF
--- a/deploy/codedeploy/backend/alloy/alloy-app-dev.alloy
+++ b/deploy/codedeploy/backend/alloy/alloy-app-dev.alloy
@@ -102,6 +102,30 @@ prometheus.scrape "cadvisor" {
   scrape_interval = "30s"
 }
 
+// ── Redis 로그 수집 (dev 전용) ──
+// Docker 소켓으로 Redis 컨테이너 로그 수집
+
+discovery.docker "redis_containers" {
+  host = "unix:///var/run/docker.sock"
+  filter {
+    name   = "name"
+    values = ["redis"]
+  }
+}
+
+loki.source.docker "redis_container" {
+  host       = "unix:///var/run/docker.sock"
+  targets    = discovery.docker.redis_containers.targets
+  forward_to = [loki.process.redis_labels.receiver]
+}
+
+loki.process "redis_labels" {
+  stage.static_labels {
+    values = { job = "redis" }
+  }
+  forward_to = [loki.write.default.receiver]
+}
+
 // ── Redis 메트릭 (dev 전용) ──
 // Dev EC2에서는 Redis가 같은 호스트에 실행됨
 


### PR DESCRIPTION
## Summary
- dev Alloy 설정에 Redis 컨테이너 로그 수집 파이프라인 추가
- Docker 소켓으로 Redis 컨테이너 로그 수집 → `job=redis` 레이블 → 기존 `loki.write "default"` 공유

## 배경
- PR #491에서 Redis 메트릭 수집은 추가했으나 로그 수집이 누락됨
- prod `alloy-redis.alloy`에는 Redis 로그 수집이 포함되어 있으므로 dev도 동일하게 구성

## Test plan
- [x] `alloy fmt`로 설정 파일 문법 검증 완료
- [ ] develop 머지 후 자동 배포 → Alloy 정상 기동 확인
- [ ] Loki에서 `{job="redis", environment="dev"}` 로그 조회 확인