### PR TITLE
🐛 fix: Docker 컨테이너 로그 로테이션 설정 추가

### DIFF
--- a/deploy/codedeploy/backend/docker-compose.alloy.yml
+++ b/deploy/codedeploy/backend/docker-compose.alloy.yml
@@ -8,6 +8,11 @@ services:
     privileged: true
     extra_hosts:
       - "host.docker.internal:host-gateway"  # Spring/Redis 호스트 포트 접근용
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "3"
     volumes:
       - ${ALLOY_CONFIG_FILE}:/etc/alloy/config.alloy:ro
       - /var/run/docker.sock:/var/run/docker.sock  # cAdvisor + 컨테이너 로그 수집용

--- a/deploy/codedeploy/backend/docker-compose.backend.yml
+++ b/deploy/codedeploy/backend/docker-compose.backend.yml
@@ -9,5 +9,10 @@ services:
       - "${CONTAINER_PORT:-8080}:8080"
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    logging:
+      driver: json-file
+      options:
+        max-size: "100m"
+        max-file: "3"
     volumes:
       - /var/log/tasteam:/var/log/tasteam # Alloy 로그 수집용 호스트 경로 공유


### PR DESCRIPTION
## Summary
- stg 서버 디스크 100% 도달 원인: Docker 컨테이너 stdout 로그 무제한 적재 (14GB)
- backend, alloy 컨테이너에 json-file 로그 드라이버 로테이션 설정 추가

## Changes
- `docker-compose.backend.yml`: max-size 100MB × 3파일
- `docker-compose.alloy.yml`: max-size 50MB × 3파일

## Test plan
- [ ] stg 서버에서 컨테이너 재생성 후 `docker inspect <container> | grep -A 5 LogConfig`로 설정 적용 확인