### PR TITLE
fix: subgroup favorite 마이그레이션 중복 데이터 대응

### DIFF
--- a/app-api/src/main/resources/db/migration/V202602101130__create_subgroup_favorite_restaurant.sql
+++ b/app-api/src/main/resources/db/migration/V202602101130__create_subgroup_favorite_restaurant.sql
@@ -16,8 +16,17 @@ BEGIN
             FROM pg_constraint
             WHERE conname = 'uq_subgroup_favorite_subgroup_restaurant'
         ) THEN
-            ALTER TABLE subgroup_favorite_restaurant
-                ADD CONSTRAINT uq_subgroup_favorite_subgroup_restaurant UNIQUE (subgroup_id, restaurant_id);
+            IF NOT EXISTS (
+                SELECT 1
+                FROM subgroup_favorite_restaurant
+                GROUP BY subgroup_id, restaurant_id
+                HAVING COUNT(*) > 1
+            ) THEN
+                ALTER TABLE subgroup_favorite_restaurant
+                    ADD CONSTRAINT uq_subgroup_favorite_subgroup_restaurant UNIQUE (subgroup_id, restaurant_id);
+            ELSE
+                RAISE NOTICE 'Skip uq_subgroup_favorite_subgroup_restaurant: duplicated (subgroup_id, restaurant_id) exists';
+            END IF;
         END IF;
 
         IF NOT EXISTS (
@@ -25,8 +34,17 @@ BEGIN
             FROM pg_constraint
             WHERE conname = 'uq_subgroup_favorite_restaurant_member'
         ) THEN
-            ALTER TABLE subgroup_favorite_restaurant
-                ADD CONSTRAINT uq_subgroup_favorite_restaurant_member UNIQUE (restaurant_id, member_id);
+            IF NOT EXISTS (
+                SELECT 1
+                FROM subgroup_favorite_restaurant
+                GROUP BY restaurant_id, member_id
+                HAVING COUNT(*) > 1
+            ) THEN
+                ALTER TABLE subgroup_favorite_restaurant
+                    ADD CONSTRAINT uq_subgroup_favorite_restaurant_member UNIQUE (restaurant_id, member_id);
+            ELSE
+                RAISE NOTICE 'Skip uq_subgroup_favorite_restaurant_member: duplicated (restaurant_id, member_id) exists';
+            END IF;
         END IF;
 
         IF NOT EXISTS (

--- a/app-api/src/main/resources/db/migration/V202602101220__alter_subgroup_favorite_restaurant_soft_delete.sql
+++ b/app-api/src/main/resources/db/migration/V202602101220__alter_subgroup_favorite_restaurant_soft_delete.sql
@@ -12,6 +12,19 @@ BEGIN
 
         DROP INDEX IF EXISTS uq_subgroup_like_active;
 
+        WITH ranked AS (
+            SELECT id,
+                   ROW_NUMBER() OVER (
+                       PARTITION BY member_id, restaurant_id, subgroup_id
+                       ORDER BY created_at DESC, id DESC
+                   ) AS rn
+            FROM subgroup_favorite_restaurant
+            WHERE deleted_at IS NULL
+        )
+        UPDATE subgroup_favorite_restaurant
+        SET deleted_at = NOW()
+        WHERE id IN (SELECT id FROM ranked WHERE rn > 1);
+
         CREATE UNIQUE INDEX IF NOT EXISTS uq_subgroup_like_active
             ON subgroup_favorite_restaurant (member_id, restaurant_id, subgroup_id)
             WHERE deleted_at IS NULL;


### PR DESCRIPTION
## 📌 PR 요약

#### Summary
- subgroup favorite restaurant 관련 Flyway 마이그레이션이 기존 중복 데이터 때문에 기동 실패하던 문제를 보완했습니다.
- 초기 unique 제약 추가를 중복 존재 시 건너뛰고, soft delete 전환 시 활성 중복을 정리한 뒤 partial unique 인덱스를 생성하도록 변경했습니다.

### Issue
- close : #530

---

## ➕ 추가된 기능

1. 없음
2. 없음

## 🛠️ 수정/변경사항

1. `V202602101130__create_subgroup_favorite_restaurant.sql`에서 `(subgroup_id, restaurant_id)`, `(restaurant_id, member_id)` 중복이 있으면 과거 unique 제약 추가를 `NOTICE`와 함께 건너뛰도록 수정했습니다.
2. `V202602101220__alter_subgroup_favorite_restaurant_soft_delete.sql`에서 `(member_id, restaurant_id, subgroup_id)` 기준 활성 중복을 `deleted_at`으로 정리한 뒤 partial unique 인덱스를 생성하도록 수정했습니다.

---

## ✅ 남은 작업

* [ ] 대상 환경에 이미 동일 버전 Flyway 이력이 있으면 checksum 차이를 검토하고 필요 시 `flyway repair`를 수행합니다.
* [ ] 로컬/개발 환경에서 실제 Flyway 적용 경로를 한 번 더 검증합니다. (이번 작업에서는 테스트 미실행)
