### PR TITLE
fix: Alloy v1.14.0-rc.1 업그레이드 — cAdvisor 개별 컨테이너 메트릭 수집

### DIFF
--- a/deploy/codedeploy/backend/alloy/alloy-app.alloy
+++ b/deploy/codedeploy/backend/alloy/alloy-app.alloy
@@ -40,7 +40,8 @@ prometheus.exporter.unix "node" {
 
 prometheus.exporter.cadvisor "containers" {
   docker_host            = "unix:///var/run/docker.sock"
-  store_container_labels = false
+  docker_only            = true
+  store_container_labels = true
 }
 
 // ── Spring Actuator 메트릭 ──

--- a/deploy/codedeploy/backend/docker-compose.alloy.yml
+++ b/deploy/codedeploy/backend/docker-compose.alloy.yml
@@ -1,16 +1,21 @@
 services:
   alloy:
-    image: grafana/alloy:latest
+    image: grafana/alloy:v1.14.0-rc.1
     container_name: alloy
     restart: unless-stopped
     ports:
       - "12345:12345"  # Alloy 자체 텔레메트리 포트
+    privileged: true
     extra_hosts:
       - "host.docker.internal:host-gateway"  # Spring/Redis 호스트 포트 접근용
     volumes:
       - ${ALLOY_CONFIG_FILE}:/etc/alloy/config.alloy:ro
       - /var/run/docker.sock:/var/run/docker.sock  # cAdvisor + 컨테이너 로그 수집용
       - /var/log/tasteam:/var/log/tasteam:ro         # Spring JSON 로그 읽기
+      - /:/rootfs:ro
+      - /var/run:/var/run
+      - /sys:/sys:ro
+      - /var/lib/docker:/var/lib/docker:ro
     environment:
       - LOKI_HOST=${LOKI_HOST}
       - PROMETHEUS_HOST=${PROMETHEUS_HOST}


### PR DESCRIPTION
## Summary
- Docker v29의 스토리지 레이아웃 변경(overlay2→overlayfs)으로 인해 Alloy 내장 cAdvisor가 개별 컨테이너를 인식하지 못하는 문제 해결
- Alloy 이미지 `latest` → `v1.14.0-rc.1` (내장 cAdvisor v0.47.0 → v0.54.1)
- cAdvisor 설정: `docker_only=true`, `store_container_labels=true`
- privileged 모드 + 호스트 볼륨 마운트 추가

## Context
- 관련 이슈: https://github.com/grafana/alloy/issues/5021
- 모니터링 서버, Redis 서버에는 이미 동일 설정 적용 및 정상 동작 확인 완료

## Test plan
- [ ] stg 배포 후 Prometheus에서 `container_memory_working_set_bytes` 쿼리 시 `name` 라벨로 개별 컨테이너 구분 확인
- [ ] Alloy 로그에 `Failed to create existing container` 에러 없음 확인