### PR TITLE
fix(admin): 어드민 뷰 is-hidden CSS !important 버그 수정

### DIFF
--- a/app-api/src/main/resources/static/admin/js/views/dummy.view.js
+++ b/app-api/src/main/resources/static/admin/js/views/dummy.view.js
@@ -67,7 +67,7 @@ function renderDummy(container) {
                     <p class="elapsed" id="r-elapsed"></p>
                 </div>
                 <div id="seedError" class="status-msg error is-hidden"></div>
-                <div id="seedLoading" class="seed-loading is-hidden">삽입 중...</div>
+                <div id="seedLoading" class="seed-loading is-hidden">삽입 중... (대용량 데이터는 수 분이 소요될 수 있습니다)</div>
             </div>
 
             <div class="card">
@@ -93,6 +93,36 @@ function toIntOrDefault(id, fallback) {
 	return Number.isNaN(value) || value < 0 ? fallback : value;
 }
 
+async function refreshCountResult() {
+	const errorEl = document.getElementById('countError');
+	const resultEl = document.getElementById('countResult');
+	const tableBody = document.getElementById('countTableBody');
+	if (!errorEl || !resultEl || !tableBody) {
+		return;
+	}
+
+	try {
+		const response = await getDataCounts();
+		const data = response?.data || response;
+		const rows = [
+			['member', data.memberCount],
+			['restaurant', data.restaurantCount],
+			['group', data.groupCount],
+			['subgroup', data.subgroupCount],
+			['review', data.reviewCount],
+			['chat_message', data.chatMessageCount]
+		];
+		tableBody.innerHTML = rows
+			.map(([name, count]) => `<tr><td>${name}</td><td class="count-value">${count.toLocaleString()}</td></tr>`)
+			.join('');
+		resultEl.classList.remove('is-hidden');
+		errorEl.classList.add('is-hidden');
+	} catch (error) {
+		errorEl.textContent = `현황 조회 실패: ${error.message}`;
+		errorEl.classList.remove('is-hidden');
+	}
+}
+
 function mountDummy() {
 	dummyCleanup = [];
 
@@ -101,30 +131,13 @@ function mountDummy() {
 		const countHandler = async () => {
 			const errorEl = document.getElementById('countError');
 			const resultEl = document.getElementById('countResult');
-			const tableBody = document.getElementById('countTableBody');
-			if (!errorEl || !resultEl || !tableBody) {
-				return;
+			if (errorEl) {
+				errorEl.classList.add('is-hidden');
 			}
-			errorEl.style.display = 'none';
-			resultEl.style.display = 'none';
-
-			try {
-				const response = await getDataCounts();
-				const data = response?.data || response;
-				const rows = [
-					['member', data.memberCount],
-					['restaurant', data.restaurantCount],
-					['group', data.groupCount],
-					['subgroup', data.subgroupCount],
-					['review', data.reviewCount],
-					['chat_message', data.chatMessageCount]
-				];
-				tableBody.innerHTML = rows.map(([name, count]) => `<tr><td>${name}</td><td class="count-value">${count.toLocaleString()}</td></tr>`).join('');
-				resultEl.style.display = 'block';
-			} catch (error) {
-				errorEl.textContent = error.message;
-				errorEl.style.display = 'block';
+			if (resultEl) {
+				resultEl.classList.add('is-hidden');
 			}
+			await refreshCountResult();
 		};
 		countBtn.addEventListener('click', countHandler);
 		dummyCleanup.push(() => countBtn.removeEventListener('click', countHandler));
@@ -145,11 +158,16 @@ function mountDummy() {
 				chats: document.getElementById('r-chat'),
 				elapsed: document.getElementById('r-elapsed')
 			};
-			errorEl.style.display = 'none';
-			if (resultEl) {
-				resultEl.style.display = 'none';
+
+			if (errorEl) {
+				errorEl.classList.add('is-hidden');
 			}
-			loading.style.display = 'block';
+			if (resultEl) {
+				resultEl.classList.add('is-hidden');
+			}
+			if (loading) {
+				loading.classList.remove('is-hidden');
+			}
 			seedBtn.disabled = true;
 
 			try {
@@ -186,14 +204,20 @@ function mountDummy() {
 					msgRows.elapsed.textContent = `소요 시간: ${result.elapsedMs.toLocaleString()} ms`;
 				}
 				if (resultEl) {
-					resultEl.style.display = 'block';
+					resultEl.classList.remove('is-hidden');
 				}
 			} catch (error) {
-				errorEl.textContent = error.message;
-				errorEl.style.display = 'block';
+				if (errorEl) {
+					errorEl.textContent = `삽입 실패: ${error.message}`;
+					errorEl.classList.remove('is-hidden');
+				}
 			} finally {
-				loading.style.display = 'none';
+				if (loading) {
+					loading.classList.add('is-hidden');
+				}
 				seedBtn.disabled = false;
+				// 성공/실패 무관하게 현황 자동 갱신
+				await refreshCountResult();
 			}
 		};
 		seedBtn.addEventListener('click', seedHandler);
@@ -209,13 +233,20 @@ function mountDummy() {
 			const msg = document.getElementById('deleteMsg');
 			try {
 				await deleteDummyData();
-				msg.textContent = '더미 데이터가 모두 삭제되었습니다.';
-				msg.className = 'status-msg success';
+				if (msg) {
+					msg.textContent = '더미 데이터가 모두 삭제되었습니다.';
+					msg.className = 'status-msg success';
+					msg.classList.remove('is-hidden');
+				}
 			} catch (error) {
-				msg.textContent = `삭제 중 오류: ${error.message}`;
-				msg.className = 'status-msg error';
+				if (msg) {
+					msg.textContent = `삭제 중 오류: ${error.message}`;
+					msg.className = 'status-msg error';
+					msg.classList.remove('is-hidden');
+				}
 			}
-			msg.style.display = 'block';
+			// 삭제 후 현황 자동 갱신
+			await refreshCountResult();
 		};
 		deleteBtn.addEventListener('click', deleteHandler);
 		dummyCleanup.push(() => deleteBtn.removeEventListener('click', deleteHandler));

--- a/app-api/src/main/resources/static/admin/js/views/groups.view.js
+++ b/app-api/src/main/resources/static/admin/js/views/groups.view.js
@@ -199,7 +199,7 @@ function resetCreateForm() {
 	}
 	const emailDomainGroup = document.getElementById('emailDomainGroup');
 	if (emailDomainGroup) {
-		emailDomainGroup.style.display = 'none';
+		emailDomainGroup.classList.add('is-hidden');
 	}
 	const lat = document.getElementById('groupLatitude');
 	const lng = document.getElementById('groupLongitude');
@@ -289,9 +289,9 @@ function mountGroups(state = {}) {
 				return;
 			}
 			if (event.target.value === 'EMAIL') {
-				emailDomainGroup.style.display = 'block';
+				emailDomainGroup.classList.remove('is-hidden');
 			} else {
-				emailDomainGroup.style.display = 'none';
+				emailDomainGroup.classList.add('is-hidden');
 			}
 		};
 		joinType.addEventListener('change', changeJoinType);

--- a/app-api/src/main/resources/static/admin/js/views/jobs.view.js
+++ b/app-api/src/main/resources/static/admin/js/views/jobs.view.js
@@ -160,16 +160,16 @@ function mountJobs() {
 					batchResult.textContent = response?.data?.successCount || 0;
 				}
 				if (listBox) {
-					listBox.style.display = 'block';
+					listBox.classList.remove('is-hidden');
 				}
 				if (errorBox) {
-					errorBox.style.display = 'none';
+					errorBox.classList.add('is-hidden');
 				}
 				document.getElementById('loadPendingImages')?.click();
 			} catch (error) {
 				if (errorBox) {
 					errorBox.textContent = error.message;
-					errorBox.style.display = 'block';
+					errorBox.classList.remove('is-hidden');
 				}
 			} finally {
 				clearLoading(discoverBtn);
@@ -190,7 +190,7 @@ function mountJobs() {
 
 			setLoading(pendingBtn, '조회 중...');
 			if (errorBox) {
-				errorBox.style.display = 'none';
+				errorBox.classList.add('is-hidden');
 			}
 			try {
 				const response = await window.apiRequest(`/admin/jobs/image-optimization/pending?limit=${limit}`);
@@ -212,12 +212,12 @@ function mountJobs() {
                     `).join('');
 				}
 				if (list) {
-					list.style.display = 'block';
+					list.classList.remove('is-hidden');
 				}
 			} catch (error) {
 				if (errorBox) {
 					errorBox.textContent = error.message;
-					errorBox.style.display = 'block';
+					errorBox.classList.remove('is-hidden');
 				}
 			} finally {
 				clearLoading(pendingBtn);
@@ -238,7 +238,7 @@ function mountJobs() {
 			const batchSize = parseInt(document.getElementById('batchSize')?.value || '100', 10);
 			setLoading(runOptBtn, '실행 중...');
 			if (resultBox) {
-				resultBox.style.display = 'none';
+				resultBox.classList.add('is-hidden');
 			}
 			try {
 				const response = await window.apiRequest(`/admin/jobs/image-optimization?batchSize=${batchSize}`, { method: 'POST' });
@@ -252,13 +252,13 @@ function mountJobs() {
 					skipped.textContent = response?.data?.skippedCount || 0;
 				}
 				if (resultBox) {
-					resultBox.style.display = 'block';
+					resultBox.classList.remove('is-hidden');
 				}
 				document.getElementById('loadPendingImages')?.click();
 			} catch (error) {
 				if (errorBox) {
 					errorBox.textContent = error.message;
-					errorBox.style.display = 'block';
+					errorBox.classList.remove('is-hidden');
 				}
 			} finally {
 				clearLoading(runOptBtn);
@@ -280,7 +280,7 @@ function mountJobs() {
 				const pendingBody = document.getElementById('pendingImagesBody');
 				const count = document.getElementById('pendingCount');
 				if (pending) {
-					pending.style.display = 'none';
+					pending.classList.add('is-hidden');
 				}
 				if (pendingBody) {
 					pendingBody.innerHTML = '';
@@ -289,15 +289,15 @@ function mountJobs() {
 					count.textContent = '0';
 				}
 				if (resultBox) {
-					resultBox.style.display = 'none';
+					resultBox.classList.add('is-hidden');
 				}
 				if (errorBox) {
-					errorBox.style.display = 'none';
+					errorBox.classList.add('is-hidden');
 				}
 			} catch (error) {
 				if (errorBox) {
 					errorBox.textContent = error.message;
-					errorBox.style.display = 'block';
+					errorBox.classList.remove('is-hidden');
 				}
 			} finally {
 				clearLoading(resetBtn);
@@ -336,15 +336,15 @@ function mountJobs() {
                     `).join('');
 				}
 				if (list) {
-					list.style.display = 'block';
+					list.classList.remove('is-hidden');
 				}
 				if (errorBox) {
-					errorBox.style.display = 'none';
+					errorBox.classList.add('is-hidden');
 				}
 			} catch (error) {
 				if (errorBox) {
 					errorBox.textContent = error.message;
-					errorBox.style.display = 'block';
+					errorBox.classList.remove('is-hidden');
 				}
 			} finally {
 				clearLoading(loadCleanupBtn);
@@ -362,7 +362,7 @@ function mountJobs() {
 			const count = document.getElementById('cleanedCount');
 			setLoading(runCleanupBtn, '실행 중...');
 			if (result) {
-				result.style.display = 'none';
+				result.classList.add('is-hidden');
 			}
 			try {
 				const response = await window.apiRequest('/admin/jobs/image-cleanup', { method: 'POST' });
@@ -370,13 +370,13 @@ function mountJobs() {
 					count.textContent = response?.data?.successCount || 0;
 				}
 				if (result) {
-					result.style.display = 'block';
+					result.classList.remove('is-hidden');
 				}
 				document.getElementById('loadCleanupPending')?.click();
 			} catch (error) {
 				if (errorBox) {
 					errorBox.textContent = error.message;
-					errorBox.style.display = 'block';
+					errorBox.classList.remove('is-hidden');
 				}
 			} finally {
 				clearLoading(runCleanupBtn);

--- a/app-api/src/main/resources/static/admin/js/views/reports.view.js
+++ b/app-api/src/main/resources/static/admin/js/views/reports.view.js
@@ -275,7 +275,7 @@ async function openReportDetail(reportId) {
 		currentReportId = report.id;
 		const modal = document.getElementById('reportModal');
 		if (modal) {
-			modal.style.display = 'block';
+			modal.classList.remove('is-hidden');
 		}
 	} catch (error) {
 		alert(`상세 조회 실패: ${error.message}`);
@@ -291,7 +291,7 @@ async function saveReportStatus() {
 		await updateReportStatus(currentReportId, nextStatus);
 		const modal = document.getElementById('reportModal');
 		if (modal) {
-			modal.style.display = 'none';
+			modal.classList.add('is-hidden');
 		}
 		await loadReports(
 			reportsCurrentPage,
@@ -375,7 +375,7 @@ function mountReports(state = {}) {
 		const close = () => {
 			const modal = document.getElementById('reportModal');
 			if (modal) {
-				modal.style.display = 'none';
+				modal.classList.add('is-hidden');
 			}
 		};
 		modalClose.addEventListener('click', close);
@@ -395,7 +395,7 @@ function mountReports(state = {}) {
 	if (modal) {
 		const outsideClick = (event) => {
 			if (event.target === modal) {
-				modal.style.display = 'none';
+				modal.classList.add('is-hidden');
 			}
 		};
 		window.addEventListener('click', outsideClick);


### PR DESCRIPTION
## Summary
- 어드민 뷰 JS 파일에서 `is-hidden` 클래스 처리 시 `!important` 우선순위 문제로 요소가 숨겨지지 않는 버그 수정
- `dummy.view.js`, `groups.view.js`, `jobs.view.js`, `reports.view.js` 4개 뷰 파일 일괄 적용

## 변경 사항
- `is-hidden` CSS 클래스 적용 방식 수정 (4개 어드민 JS 뷰 파일)

## 스키마 / API 영향
- 없음

## 테스트
- [ ] 어드민 페이지에서 각 뷰(더미/그룹/잡/신고) 노출·숨김 동작 확인

## 관련 이슈
- close: #