### PR TITLE
✨ feat: 채팅 Redis Stream 소비를 고정 파티션 기반으로 전환하고 legacy 이행 경로를 추가

### DIFF
--- a/app-api/src/main/java/com/tasteam/domain/chat/config/ChatStreamProperties.java
+++ b/app-api/src/main/java/com/tasteam/domain/chat/config/ChatStreamProperties.java
@@ -6,10 +6,17 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public record ChatStreamProperties(
 	boolean enabled,
 	boolean bootstrapEnabled,
+	// Legacy room consume path only.
 	int bootstrapBatchSize,
+	// Legacy room consume path only.
 	int maxTotalSubscriptions,
 	int executorThreadPoolSize,
-	int executorQueueCapacity) {
+	int executorQueueCapacity,
+	int partitionCount,
+	int maxAllowedPartitions,
+	boolean partitionConsumeEnabled,
+	boolean dualWriteEnabled,
+	boolean legacyRoomConsumeEnabled) {
 	public ChatStreamProperties() {
 		this(
 			true,
@@ -17,6 +24,11 @@ public record ChatStreamProperties(
 			100,
 			1000,
 			4,
-			256);
+			256,
+			16,
+			128,
+			true,
+			true,
+			false);
 	}
 }

--- a/app-api/src/main/java/com/tasteam/domain/chat/stream/ChatStreamGroupNameProvider.java
+++ b/app-api/src/main/java/com/tasteam/domain/chat/stream/ChatStreamGroupNameProvider.java
@@ -1,7 +1,13 @@
 package com.tasteam.domain.chat.stream;
 
+import java.lang.management.ManagementFactory;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.UUID;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 @Component
 public class ChatStreamGroupNameProvider {
@@ -10,11 +16,9 @@ public class ChatStreamGroupNameProvider {
 
 	public ChatStreamGroupNameProvider(
 		@Value("${spring.application.name:app}")
-		String appName,
-		@Value("${random.uuid}")
-		String random) {
-		this.groupName = "chat-group-" + appName + "-" + random;
-		this.consumerName = this.groupName;
+		String appName) {
+		this.groupName = "chat-group-" + sanitize(appName);
+		this.consumerName = resolveConsumerName();
 	}
 
 	public String groupName() {
@@ -23,5 +27,48 @@ public class ChatStreamGroupNameProvider {
 
 	public String consumerName() {
 		return consumerName;
+	}
+
+	private String resolveConsumerName() {
+		String podName = System.getenv("POD_NAME");
+		if (StringUtils.hasText(podName)) {
+			return sanitize(podName);
+		}
+
+		String hostname = resolveHostname();
+		Long pid = resolvePid();
+		if (hostname != null && pid != null) {
+			return sanitize(hostname + "-" + pid);
+		}
+
+		String fallbackHost = hostname == null ? "unknown-host" : hostname;
+		return sanitize(fallbackHost + "-" + UUID.randomUUID());
+	}
+
+	private String resolveHostname() {
+		try {
+			return InetAddress.getLocalHost().getHostName();
+		} catch (UnknownHostException ex) {
+			return null;
+		}
+	}
+
+	private Long resolvePid() {
+		try {
+			return ProcessHandle.current().pid();
+		} catch (Exception ex) {
+			try {
+				return Long.parseLong(ManagementFactory.getRuntimeMXBean().getName().split("@")[0]);
+			} catch (Exception ignored) {
+				return null;
+			}
+		}
+	}
+
+	private String sanitize(String value) {
+		if (!StringUtils.hasText(value)) {
+			return "app";
+		}
+		return value.replaceAll("[^a-zA-Z0-9._:-]", "_");
 	}
 }

--- a/app-api/src/main/java/com/tasteam/domain/chat/stream/ChatStreamKeyResolver.java
+++ b/app-api/src/main/java/com/tasteam/domain/chat/stream/ChatStreamKeyResolver.java
@@ -5,10 +5,25 @@ import org.springframework.stereotype.Component;
 @Component
 public class ChatStreamKeyResolver {
 	private static final String ROOM_STREAM_PREFIX = "chat:room:";
+	private static final String PARTITION_STREAM_PREFIX = "chat:partition:";
 	private static final String DEAD_LETTER_STREAM = "chat:dead-letter";
 
 	public String roomStreamKey(Long chatRoomId) {
 		return ROOM_STREAM_PREFIX + chatRoomId;
+	}
+
+	public String partitionStreamKey(int partitionId) {
+		return PARTITION_STREAM_PREFIX + partitionId;
+	}
+
+	public int resolvePartition(Long chatRoomId, int partitionCount) {
+		if (chatRoomId == null) {
+			throw new IllegalArgumentException("chatRoomId must not be null");
+		}
+		if (partitionCount <= 0) {
+			throw new IllegalArgumentException("partitionCount must be greater than 0");
+		}
+		return (int)Math.floorMod(chatRoomId, (long)partitionCount);
 	}
 
 	public String deadLetterStreamKey() {

--- a/app-api/src/main/java/com/tasteam/domain/chat/stream/ChatStreamPublisher.java
+++ b/app-api/src/main/java/com/tasteam/domain/chat/stream/ChatStreamPublisher.java
@@ -7,6 +7,7 @@ import org.springframework.data.redis.connection.stream.StreamRecords;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
+import com.tasteam.domain.chat.config.ChatStreamProperties;
 import com.tasteam.domain.chat.dto.response.ChatMessageItemResponse;
 
 import lombok.RequiredArgsConstructor;
@@ -19,14 +20,23 @@ public class ChatStreamPublisher {
 
 	private final StringRedisTemplate stringRedisTemplate;
 	private final ChatStreamKeyResolver keyResolver;
+	private final ChatStreamProperties chatStreamProperties;
 
 	public void publish(Long chatRoomId, ChatMessageItemResponse message) {
-		String streamKey = keyResolver.roomStreamKey(chatRoomId);
 		ChatStreamPayload payload = ChatStreamPayload.from(chatRoomId, message);
-		MapRecord<String, String, String> record = StreamRecords.newRecord()
-			.in(streamKey)
-			.ofMap(payload.toMap());
+		if (chatStreamProperties.partitionConsumeEnabled()) {
+			int partitionId = keyResolver.resolvePartition(chatRoomId, chatStreamProperties.partitionCount());
+			publishTo(keyResolver.partitionStreamKey(partitionId), payload);
+			if (chatStreamProperties.dualWriteEnabled()) {
+				publishTo(keyResolver.roomStreamKey(chatRoomId), payload);
+			}
+			return;
+		}
+		publishTo(keyResolver.roomStreamKey(chatRoomId), payload);
+	}
 
+	private void publishTo(String streamKey, ChatStreamPayload payload) {
+		MapRecord<String, String, String> record = StreamRecords.newRecord().in(streamKey).ofMap(payload.toMap());
 		stringRedisTemplate.opsForStream().add(
 			record,
 			XAddOptions.maxlen(MAX_STREAM_LENGTH).approximateTrimming(true));

--- a/app-api/src/main/java/com/tasteam/domain/chat/stream/ChatStreamSubscriber.java
+++ b/app-api/src/main/java/com/tasteam/domain/chat/stream/ChatStreamSubscriber.java
@@ -2,22 +2,27 @@ package com.tasteam.domain.chat.stream;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
+import org.springframework.core.task.TaskRejectedException;
+import org.springframework.dao.DataAccessException;
 import org.springframework.data.domain.Range;
 import org.springframework.data.redis.connection.RedisStreamCommands.XClaimOptions;
 import org.springframework.data.redis.connection.stream.Consumer;
 import org.springframework.data.redis.connection.stream.MapRecord;
 import org.springframework.data.redis.connection.stream.PendingMessage;
 import org.springframework.data.redis.connection.stream.PendingMessages;
+import org.springframework.data.redis.connection.stream.PendingMessagesSummary;
 import org.springframework.data.redis.connection.stream.ReadOffset;
 import org.springframework.data.redis.connection.stream.RecordId;
 import org.springframework.data.redis.connection.stream.StreamOffset;
@@ -27,6 +32,7 @@ import org.springframework.data.redis.core.StreamOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.stream.StreamMessageListenerContainer;
 import org.springframework.data.redis.stream.Subscription;
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -34,7 +40,10 @@ import org.springframework.stereotype.Component;
 import com.tasteam.domain.chat.config.ChatStreamProperties;
 import com.tasteam.domain.chat.dto.response.ChatMessageItemResponse;
 import com.tasteam.domain.chat.repository.ChatRoomRepository;
+import com.tasteam.global.metrics.MetricLabelPolicy;
 
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import lombok.extern.slf4j.Slf4j;
@@ -47,6 +56,7 @@ public class ChatStreamSubscriber {
 	private static final int PENDING_SCAN_COUNT = 100;
 	private static final int MAX_RETRY_COUNT = 3;
 	private static final int MAX_STREAM_LENGTH = 1000;
+	private static final String PARTITION_STREAM_PREFIX = "chat:partition:";
 
 	private final StreamMessageListenerContainer<String, MapRecord<String, String, String>> container;
 	private final StringRedisTemplate stringRedisTemplate;
@@ -55,8 +65,12 @@ public class ChatStreamSubscriber {
 	private final ChatStreamGroupNameProvider groupNameProvider;
 	private final SimpMessagingTemplate messagingTemplate;
 	private final ChatStreamProperties chatStreamProperties;
+	@Nullable
+	private final MeterRegistry meterRegistry;
 
-	private final Map<Long, Subscription> subscriptions = new ConcurrentHashMap<>();
+	private final Map<Integer, Subscription> partitionSubscriptions = new ConcurrentHashMap<>();
+	private final Map<Long, Subscription> legacyRoomSubscriptions = new ConcurrentHashMap<>();
+	private final Map<Integer, AtomicLong> partitionPendingMessages = new ConcurrentHashMap<>();
 
 	@Autowired
 	public ChatStreamSubscriber(
@@ -67,7 +81,9 @@ public class ChatStreamSubscriber {
 		ChatStreamKeyResolver keyResolver,
 		ChatStreamGroupNameProvider groupNameProvider,
 		SimpMessagingTemplate messagingTemplate,
-		ChatStreamProperties chatStreamProperties) {
+		ChatStreamProperties chatStreamProperties,
+		@Nullable
+		MeterRegistry meterRegistry) {
 		this.container = container;
 		this.stringRedisTemplate = stringRedisTemplate;
 		this.chatRoomRepository = chatRoomRepository;
@@ -75,6 +91,7 @@ public class ChatStreamSubscriber {
 		this.groupNameProvider = groupNameProvider;
 		this.messagingTemplate = messagingTemplate;
 		this.chatStreamProperties = chatStreamProperties;
+		this.meterRegistry = meterRegistry;
 	}
 
 	@PostConstruct
@@ -88,12 +105,22 @@ public class ChatStreamSubscriber {
 
 	@EventListener(ApplicationReadyEvent.class)
 	public void onApplicationReady() {
-		if (!chatStreamProperties.enabled() || !chatStreamProperties.bootstrapEnabled()) {
-			log.info("채팅 스트림 구독 부트스트랩을 건너뜁니다. enabled={}, bootstrapEnabled={}",
-				chatStreamProperties.enabled(), chatStreamProperties.bootstrapEnabled());
+		if (!chatStreamProperties.enabled()) {
+			log.info("채팅 스트림 구독 부트스트랩을 건너뜁니다. enabled={}", chatStreamProperties.enabled());
 			return;
 		}
-		refreshSubscriptions();
+
+		validateConfiguration();
+		logConfiguration();
+
+		if (chatStreamProperties.partitionConsumeEnabled()) {
+			ensurePartitionGroupsAtStartup();
+			ensurePartitionSubscriptions();
+		}
+
+		if (chatStreamProperties.legacyRoomConsumeEnabled() && chatStreamProperties.bootstrapEnabled()) {
+			refreshLegacyRoomSubscriptions();
+		}
 	}
 
 	@PreDestroy
@@ -102,8 +129,8 @@ public class ChatStreamSubscriber {
 	}
 
 	@Scheduled(fixedDelayString = "PT30S")
-	public void refreshSubscriptions() {
-		if (!chatStreamProperties.enabled()) {
+	public void refreshLegacyRoomSubscriptions() {
+		if (!chatStreamProperties.enabled() || !chatStreamProperties.legacyRoomConsumeEnabled()) {
 			return;
 		}
 		if (chatStreamProperties.maxTotalSubscriptions() <= 0 || chatStreamProperties.bootstrapBatchSize() <= 0) {
@@ -113,7 +140,7 @@ public class ChatStreamSubscriber {
 		Set<Long> currentRoomIds = Set.copyOf(chatRoomRepository.findActiveRoomIds());
 		int remainingCapacity = Math.min(
 			chatStreamProperties.bootstrapBatchSize(),
-			Math.max(0, chatStreamProperties.maxTotalSubscriptions() - subscriptions.size()));
+			Math.max(0, chatStreamProperties.maxTotalSubscriptions() - legacyRoomSubscriptions.size()));
 		if (remainingCapacity <= 0) {
 			return;
 		}
@@ -123,45 +150,193 @@ public class ChatStreamSubscriber {
 			if (subscribedThisRound >= remainingCapacity) {
 				break;
 			}
-			if (subscriptions.containsKey(roomId)) {
-				continue;
-			}
-			if (roomId == null) {
+			if (legacyRoomSubscriptions.containsKey(roomId) || roomId == null) {
 				continue;
 			}
 			try {
-				subscriptions.computeIfAbsent(roomId, this::registerRoomSubscription);
+				legacyRoomSubscriptions.computeIfAbsent(roomId, this::registerLegacyRoomSubscription);
 				subscribedThisRound++;
 			} catch (Exception ex) {
-				log.warn("채팅방 구독 등록 실패, 다음 주기에 재시도합니다. roomId={}", roomId, ex);
+				log.warn("레거시 채팅방 구독 등록 실패, 다음 주기에 재시도합니다. roomId={}", roomId, ex);
 			}
 		}
 
 		if (subscribedThisRound > 0) {
-			log.info("채팅방 구독 부트스트랩 {}건 등록 (현재 구독 수: {})", subscribedThisRound, subscriptions.size());
+			log.info("레거시 채팅방 구독 {}건 등록 (현재 레거시 구독 수: {})", subscribedThisRound, legacyRoomSubscriptions.size());
 		}
 	}
 
-	public void ensureSubscribed(Long roomId) {
-		if (roomId == null) {
+	@Scheduled(fixedDelayString = "PT30S")
+	public void retryPartitionSubscriptions() {
+		if (!chatStreamProperties.enabled() || !chatStreamProperties.partitionConsumeEnabled()) {
 			return;
 		}
-		subscriptions.computeIfAbsent(roomId, this::registerRoomSubscription);
+		if (partitionSubscriptions.size() >= chatStreamProperties.partitionCount()) {
+			return;
+		}
+		ensurePartitionSubscriptions();
+	}
+
+	public void ensureSubscribed(Long roomId) {
+		if (roomId == null || !chatStreamProperties.enabled() || !chatStreamProperties.legacyRoomConsumeEnabled()) {
+			return;
+		}
+		legacyRoomSubscriptions.computeIfAbsent(roomId, this::registerLegacyRoomSubscription);
 	}
 
 	@Scheduled(fixedDelayString = "PT30S")
 	public void recoverPendingMessages() {
+		if (!chatStreamProperties.enabled()) {
+			return;
+		}
+
 		StreamOperations<String, String, String> streamOperations = stringRedisTemplate.opsForStream();
-		for (Long roomId : subscriptions.keySet()) {
-			String streamKey = keyResolver.roomStreamKey(roomId);
+		if (chatStreamProperties.partitionConsumeEnabled()) {
+			for (int partitionId = 0; partitionId < chatStreamProperties.partitionCount(); partitionId++) {
+				String streamKey = keyResolver.partitionStreamKey(partitionId);
+				recoverPendingMessages(streamOperations, streamKey, partitionId);
+			}
+		}
+		if (chatStreamProperties.legacyRoomConsumeEnabled()) {
+			for (Long roomId : legacyRoomSubscriptions.keySet()) {
+				String streamKey = keyResolver.roomStreamKey(roomId);
+				recoverPendingMessages(streamOperations, streamKey, null);
+			}
+		}
+	}
+
+	private void validateConfiguration() {
+		if (chatStreamProperties.partitionCount() <= 0) {
+			throw new IllegalStateException("chat.stream.partition-count must be greater than 0");
+		}
+		if (chatStreamProperties.maxAllowedPartitions() <= 0) {
+			throw new IllegalStateException("chat.stream.max-allowed-partitions must be greater than 0");
+		}
+		if (chatStreamProperties.partitionCount() > chatStreamProperties.maxAllowedPartitions()) {
+			throw new IllegalStateException(
+				"chat.stream.partition-count must be <= chat.stream.max-allowed-partitions");
+		}
+		if (chatStreamProperties.executorThreadPoolSize() <= 0) {
+			throw new IllegalStateException("chat.stream.executor-thread-pool-size must be greater than 0");
+		}
+		if (chatStreamProperties.executorQueueCapacity() < 0) {
+			throw new IllegalStateException("chat.stream.executor-queue-capacity must be >= 0");
+		}
+	}
+
+	private void logConfiguration() {
+		log.info(
+			"Chat stream config: partitionCount={}, executorThreads={}, partitionConsumeEnabled={}, legacyRoomConsumeEnabled={}, dualWriteEnabled={}",
+			chatStreamProperties.partitionCount(),
+			chatStreamProperties.executorThreadPoolSize(),
+			chatStreamProperties.partitionConsumeEnabled(),
+			chatStreamProperties.legacyRoomConsumeEnabled(),
+			chatStreamProperties.dualWriteEnabled());
+
+		double ratio = (double)chatStreamProperties.partitionCount() / chatStreamProperties.executorThreadPoolSize();
+		if (chatStreamProperties.partitionConsumeEnabled() && ratio > 8.0d) {
+			log.warn(
+				"Partition to executor ratio may be too high. partitionCount={}, executorThreads={}, ratio={}",
+				chatStreamProperties.partitionCount(),
+				chatStreamProperties.executorThreadPoolSize(),
+				String.format("%.2f", ratio));
+		}
+	}
+
+	private void ensurePartitionGroupsAtStartup() {
+		int createdCount = 0;
+		int alreadyExistsCount = 0;
+		int failedCount = 0;
+		List<Integer> failedPartitions = new ArrayList<>();
+
+		for (int partitionId = 0; partitionId < chatStreamProperties.partitionCount(); partitionId++) {
+			String streamKey = keyResolver.partitionStreamKey(partitionId);
+			try {
+				EnsureGroupResult result = ensureGroupExists(streamKey);
+				if (result == EnsureGroupResult.CREATED) {
+					createdCount++;
+				} else {
+					alreadyExistsCount++;
+				}
+				registerPartitionPendingGauge(partitionId, streamKey);
+			} catch (Exception ex) {
+				failedCount++;
+				failedPartitions.add(partitionId);
+				log.error("파티션 consumer group 초기화 실패. partitionId={}, streamKey={}", partitionId, streamKey, ex);
+			}
+		}
+
+		log.info(
+			"Partition consumer group ensure completed. created={}, alreadyExists={}, failed={}",
+			createdCount,
+			alreadyExistsCount,
+			failedCount);
+		if (failedCount > 0) {
+			log.warn("Partition consumer group ensure failed partitions={}", failedPartitions);
+		}
+	}
+
+	private void ensurePartitionSubscriptions() {
+		int subscribedThisRound = 0;
+		for (int partitionId = 0; partitionId < chatStreamProperties.partitionCount(); partitionId++) {
+			if (partitionSubscriptions.containsKey(partitionId)) {
+				continue;
+			}
+			final int currentPartitionId = partitionId;
+			try {
+				partitionSubscriptions.computeIfAbsent(currentPartitionId, this::registerPartitionSubscription);
+				subscribedThisRound++;
+			} catch (Exception ex) {
+				log.warn("파티션 구독 등록 실패, 다음 주기에 재시도합니다. partitionId={}", currentPartitionId, ex);
+			}
+		}
+
+		if (subscribedThisRound > 0) {
+			log.info("파티션 구독 {}건 등록 (현재 파티션 구독 수: {})", subscribedThisRound, partitionSubscriptions.size());
+		}
+	}
+
+	private Subscription registerPartitionSubscription(int partitionId) {
+		String streamKey = keyResolver.partitionStreamKey(partitionId);
+		ensureGroupExists(streamKey);
+		Consumer consumer = Consumer.from(groupNameProvider.groupName(), groupNameProvider.consumerName());
+		return container.receive(consumer,
+			StreamOffset.create(streamKey, ReadOffset.lastConsumed()),
+			record -> handleRecord(record, partitionId, streamKey));
+	}
+
+	private Subscription registerLegacyRoomSubscription(Long roomId) {
+		String streamKey = keyResolver.roomStreamKey(roomId);
+		// Legacy room consume 경로는 room stream이 런타임에 생성될 수 있어 호환을 위해 유지한다.
+		ensureGroupExists(streamKey);
+		Consumer consumer = Consumer.from(groupNameProvider.groupName(), groupNameProvider.consumerName());
+		return container.receive(consumer,
+			StreamOffset.create(streamKey, ReadOffset.lastConsumed()),
+			record -> handleRecord(record, null, streamKey));
+	}
+
+	private void recoverPendingMessages(
+		StreamOperations<String, String, String> streamOperations,
+		String streamKey,
+		@Nullable
+		Integer partitionId) {
+		try {
+			PendingMessagesSummary pendingSummary = streamOperations.pending(streamKey, groupNameProvider.groupName());
+			long totalPending = pendingSummary == null ? 0L : pendingSummary.getTotalPendingMessages();
+			updatePendingBacklog(partitionId, streamKey, totalPending);
+			if (totalPending <= 0) {
+				return;
+			}
+
 			PendingMessages pending = streamOperations.pending(
 				streamKey,
 				groupNameProvider.groupName(),
 				Range.unbounded(),
 				PENDING_SCAN_COUNT);
 			if (pending == null || pending.isEmpty()) {
-				continue;
+				return;
 			}
+
 			List<RecordId> toRetry = new ArrayList<>();
 			List<RecordId> toDeadLetter = new ArrayList<>();
 			for (PendingMessage message : pending) {
@@ -175,88 +350,374 @@ public class ChatStreamSubscriber {
 				}
 			}
 
-			claimAndHandle(streamKey, toRetry, false);
-			claimAndHandle(streamKey, toDeadLetter, true);
+			claimAndHandle(streamKey, toRetry, false, partitionId);
+			claimAndHandle(streamKey, toDeadLetter, true, partitionId);
+		} catch (DataAccessException ex) {
+			if (isNoGroupError(ex)) {
+				handleNoGroup(partitionId, streamKey, "pending_recovery");
+				return;
+			}
+			log.warn(
+				"Pending recovery failed. partitionId={}, streamKey={}, errorType={}",
+				partitionLabel(partitionId),
+				streamKey,
+				"redis_recovery_error",
+				ex);
+			recordErrorMetric(partitionLabel(partitionId), streamKey, "redis_recovery_error");
 		}
 	}
 
-	private Subscription registerRoomSubscription(Long roomId) {
-		String streamKey = keyResolver.roomStreamKey(roomId);
-		ensureGroupExists(streamKey);
-		Consumer consumer = Consumer.from(groupNameProvider.groupName(), groupNameProvider.consumerName());
-		return container.receive(consumer, StreamOffset.create(streamKey, ReadOffset.lastConsumed()),
-			this::handleRecord);
-	}
+	private void handleRecord(MapRecord<String, String, String> record, @Nullable
+	Integer partitionId, String streamKey) {
+		long startNanos = System.nanoTime();
+		Integer resolvedPartitionId = partitionId == null ? resolvePartitionId(record.getStream()) : partitionId;
+		String partitionLabel = partitionLabel(resolvedPartitionId);
 
-	private void handleRecord(MapRecord<String, String, String> record) {
 		try {
 			ChatStreamPayload payload = ChatStreamPayload.fromMap(record.getValue());
 			ChatMessageItemResponse itemResponse = payload.toMessageItem();
 			messagingTemplate.convertAndSend("/topic/chat-rooms/" + payload.chatRoomId(), itemResponse);
-			ack(record);
+			if (ack(record)) {
+				recordSuccessMetrics(partitionLabel, streamKey, Duration.ofNanos(System.nanoTime() - startNanos));
+			}
+		} catch (TaskRejectedException ex) {
+			log.warn(
+				"Failed to process chat stream record. partitionId={}, streamKey={}, errorType={}, recordId={}",
+				partitionLabel,
+				streamKey,
+				"task_rejected",
+				record.getId(),
+				ex);
+			recordErrorMetric(partitionLabel, streamKey, "task_rejected");
+		} catch (DataAccessException ex) {
+			log.warn(
+				"Failed to process chat stream record. partitionId={}, streamKey={}, errorType={}, recordId={}",
+				partitionLabel,
+				streamKey,
+				"redis_error",
+				record.getId(),
+				ex);
+			recordErrorMetric(partitionLabel, streamKey, "redis_error");
 		} catch (Exception ex) {
-			log.warn("Failed to process chat stream record. stream={}, id={}", record.getStream(), record.getId(), ex);
+			log.warn(
+				"Failed to process chat stream record. partitionId={}, streamKey={}, errorType={}, recordId={}",
+				partitionLabel,
+				streamKey,
+				"processing_error",
+				record.getId(),
+				ex);
+			recordErrorMetric(partitionLabel, streamKey, "processing_error");
 		}
 	}
 
-	private void claimAndHandle(String streamKey, List<RecordId> recordIds, boolean deadLetter) {
+	private void claimAndHandle(String streamKey, List<RecordId> recordIds, boolean deadLetter, @Nullable
+	Integer partitionId) {
 		if (recordIds.isEmpty()) {
 			return;
 		}
+
 		StreamOperations<String, String, String> streamOperations = stringRedisTemplate.opsForStream();
 		XClaimOptions claimOptions = XClaimOptions.minIdle(POLL_MIN_IDLE).ids(recordIds.toArray(RecordId[]::new));
-		List<MapRecord<String, String, String>> claimed = streamOperations.claim(
-			streamKey,
-			groupNameProvider.groupName(),
-			groupNameProvider.consumerName(),
-			claimOptions);
+		List<MapRecord<String, String, String>> claimed;
+		try {
+			claimed = streamOperations.claim(
+				streamKey,
+				groupNameProvider.groupName(),
+				groupNameProvider.consumerName(),
+				claimOptions);
+		} catch (DataAccessException ex) {
+			if (isNoGroupError(ex)) {
+				handleNoGroup(partitionId, streamKey, "pending_claim");
+				return;
+			}
+			log.warn(
+				"Pending claim failed. partitionId={}, streamKey={}, errorType={}, deadLetter={}",
+				partitionLabel(partitionId),
+				streamKey,
+				"redis_claim_error",
+				deadLetter,
+				ex);
+			recordErrorMetric(partitionLabel(partitionId), streamKey, "redis_claim_error");
+			return;
+		}
+
 		if (claimed == null || claimed.isEmpty()) {
 			return;
 		}
 		for (MapRecord<String, String, String> record : claimed) {
 			if (deadLetter) {
-				sendToDeadLetter(record);
-				ack(record);
+				boolean deadLettered = sendToDeadLetter(record, partitionId, streamKey);
+				if (deadLettered) {
+					ack(record);
+				}
 			} else {
-				handleRecord(record);
+				handleRecord(record, partitionId, streamKey);
 			}
 		}
 	}
 
-	private void sendToDeadLetter(MapRecord<String, String, String> record) {
+	private boolean sendToDeadLetter(MapRecord<String, String, String> record, @Nullable
+	Integer partitionId, String streamKey) {
 		String deadLetterKey = keyResolver.deadLetterStreamKey();
+		Map<String, String> value = new HashMap<>(record.getValue());
+		value.put("sourceStreamKey", streamKey);
+		value.put("sourceRecordId", record.getId().getValue());
+		if (partitionId != null) {
+			value.put("partitionId", String.valueOf(partitionId));
+		}
+
 		MapRecord<String, String, String> dlqRecord = StreamRecords.newRecord()
 			.in(deadLetterKey)
-			.ofMap(record.getValue());
-		stringRedisTemplate.opsForStream().add(
-			dlqRecord,
-			org.springframework.data.redis.connection.RedisStreamCommands.XAddOptions
-				.maxlen(MAX_STREAM_LENGTH)
-				.approximateTrimming(true));
+			.ofMap(value);
+		try {
+			stringRedisTemplate.opsForStream().add(
+				dlqRecord,
+				org.springframework.data.redis.connection.RedisStreamCommands.XAddOptions
+					.maxlen(MAX_STREAM_LENGTH)
+					.approximateTrimming(true));
+			return true;
+		} catch (DataAccessException ex) {
+			log.warn(
+				"DLQ publish failed. partitionId={}, streamKey={}, errorType={}, recordId={}",
+				partitionLabel(partitionId),
+				streamKey,
+				"redis_dlq_error",
+				record.getId(),
+				ex);
+			recordErrorMetric(partitionLabel(partitionId), streamKey, "redis_dlq_error");
+			return false;
+		}
 	}
 
-	private void ack(MapRecord<String, String, String> record) {
-		stringRedisTemplate.opsForStream().acknowledge(
-			record.getStream(),
-			groupNameProvider.groupName(),
-			record.getId());
+	private boolean ack(MapRecord<String, String, String> record) {
+		try {
+			stringRedisTemplate.opsForStream().acknowledge(
+				record.getStream(),
+				groupNameProvider.groupName(),
+				record.getId());
+			return true;
+		} catch (DataAccessException ex) {
+			String streamKey = record.getStream();
+			Integer partitionId = resolvePartitionId(streamKey);
+			if (isNoGroupError(ex)) {
+				handleNoGroup(partitionId, streamKey, "ack");
+				return false;
+			}
+			log.warn(
+				"ACK failed. partitionId={}, streamKey={}, errorType={}, recordId={}",
+				partitionLabel(partitionId),
+				streamKey,
+				"redis_ack_error",
+				record.getId(),
+				ex);
+			recordErrorMetric(partitionLabel(partitionId), streamKey, "redis_ack_error");
+			return false;
+		}
 	}
 
-	private void ensureGroupExists(String streamKey) {
-		stringRedisTemplate.execute((RedisCallback<Void>)connection -> {
-			try {
+	private EnsureGroupResult ensureGroupExists(String streamKey) {
+		return ensureGroupExists(streamKey, false);
+	}
+
+	private EnsureGroupResult ensureGroupExists(String streamKey, boolean suppressLog) {
+		try {
+			stringRedisTemplate.execute((RedisCallback<Void>)connection -> {
 				connection.streamCommands().xGroupCreate(
 					stringRedisTemplate.getStringSerializer().serialize(streamKey),
 					groupNameProvider.groupName(),
 					ReadOffset.latest(),
 					true);
-			} catch (Exception ex) {
-				String message = ex.getMessage();
-				if (message == null || !message.contains("BUSYGROUP")) {
-					throw ex;
-				}
+				return null;
+			});
+			if (!suppressLog) {
+				log.debug("Created consumer group. streamKey={}, groupName={}", streamKey,
+					groupNameProvider.groupName());
 			}
-			return null;
+			return EnsureGroupResult.CREATED;
+		} catch (DataAccessException ex) {
+			if (isBusyGroupError(ex)) {
+				return EnsureGroupResult.ALREADY_EXISTS;
+			}
+			throw ex;
+		} catch (RuntimeException ex) {
+			if (isBusyGroupError(ex)) {
+				return EnsureGroupResult.ALREADY_EXISTS;
+			}
+			throw ex;
+		}
+	}
+
+	private void handleNoGroup(@Nullable
+	Integer partitionId, String streamKey, String phase) {
+		log.warn(
+			"NOGROUP detected. partitionId={}, streamKey={}, phase={}. consumer group를 재생성합니다.",
+			partitionLabel(partitionId),
+			streamKey,
+			phase);
+		try {
+			ensureGroupExists(streamKey, true);
+			if (partitionId != null) {
+				resubscribePartition(partitionId);
+			}
+			log.info(
+				"NOGROUP recovery completed. partitionId={}, streamKey={}, phase={}",
+				partitionLabel(partitionId),
+				streamKey,
+				phase);
+		} catch (Exception recoveryEx) {
+			log.error(
+				"NOGROUP recovery failed. partitionId={}, streamKey={}, phase={}",
+				partitionLabel(partitionId),
+				streamKey,
+				phase,
+				recoveryEx);
+		}
+	}
+
+	private void resubscribePartition(int partitionId) {
+		Subscription existing = partitionSubscriptions.remove(partitionId);
+		if (existing != null) {
+			try {
+				existing.cancel();
+			} catch (Exception cancelEx) {
+				log.debug("기존 파티션 구독 cancel 중 예외를 무시합니다. partitionId={}", partitionId, cancelEx);
+			}
+		}
+		try {
+			partitionSubscriptions.put(partitionId, registerPartitionSubscription(partitionId));
+			log.info("파티션 구독을 재등록했습니다. partitionId={}", partitionId);
+		} catch (Exception ex) {
+			log.warn("파티션 구독 재등록 실패, 다음 스케줄에서 재시도합니다. partitionId={}", partitionId, ex);
+		}
+	}
+
+	private boolean isBusyGroupError(Throwable throwable) {
+		return hasRedisErrorToken(throwable, "BUSYGROUP");
+	}
+
+	private boolean isNoGroupError(Throwable throwable) {
+		return hasRedisErrorToken(throwable, "NOGROUP");
+	}
+
+	private boolean hasRedisErrorToken(@Nullable
+	Throwable throwable, String token) {
+		Throwable current = throwable;
+		while (current != null) {
+			String message = current.getMessage();
+			if (message != null && message.toUpperCase().contains(token)) {
+				return true;
+			}
+			current = current.getCause();
+		}
+		return false;
+	}
+
+	private void registerPartitionPendingGauge(int partitionId, String streamKey) {
+		if (meterRegistry == null) {
+			return;
+		}
+		partitionPendingMessages.computeIfAbsent(partitionId, id -> {
+			AtomicLong gaugeValue = new AtomicLong();
+			MetricLabelPolicy.validate(
+				"chat_stream_partition_pending_messages",
+				"partitionId",
+				String.valueOf(id),
+				"streamKey",
+				streamKey);
+			meterRegistry.gauge(
+				"chat_stream_partition_pending_messages",
+				Tags.of("partitionId", String.valueOf(id), "streamKey", streamKey),
+				gaugeValue);
+			return gaugeValue;
 		});
+	}
+
+	private void updatePendingBacklog(@Nullable
+	Integer partitionId, String streamKey, long totalPending) {
+		if (partitionId == null || meterRegistry == null) {
+			return;
+		}
+		registerPartitionPendingGauge(partitionId, streamKey);
+		AtomicLong gaugeValue = partitionPendingMessages.get(partitionId);
+		if (gaugeValue != null) {
+			gaugeValue.set(totalPending);
+		}
+	}
+
+	private void recordSuccessMetrics(String partitionId, String streamKey, Duration latency) {
+		if (meterRegistry == null) {
+			return;
+		}
+		MetricLabelPolicy.validate(
+			"chat_stream_partition_messages_total",
+			"partitionId",
+			partitionId,
+			"streamKey",
+			streamKey);
+		meterRegistry.counter(
+			"chat_stream_partition_messages_total",
+			"partitionId",
+			partitionId,
+			"streamKey",
+			streamKey).increment();
+
+		MetricLabelPolicy.validate(
+			"chat_stream_partition_processing_latency",
+			"partitionId",
+			partitionId,
+			"streamKey",
+			streamKey);
+		meterRegistry.timer(
+			"chat_stream_partition_processing_latency",
+			"partitionId",
+			partitionId,
+			"streamKey",
+			streamKey).record(latency);
+	}
+
+	private void recordErrorMetric(String partitionId, String streamKey, String errorType) {
+		if (meterRegistry == null) {
+			return;
+		}
+		MetricLabelPolicy.validate(
+			"chat_stream_partition_errors_total",
+			"partitionId",
+			partitionId,
+			"streamKey",
+			streamKey,
+			"errorType",
+			errorType);
+		meterRegistry.counter(
+			"chat_stream_partition_errors_total",
+			"partitionId",
+			partitionId,
+			"streamKey",
+			streamKey,
+			"errorType",
+			errorType).increment();
+	}
+
+	@Nullable
+	private Integer resolvePartitionId(@Nullable
+	String streamKey) {
+		if (streamKey == null || !streamKey.startsWith(PARTITION_STREAM_PREFIX)) {
+			return null;
+		}
+		String partitionText = streamKey.substring(PARTITION_STREAM_PREFIX.length());
+		try {
+			return Integer.valueOf(partitionText);
+		} catch (NumberFormatException ex) {
+			return null;
+		}
+	}
+
+	private String partitionLabel(@Nullable
+	Integer partitionId) {
+		return partitionId == null ? "legacy" : String.valueOf(partitionId);
+	}
+
+	private enum EnsureGroupResult {
+		CREATED,
+		ALREADY_EXISTS
 	}
 }

--- a/app-api/src/main/java/com/tasteam/domain/chat/ws/ChatRoomSubscriptionListener.java
+++ b/app-api/src/main/java/com/tasteam/domain/chat/ws/ChatRoomSubscriptionListener.java
@@ -5,6 +5,7 @@ import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.messaging.SessionSubscribeEvent;
 
+import com.tasteam.domain.chat.config.ChatStreamProperties;
 import com.tasteam.domain.chat.stream.ChatStreamSubscriber;
 
 import lombok.RequiredArgsConstructor;
@@ -16,9 +17,14 @@ public class ChatRoomSubscriptionListener {
 	private static final String DESTINATION_PREFIX = "/topic/chat-rooms/";
 
 	private final ChatStreamSubscriber chatStreamSubscriber;
+	private final ChatStreamProperties chatStreamProperties;
 
 	@EventListener
 	public void handleSubscribe(SessionSubscribeEvent event) {
+		if (!chatStreamProperties.legacyRoomConsumeEnabled()) {
+			return;
+		}
+
 		String destination = SimpMessageHeaderAccessor.wrap(event.getMessage()).getDestination();
 		if (destination == null || !destination.startsWith(DESTINATION_PREFIX)) {
 			return;

--- a/app-api/src/main/java/com/tasteam/global/metrics/MetricLabelPolicy.java
+++ b/app-api/src/main/java/com/tasteam/global/metrics/MetricLabelPolicy.java
@@ -23,7 +23,10 @@ public final class MetricLabelPolicy {
 		"domain",
 		"outcome",
 		"read_only",
-		"method_name");
+		"method_name",
+		"partitionId",
+		"streamKey",
+		"errorType");
 
 	private static final Set<String> FORBIDDEN_LABELS = Set.of(
 		"eventId",

--- a/app-api/src/main/resources/application.prod.yml
+++ b/app-api/src/main/resources/application.prod.yml
@@ -97,6 +97,18 @@ chat:
       enabled: ${CHAT_WEBSOCKET_HEARTBEAT_ENABLED:true}
       server-to-client: ${CHAT_WEBSOCKET_HEARTBEAT_SERVER_TO_CLIENT:15000}
       client-to-server: ${CHAT_WEBSOCKET_HEARTBEAT_CLIENT_TO_SERVER:15000}
+  stream:
+    enabled: ${CHAT_STREAM_ENABLED:true}
+    bootstrap-enabled: ${CHAT_STREAM_BOOTSTRAP_ENABLED:true}
+    bootstrap-batch-size: ${CHAT_STREAM_BOOTSTRAP_BATCH_SIZE:100}
+    max-total-subscriptions: ${CHAT_STREAM_MAX_TOTAL_SUBSCRIPTIONS:1000}
+    executor-thread-pool-size: ${CHAT_STREAM_EXECUTOR_THREAD_POOL_SIZE:4}
+    executor-queue-capacity: ${CHAT_STREAM_EXECUTOR_QUEUE_CAPACITY:256}
+    partition-count: ${CHAT_STREAM_PARTITION_COUNT:16}
+    max-allowed-partitions: ${CHAT_STREAM_MAX_ALLOWED_PARTITIONS:128}
+    partition-consume-enabled: ${CHAT_STREAM_PARTITION_CONSUME_ENABLED:true}
+    dual-write-enabled: ${CHAT_STREAM_DUAL_WRITE_ENABLED:true}
+    legacy-room-consume-enabled: ${CHAT_STREAM_LEGACY_ROOM_CONSUME_ENABLED:false}
 
 tasteam:
   notification:

--- a/app-api/src/main/resources/application.stg.yml
+++ b/app-api/src/main/resources/application.stg.yml
@@ -95,6 +95,18 @@ chat:
       enabled: ${CHAT_WEBSOCKET_HEARTBEAT_ENABLED:true}
       server-to-client: ${CHAT_WEBSOCKET_HEARTBEAT_SERVER_TO_CLIENT:15000}
       client-to-server: ${CHAT_WEBSOCKET_HEARTBEAT_CLIENT_TO_SERVER:15000}
+  stream:
+    enabled: ${CHAT_STREAM_ENABLED:true}
+    bootstrap-enabled: ${CHAT_STREAM_BOOTSTRAP_ENABLED:true}
+    bootstrap-batch-size: ${CHAT_STREAM_BOOTSTRAP_BATCH_SIZE:100}
+    max-total-subscriptions: ${CHAT_STREAM_MAX_TOTAL_SUBSCRIPTIONS:1000}
+    executor-thread-pool-size: ${CHAT_STREAM_EXECUTOR_THREAD_POOL_SIZE:4}
+    executor-queue-capacity: ${CHAT_STREAM_EXECUTOR_QUEUE_CAPACITY:256}
+    partition-count: ${CHAT_STREAM_PARTITION_COUNT:16}
+    max-allowed-partitions: ${CHAT_STREAM_MAX_ALLOWED_PARTITIONS:128}
+    partition-consume-enabled: ${CHAT_STREAM_PARTITION_CONSUME_ENABLED:true}
+    dual-write-enabled: ${CHAT_STREAM_DUAL_WRITE_ENABLED:true}
+    legacy-room-consume-enabled: ${CHAT_STREAM_LEGACY_ROOM_CONSUME_ENABLED:false}
 
 tasteam:
   auth:

--- a/app-api/src/main/resources/application.yml
+++ b/app-api/src/main/resources/application.yml
@@ -80,6 +80,18 @@ chat:
       enabled: ${CHAT_WEBSOCKET_HEARTBEAT_ENABLED:true}
       server-to-client: ${CHAT_WEBSOCKET_HEARTBEAT_SERVER_TO_CLIENT:15000}
       client-to-server: ${CHAT_WEBSOCKET_HEARTBEAT_CLIENT_TO_SERVER:15000}
+  stream:
+    enabled: ${CHAT_STREAM_ENABLED:true}
+    bootstrap-enabled: ${CHAT_STREAM_BOOTSTRAP_ENABLED:true}
+    bootstrap-batch-size: ${CHAT_STREAM_BOOTSTRAP_BATCH_SIZE:100}
+    max-total-subscriptions: ${CHAT_STREAM_MAX_TOTAL_SUBSCRIPTIONS:1000}
+    executor-thread-pool-size: ${CHAT_STREAM_EXECUTOR_THREAD_POOL_SIZE:4}
+    executor-queue-capacity: ${CHAT_STREAM_EXECUTOR_QUEUE_CAPACITY:256}
+    partition-count: ${CHAT_STREAM_PARTITION_COUNT:16}
+    max-allowed-partitions: ${CHAT_STREAM_MAX_ALLOWED_PARTITIONS:128}
+    partition-consume-enabled: ${CHAT_STREAM_PARTITION_CONSUME_ENABLED:true}
+    dual-write-enabled: ${CHAT_STREAM_DUAL_WRITE_ENABLED:true}
+    legacy-room-consume-enabled: ${CHAT_STREAM_LEGACY_ROOM_CONSUME_ENABLED:false}
 
 tasteam:
   admin:

--- a/app-api/src/test/java/com/tasteam/domain/chat/stream/ChatStreamKeyResolverTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/chat/stream/ChatStreamKeyResolverTest.java
@@ -1,0 +1,36 @@
+package com.tasteam.domain.chat.stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.tasteam.config.annotation.UnitTest;
+
+@UnitTest
+@DisplayName("[유닛](Chat) ChatStreamKeyResolver 단위 테스트")
+class ChatStreamKeyResolverTest {
+
+	private final ChatStreamKeyResolver keyResolver = new ChatStreamKeyResolver();
+
+	@Test
+	@DisplayName("파티션 키는 chat:partition:{id} 형식으로 생성된다")
+	void partitionStreamKey_success() {
+		assertThat(keyResolver.partitionStreamKey(7)).isEqualTo("chat:partition:7");
+	}
+
+	@Test
+	@DisplayName("채팅방 ID는 floorMod로 파티션을 계산한다")
+	void resolvePartition_success() {
+		assertThat(keyResolver.resolvePartition(123L, 16)).isEqualTo(11);
+		assertThat(keyResolver.resolvePartition(-1L, 16)).isEqualTo(15);
+	}
+
+	@Test
+	@DisplayName("partitionCount가 0 이하이면 예외가 발생한다")
+	void resolvePartition_invalidPartitionCount() {
+		assertThatThrownBy(() -> keyResolver.resolvePartition(1L, 0))
+			.isInstanceOf(IllegalArgumentException.class);
+	}
+}

--- a/app-api/src/test/java/com/tasteam/domain/chat/stream/ChatStreamPublisherTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/chat/stream/ChatStreamPublisherTest.java
@@ -1,0 +1,138 @@
+package com.tasteam.domain.chat.stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.connection.RedisStreamCommands.XAddOptions;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.core.StreamOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import com.tasteam.config.annotation.UnitTest;
+import com.tasteam.domain.chat.config.ChatStreamProperties;
+import com.tasteam.domain.chat.dto.response.ChatMessageItemResponse;
+import com.tasteam.domain.chat.type.ChatMessageType;
+
+@UnitTest
+@DisplayName("[유닛](Chat) ChatStreamPublisher 단위 테스트")
+class ChatStreamPublisherTest {
+
+	private final ChatStreamKeyResolver keyResolver = new ChatStreamKeyResolver();
+
+	@Test
+	@DisplayName("파티션 소비가 활성화되면 파티션 stream에만 발행한다")
+	void publish_partitionOnly() {
+		StringRedisTemplate redisTemplate = mock(StringRedisTemplate.class);
+		@SuppressWarnings("unchecked") StreamOperations<String, Object, Object> streamOperations = mock(
+			StreamOperations.class);
+		when(redisTemplate.opsForStream()).thenReturn(streamOperations);
+
+		ChatStreamProperties properties = new ChatStreamProperties(
+			true,
+			true,
+			100,
+			1000,
+			4,
+			256,
+			16,
+			128,
+			true,
+			false,
+			false);
+
+		ChatStreamPublisher publisher = new ChatStreamPublisher(redisTemplate, keyResolver, properties);
+		publisher.publish(33L, sampleMessage());
+
+		@SuppressWarnings("unchecked") org.mockito.ArgumentCaptor<MapRecord<String, String, String>> recordCaptor = org.mockito.ArgumentCaptor
+			.forClass(
+				(Class)MapRecord.class);
+		verify(streamOperations).add(recordCaptor.capture(), any(XAddOptions.class));
+
+		assertThat(recordCaptor.getValue().getStream()).isEqualTo("chat:partition:1");
+	}
+
+	@Test
+	@DisplayName("dual-write가 활성화되면 파티션 stream과 room stream에 모두 발행한다")
+	void publish_dualWrite() {
+		StringRedisTemplate redisTemplate = mock(StringRedisTemplate.class);
+		@SuppressWarnings("unchecked") StreamOperations<String, Object, Object> streamOperations = mock(
+			StreamOperations.class);
+		when(redisTemplate.opsForStream()).thenReturn(streamOperations);
+
+		ChatStreamProperties properties = new ChatStreamProperties(
+			true,
+			true,
+			100,
+			1000,
+			4,
+			256,
+			16,
+			128,
+			true,
+			true,
+			false);
+
+		ChatStreamPublisher publisher = new ChatStreamPublisher(redisTemplate, keyResolver, properties);
+		publisher.publish(33L, sampleMessage());
+
+		@SuppressWarnings("unchecked") org.mockito.ArgumentCaptor<MapRecord<String, String, String>> recordCaptor = org.mockito.ArgumentCaptor
+			.forClass(
+				(Class)MapRecord.class);
+		verify(streamOperations, org.mockito.Mockito.times(2)).add(recordCaptor.capture(), any(XAddOptions.class));
+
+		List<String> streamKeys = recordCaptor.getAllValues().stream().map(MapRecord::getStream).toList();
+		assertThat(streamKeys).containsExactlyInAnyOrder("chat:partition:1", "chat:room:33");
+	}
+
+	@Test
+	@DisplayName("파티션 소비가 비활성화되면 레거시 room stream에만 발행한다")
+	void publish_legacyOnly() {
+		StringRedisTemplate redisTemplate = mock(StringRedisTemplate.class);
+		@SuppressWarnings("unchecked") StreamOperations<String, Object, Object> streamOperations = mock(
+			StreamOperations.class);
+		when(redisTemplate.opsForStream()).thenReturn(streamOperations);
+
+		ChatStreamProperties properties = new ChatStreamProperties(
+			true,
+			true,
+			100,
+			1000,
+			4,
+			256,
+			16,
+			128,
+			false,
+			true,
+			true);
+
+		ChatStreamPublisher publisher = new ChatStreamPublisher(redisTemplate, keyResolver, properties);
+		publisher.publish(33L, sampleMessage());
+
+		@SuppressWarnings("unchecked") org.mockito.ArgumentCaptor<MapRecord<String, String, String>> recordCaptor = org.mockito.ArgumentCaptor
+			.forClass(
+				(Class)MapRecord.class);
+		verify(streamOperations).add(recordCaptor.capture(), any(XAddOptions.class));
+
+		assertThat(recordCaptor.getValue().getStream()).isEqualTo("chat:room:33");
+	}
+
+	private ChatMessageItemResponse sampleMessage() {
+		return new ChatMessageItemResponse(
+			101L,
+			7L,
+			"member",
+			null,
+			"hello",
+			ChatMessageType.TEXT,
+			List.of(),
+			Instant.parse("2026-03-11T00:00:00Z"));
+	}
+}


### PR DESCRIPTION
 ## 📌 PR 요약

  #### Summary

  - 채팅방 수에 비례해 증가하던 Redis Stream 구독 구조를 고정 파티션 기반으로 전환했습니다.
  - 클라이언트 WebSocket 계약(/topic/chat-rooms/{roomId})은 유지하면서, 이행을 위한 legacy consume/dual-write 경로를 함께 추가했습니다.
  - 운영 안정성을 위해 Consumer Group 선생성, NOGROUP 자가복구, 파티션 관측성 지표를 보강했습니다.

  ### Issue

  - close : #

  ———

  ## ➕ 추가된 기능

  1. 파티션 기반 스트림 라우팅 추가
      - chat:partition:{id} 키 전략 및 chatRoomId -> partitionId(floorMod) 매핑 도입
  2. 이행/운영 설정 확장
      - partitionCount, maxAllowedPartitions, partitionConsumeEnabled, dualWriteEnabled, legacyRoomConsumeEnabled 추가
  3. Consumer Group/Consumer 정책 고정
      - groupName 고정, consumerName은 POD_NAME 또는 hostname-pid 기반으로 생성
  4. 파티션 관측성 추가
      - 파티션 처리량/지연/백로그/에러 메트릭 및 로그 태그(partitionId, streamKey, errorType) 보강

  ## 🛠️ 수정/변경사항

  1. Publisher/Subscriber 구조 변경
      - Publisher 기본 write 대상을 파티션 stream으로 전환, dualWriteEnabled=true 시 legacy room stream 동시 write
      - Subscriber를 room별 동적 구독에서 고정 파티션 구독으로 교체
  2. Consumer Group 초기화/복구 강화
      - 앱 시작 시 파티션별 group 선생성(BUSYGROUP 정상 처리)
      - NOGROUP 감지 시 group 재보장 + 파티션 재구독 자가복구 추가
  3. WS 구독 리스너 단순화
      - room별 ensureSubscribed는 legacyRoomConsumeEnabled일 때만 동작
  4. 설정 반영 및 테스트 보강
      - application.yml, application.stg.yml, application.prod.yml에 chat.stream 파티션 기본값 반영(partitionCount=16)
      - 파티션 해시 분배/dual-write 분기 단위 테스트 추가

  ———

  ## ✅ 남은 작업

  - [ ] 통합 테스트 보강 (publish → partition consume → websocket 전달, ACK/재시도/DLQ)
  - [ ] 파티션 부하 테스트 및 partitionCount/executor 튜닝 기준 확정
  - [ ] Legacy stream drain 운영 절차 수행 (XPENDING 점검 후 legacyRoomConsumeEnabled=false)
  - [ ] 안정화 후 dualWriteEnabled=false 전환
