### PR TITLE
♻️ refactor: QueueMessage payload를 byte[]에서 JsonNode로 변경하여 직렬화 구조 단순화

### DIFF
--- a/app-api/src/main/java/com/tasteam/domain/notification/consumer/NotificationMessageQueueConsumer.java
+++ b/app-api/src/main/java/com/tasteam/domain/notification/consumer/NotificationMessageQueueConsumer.java
@@ -1,7 +1,6 @@
 package com.tasteam.domain.notification.consumer;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -10,6 +9,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tasteam.domain.notification.payload.NotificationRequestedPayload;
 import com.tasteam.infra.messagequeue.MessageQueueConsumer;
@@ -89,12 +89,11 @@ public class NotificationMessageQueueConsumer {
 		}
 	}
 
-	private NotificationRequestedPayload deserializePayload(byte[] payload) {
+	private NotificationRequestedPayload deserializePayload(JsonNode payload) {
 		try {
-			return objectMapper.readValue(payload, NotificationRequestedPayload.class);
+			return objectMapper.treeToValue(payload, NotificationRequestedPayload.class);
 		} catch (IOException ex) {
-			String payloadAsString = new String(payload, StandardCharsets.UTF_8);
-			throw new IllegalArgumentException("알림 메시지 역직렬화 실패. payload=" + payloadAsString, ex);
+			throw new IllegalArgumentException("알림 메시지 역직렬화 실패. payload=" + payload, ex);
 		}
 	}
 }

--- a/app-api/src/main/java/com/tasteam/infra/messagequeue/GroupMemberJoinedMessageQueuePublisher.java
+++ b/app-api/src/main/java/com/tasteam/infra/messagequeue/GroupMemberJoinedMessageQueuePublisher.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tasteam.domain.group.event.GroupMemberJoinedEvent;
 
@@ -29,7 +29,7 @@ public class GroupMemberJoinedMessageQueuePublisher {
 			return;
 		}
 
-		byte[] payload = serializePayload(event);
+		JsonNode payload = serializePayload(event);
 		QueueMessage message = new QueueMessage(
 			topicNamingPolicy.main(QueueTopic.GROUP_MEMBER_JOINED),
 			String.valueOf(event.memberId()),
@@ -41,15 +41,15 @@ public class GroupMemberJoinedMessageQueuePublisher {
 		messageQueueProducer.publish(message);
 	}
 
-	private byte[] serializePayload(GroupMemberJoinedEvent event) {
+	private JsonNode serializePayload(GroupMemberJoinedEvent event) {
 		GroupMemberJoinedMessagePayload payload = new GroupMemberJoinedMessagePayload(
 			event.groupId(),
 			event.memberId(),
 			event.groupName(),
 			event.joinedAt().toEpochMilli());
 		try {
-			return objectMapper.writeValueAsBytes(payload);
-		} catch (JsonProcessingException ex) {
+			return objectMapper.valueToTree(payload);
+		} catch (IllegalArgumentException ex) {
 			throw new IllegalStateException("GroupMemberJoinedEvent 메시지 직렬화에 실패했습니다", ex);
 		}
 	}

--- a/app-api/src/main/java/com/tasteam/infra/messagequeue/MessageQueueConfig.java
+++ b/app-api/src/main/java/com/tasteam/infra/messagequeue/MessageQueueConfig.java
@@ -75,6 +75,7 @@ public class MessageQueueConfig {
 	public MessageQueueConsumer messageQueueConsumer(
 		MessageQueueProperties properties,
 		MessageQueueTraceService traceService,
+		ObjectMapper objectMapper,
 		@Nullable
 		StringRedisTemplate stringRedisTemplate,
 		@Nullable @Qualifier("messageQueueStreamListenerContainer")
@@ -85,7 +86,8 @@ public class MessageQueueConfig {
 			case REDIS_STREAM -> new RedisStreamMessageQueueConsumer(
 				requireRedisTemplate(stringRedisTemplate),
 				requireStreamListenerContainer(messageQueueStreamListenerContainer),
-				properties);
+				properties,
+				objectMapper);
 			case KAFKA -> new UnsupportedMessageQueueConsumer(providerType);
 		};
 		return new TracingMessageQueueConsumer(delegate, providerType, traceService);

--- a/app-api/src/main/java/com/tasteam/infra/messagequeue/MessageQueueProducer.java
+++ b/app-api/src/main/java/com/tasteam/infra/messagequeue/MessageQueueProducer.java
@@ -19,9 +19,9 @@ public interface MessageQueueProducer {
 	 *
 	 * @param topic 메시지 라우팅 토픽
 	 * @param key 파티셔닝 또는 식별에 사용하는 키
-	 * @param payload 직렬화된 메시지 본문
+	 * @param payload JSON 페이로드
 	 */
-	default void publish(String topic, String key, byte[] payload) {
+	default void publish(String topic, String key, com.fasterxml.jackson.databind.JsonNode payload) {
 		publish(QueueMessage.of(topic, key, payload));
 	}
 }

--- a/app-api/src/main/java/com/tasteam/infra/messagequeue/NotificationMessageQueueConsumerRegistrar.java
+++ b/app-api/src/main/java/com/tasteam/infra/messagequeue/NotificationMessageQueueConsumerRegistrar.java
@@ -1,11 +1,10 @@
 package com.tasteam.infra.messagequeue;
 
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tasteam.domain.notification.entity.NotificationType;
 import com.tasteam.domain.notification.service.NotificationService;
@@ -53,12 +52,11 @@ public class NotificationMessageQueueConsumerRegistrar {
 		}
 	}
 
-	private GroupMemberJoinedMessagePayload deserializePayload(byte[] payload) {
+	private GroupMemberJoinedMessagePayload deserializePayload(JsonNode payload) {
 		try {
-			return objectMapper.readValue(payload, GroupMemberJoinedMessagePayload.class);
-		} catch (IOException ex) {
-			String payloadAsString = new String(payload, StandardCharsets.UTF_8);
-			throw new IllegalArgumentException("GroupMemberJoined 메시지 역직렬화에 실패했습니다. payload=" + payloadAsString, ex);
+			return objectMapper.treeToValue(payload, GroupMemberJoinedMessagePayload.class);
+		} catch (JsonProcessingException ex) {
+			throw new IllegalArgumentException("GroupMemberJoined 메시지 역직렬화에 실패했습니다. payload=" + payload, ex);
 		}
 	}
 

--- a/app-api/src/main/java/com/tasteam/infra/messagequeue/QueueMessage.java
+++ b/app-api/src/main/java/com/tasteam/infra/messagequeue/QueueMessage.java
@@ -5,10 +5,12 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 
+import com.fasterxml.jackson.databind.JsonNode;
+
 public record QueueMessage(
 	String topic,
 	String key,
-	byte[] payload,
+	JsonNode payload,
 	Map<String, String> headers,
 	Instant occurredAt,
 	String messageId) {
@@ -19,13 +21,12 @@ public record QueueMessage(
 		}
 		Objects.requireNonNull(payload, "payload는 필수입니다");
 
-		payload = payload.clone();
 		headers = headers == null ? Map.of() : Map.copyOf(headers);
 		occurredAt = occurredAt == null ? Instant.now() : occurredAt;
 		messageId = (messageId == null || messageId.isBlank()) ? UUID.randomUUID().toString() : messageId;
 	}
 
-	public static QueueMessage of(String topic, String key, byte[] payload) {
+	public static QueueMessage of(String topic, String key, JsonNode payload) {
 		return new QueueMessage(topic, key, payload, Map.of(), Instant.now(), null);
 	}
 }

--- a/app-api/src/main/java/com/tasteam/infra/messagequeue/RedisStreamMessageQueueConsumer.java
+++ b/app-api/src/main/java/com/tasteam/infra/messagequeue/RedisStreamMessageQueueConsumer.java
@@ -14,6 +14,10 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.stream.StreamMessageListenerContainer;
 import org.springframework.data.redis.stream.Subscription;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.NullNode;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -24,6 +28,7 @@ public class RedisStreamMessageQueueConsumer implements MessageQueueConsumer {
 	private final StringRedisTemplate stringRedisTemplate;
 	private final StreamMessageListenerContainer<String, MapRecord<String, String, String>> streamListenerContainer;
 	private final MessageQueueProperties properties;
+	private final ObjectMapper objectMapper;
 	private final Map<MessageQueueSubscription, Subscription> subscriptions = new ConcurrentHashMap<>();
 
 	@Override
@@ -80,7 +85,7 @@ public class RedisStreamMessageQueueConsumer implements MessageQueueConsumer {
 		String key = emptyToNull(recordValue.get("key"));
 		String messageId = recordValue.get("messageId");
 		Instant occurredAt = parseOccurredAt(recordValue.get("occurredAt"));
-		byte[] payload = java.util.Base64.getDecoder().decode(recordValue.getOrDefault("payload", ""));
+		JsonNode payload = parsePayload(recordValue.get("payload"));
 
 		Map<String, String> headers = new HashMap<>();
 		recordValue.forEach((field, value) -> {
@@ -90,6 +95,18 @@ public class RedisStreamMessageQueueConsumer implements MessageQueueConsumer {
 		});
 
 		return new QueueMessage(topic, key, payload, headers, occurredAt, messageId);
+	}
+
+	private JsonNode parsePayload(String value) {
+		if (value == null || value.isBlank()) {
+			return NullNode.getInstance();
+		}
+		try {
+			return objectMapper.readTree(value);
+		} catch (Exception ex) {
+			log.warn("메시지큐 레코드의 payload JSON 파싱 실패. value={}", value);
+			return NullNode.getInstance();
+		}
 	}
 
 	private Instant parseOccurredAt(String value) {

--- a/app-api/src/main/java/com/tasteam/infra/messagequeue/RedisStreamMessageQueueProducer.java
+++ b/app-api/src/main/java/com/tasteam/infra/messagequeue/RedisStreamMessageQueueProducer.java
@@ -44,7 +44,7 @@ public class RedisStreamMessageQueueProducer implements MessageQueueProducer {
 		value.put("topic", message.topic());
 		value.put("key", message.key() == null ? "" : message.key());
 		value.put("occurredAt", String.valueOf(message.occurredAt().toEpochMilli()));
-		value.put("payload", java.util.Base64.getEncoder().encodeToString(message.payload()));
+		value.put("payload", message.payload().toString());
 
 		message.headers().forEach((headerKey, headerValue) -> value.put("header." + headerKey, headerValue));
 		return value;

--- a/app-api/src/main/java/com/tasteam/infra/messagequeue/UserActivityMessageQueueConsumerRegistrar.java
+++ b/app-api/src/main/java/com/tasteam/infra/messagequeue/UserActivityMessageQueueConsumerRegistrar.java
@@ -1,12 +1,12 @@
 package com.tasteam.infra.messagequeue;
 
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tasteam.domain.analytics.api.ActivityEvent;
 import com.tasteam.domain.analytics.persistence.UserActivityEventStoreService;
@@ -43,8 +43,8 @@ public class UserActivityMessageQueueConsumerRegistrar {
 			"user-activity-" + UUID.randomUUID());
 
 		messageQueueConsumer.subscribe(subscription, message -> {
-			ActivityEvent payload = deserializePayload(message.payload());
-			userActivityEventStoreService.store(payload);
+			ActivityEvent event = deserializePayload(message.payload());
+			userActivityEventStoreService.store(event);
 		});
 	}
 
@@ -55,12 +55,11 @@ public class UserActivityMessageQueueConsumerRegistrar {
 		}
 	}
 
-	private ActivityEvent deserializePayload(byte[] payload) {
+	private ActivityEvent deserializePayload(JsonNode payload) {
 		try {
-			return objectMapper.readValue(payload, ActivityEvent.class);
-		} catch (IOException ex) {
-			String payloadAsString = new String(payload, StandardCharsets.UTF_8);
-			throw new IllegalArgumentException("UserActivity 메시지 역직렬화에 실패했습니다. payload=" + payloadAsString, ex);
+			return objectMapper.treeToValue(payload, ActivityEvent.class);
+		} catch (JsonProcessingException ex) {
+			throw new IllegalArgumentException("UserActivity 메시지 역직렬화에 실패했습니다. payload=" + payload, ex);
 		}
 	}
 }

--- a/app-api/src/main/java/com/tasteam/infra/messagequeue/UserActivityMessageQueuePublisher.java
+++ b/app-api/src/main/java/com/tasteam/infra/messagequeue/UserActivityMessageQueuePublisher.java
@@ -9,7 +9,7 @@ import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tasteam.domain.analytics.api.ActivityEvent;
 import com.tasteam.domain.analytics.api.ActivitySink;
@@ -60,12 +60,8 @@ public class UserActivityMessageQueuePublisher implements ActivitySink {
 		}
 	}
 
-	private byte[] serialize(ActivityEvent event) {
-		try {
-			return objectMapper.writeValueAsBytes(event);
-		} catch (JsonProcessingException ex) {
-			throw new IllegalStateException("사용자 이벤트 메시지 직렬화에 실패했습니다", ex);
-		}
+	private JsonNode serialize(ActivityEvent event) {
+		return objectMapper.valueToTree(event);
 	}
 
 	private Map<String, String> buildHeaders(ActivityEvent event) {

--- a/app-api/src/main/java/com/tasteam/infra/messagequeue/serialization/JsonQueueMessageSerializer.java
+++ b/app-api/src/main/java/com/tasteam/infra/messagequeue/serialization/JsonQueueMessageSerializer.java
@@ -2,10 +2,9 @@ package com.tasteam.infra.messagequeue.serialization;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
-import java.util.Base64;
 import java.util.Map;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tasteam.infra.messagequeue.QueueMessage;
 import com.tasteam.infra.messagequeue.exception.MessageQueueNonRetryableException;
@@ -20,8 +19,8 @@ public class JsonQueueMessageSerializer implements QueueMessageSerializer {
 	@Override
 	public QueueMessage createMessage(String topic, String key, Object payload, Map<String, String> headers) {
 		try {
-			byte[] payloadBytes = toPayloadBytes(payload);
-			return new QueueMessage(topic, key, payloadBytes, headers, Instant.now(), null);
+			JsonNode payloadNode = toPayloadNode(payload);
+			return new QueueMessage(topic, key, payloadNode, headers, Instant.now(), null);
 		} catch (Exception ex) {
 			throw new MessageQueueNonRetryableException(
 				"메시지 payload 직렬화에 실패했습니다. topic=%s".formatted(topic),
@@ -37,12 +36,12 @@ public class JsonQueueMessageSerializer implements QueueMessageSerializer {
 			QueueMessageEnvelope envelope = new QueueMessageEnvelope(
 				message.topic(),
 				message.key(),
-				Base64.getEncoder().encodeToString(message.payload()),
+				message.payload(),
 				message.headers(),
 				message.occurredAt().toEpochMilli(),
 				message.messageId());
 			return objectMapper.writeValueAsString(envelope);
-		} catch (JsonProcessingException ex) {
+		} catch (Exception ex) {
 			throw new IllegalArgumentException("메시지 직렬화에 실패했습니다", ex);
 		}
 	}
@@ -55,12 +54,11 @@ public class JsonQueueMessageSerializer implements QueueMessageSerializer {
 
 		try {
 			QueueMessageEnvelope envelope = objectMapper.readValue(serialized, QueueMessageEnvelope.class);
-			byte[] payload = Base64.getDecoder().decode(emptyToDefault(envelope.payloadBase64(), ""));
 
 			return new QueueMessage(
 				emptyToDefault(envelope.topic(), "unknown"),
 				blankToNull(envelope.key()),
-				payload,
+				envelope.payload() != null ? envelope.payload() : objectMapper.nullNode(),
 				envelope.headers() == null ? Map.of() : envelope.headers(),
 				Instant.ofEpochMilli(envelope.occurredAtEpochMillis()),
 				envelope.messageId());
@@ -91,10 +89,10 @@ public class JsonQueueMessageSerializer implements QueueMessageSerializer {
 		return value.substring(0, Math.min(value.length(), 120)) + "...";
 	}
 
-	private byte[] toPayloadBytes(Object payload) throws JsonProcessingException {
-		if (payload instanceof byte[] bytes) {
-			return bytes.clone();
+	private JsonNode toPayloadNode(Object payload) {
+		if (payload instanceof JsonNode jsonNode) {
+			return jsonNode;
 		}
-		return objectMapper.writeValueAsBytes(payload);
+		return objectMapper.valueToTree(payload);
 	}
 }

--- a/app-api/src/main/java/com/tasteam/infra/messagequeue/serialization/QueueMessageEnvelope.java
+++ b/app-api/src/main/java/com/tasteam/infra/messagequeue/serialization/QueueMessageEnvelope.java
@@ -2,10 +2,12 @@ package com.tasteam.infra.messagequeue.serialization;
 
 import java.util.Map;
 
+import com.fasterxml.jackson.databind.JsonNode;
+
 public record QueueMessageEnvelope(
 	String topic,
 	String key,
-	String payloadBase64,
+	JsonNode payload,
 	Map<String, String> headers,
 	long occurredAtEpochMillis,
 	String messageId) {

--- a/app-api/src/test/java/com/tasteam/domain/notification/consumer/NotificationMessageQueueConsumerTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/notification/consumer/NotificationMessageQueueConsumerTest.java
@@ -55,7 +55,7 @@ class NotificationMessageQueueConsumerTest {
 		QueueMessage message = QueueMessage.of(
 			QueueTopic.NOTIFICATION_REQUESTED.defaultMainTopic(),
 			"10",
-			objectMapper.writeValueAsBytes(samplePayload("evt-success")));
+			objectMapper.valueToTree(samplePayload("evt-success")));
 
 		ReflectionTestUtils.invokeMethod(consumer, "handleMessage", message);
 
@@ -87,7 +87,7 @@ class NotificationMessageQueueConsumerTest {
 		QueueMessage message = QueueMessage.of(
 			QueueTopic.NOTIFICATION_REQUESTED.defaultMainTopic(),
 			"10",
-			objectMapper.writeValueAsBytes(samplePayload("evt-fail")));
+			objectMapper.valueToTree(samplePayload("evt-fail")));
 
 		ReflectionTestUtils.invokeMethod(consumer, "handleMessage", message);
 
@@ -105,7 +105,7 @@ class NotificationMessageQueueConsumerTest {
 		QueueMessage message = QueueMessage.of(
 			QueueTopic.NOTIFICATION_REQUESTED.defaultMainTopic(),
 			"10",
-			objectMapper.writeValueAsBytes(samplePayload("evt-fail")));
+			objectMapper.valueToTree(samplePayload("evt-fail")));
 		org.mockito.ArgumentCaptor<QueueMessage> captor = forClass(QueueMessage.class);
 
 		dlqPublisher.publish(message);

--- a/app-api/src/test/java/com/tasteam/infra/messagequeue/GroupMemberJoinedMessageQueuePublisherTest.java
+++ b/app-api/src/test/java/com/tasteam/infra/messagequeue/GroupMemberJoinedMessageQueuePublisherTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tasteam.config.annotation.UnitTest;
 import com.tasteam.domain.group.event.GroupMemberJoinedEvent;
@@ -76,7 +75,7 @@ class GroupMemberJoinedMessageQueuePublisherTest {
 		assertThat(message.occurredAt()).isEqualTo(joinedAt);
 		assertThat(message.headers()).containsEntry("eventType", "GroupMemberJoinedEvent");
 
-		GroupMemberJoinedMessagePayload payload = objectMapper.readValue(
+		GroupMemberJoinedMessagePayload payload = objectMapper.treeToValue(
 			message.payload(),
 			GroupMemberJoinedMessagePayload.class);
 		assertThat(payload.groupId()).isEqualTo(10L);
@@ -94,8 +93,8 @@ class GroupMemberJoinedMessageQueuePublisherTest {
 		properties.setProvider("redis-stream");
 		TopicNamingPolicy topicNamingPolicy = new DefaultTopicNamingPolicy(new KafkaMessageQueueProperties());
 		ObjectMapper objectMapper = mock(ObjectMapper.class);
-		when(objectMapper.writeValueAsBytes(org.mockito.ArgumentMatchers.any()))
-			.thenThrow(new JsonProcessingException("failed") {});
+		when(objectMapper.valueToTree(org.mockito.ArgumentMatchers.any()))
+			.thenThrow(new IllegalArgumentException("failed"));
 		GroupMemberJoinedMessageQueuePublisher publisher = new GroupMemberJoinedMessageQueuePublisher(
 			producer,
 			properties,

--- a/app-api/src/test/java/com/tasteam/infra/messagequeue/KafkaPublishSupportTest.java
+++ b/app-api/src/test/java/com/tasteam/infra/messagequeue/KafkaPublishSupportTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.support.SendResult;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tasteam.config.annotation.UnitTest;
 import com.tasteam.infra.messagequeue.exception.MessageQueuePublishException;
 import com.tasteam.infra.messagequeue.serialization.QueueMessageSerializer;
@@ -25,14 +26,14 @@ class KafkaPublishSupportTest {
 
 	@Test
 	@DisplayName("Kafka 전송이 성공하면 예외 없이 반환한다")
-	void publish_success_returnsNormally() {
+	void publish_success_returnsNormally() throws Exception {
 		// given
 		@SuppressWarnings("unchecked") KafkaTemplate<String, String> kafkaTemplate = mock(KafkaTemplate.class);
 		QueueMessageSerializer serializer = mock(QueueMessageSerializer.class);
 		QueueMessage message = new QueueMessage(
 			"evt.test",
 			"k1",
-			"{\"ok\":true}".getBytes(),
+			new ObjectMapper().readTree("{\"ok\":true}"),
 			Map.of("eventType", "TEST"),
 			Instant.now(),
 			"msg-1");
@@ -55,14 +56,14 @@ class KafkaPublishSupportTest {
 
 	@Test
 	@DisplayName("Kafka 전송이 실패하면 MessageQueuePublishException으로 래핑한다")
-	void publish_failure_wrapsException() {
+	void publish_failure_wrapsException() throws Exception {
 		// given
 		@SuppressWarnings("unchecked") KafkaTemplate<String, String> kafkaTemplate = mock(KafkaTemplate.class);
 		QueueMessageSerializer serializer = mock(QueueMessageSerializer.class);
 		QueueMessage message = new QueueMessage(
 			"evt.test",
 			"k1",
-			"{\"ok\":false}".getBytes(),
+			new ObjectMapper().readTree("{\"ok\":false}"),
 			Map.of(),
 			Instant.now(),
 			"msg-2");

--- a/app-api/src/test/java/com/tasteam/infra/messagequeue/MessageQueueConfigTest.java
+++ b/app-api/src/test/java/com/tasteam/infra/messagequeue/MessageQueueConfigTest.java
@@ -10,6 +10,7 @@ import org.springframework.data.redis.connection.stream.MapRecord;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.stream.StreamMessageListenerContainer;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tasteam.config.annotation.UnitTest;
 import com.tasteam.infra.messagequeue.trace.MessageQueueTraceService;
 
@@ -72,9 +73,10 @@ class MessageQueueConfigTest {
 		MessageQueueProperties properties = new MessageQueueProperties();
 		properties.setProvider("none");
 		MessageQueueTraceService traceService = mock(MessageQueueTraceService.class);
+		ObjectMapper objectMapper = new ObjectMapper();
 
 		// when
-		MessageQueueConsumer consumer = config.messageQueueConsumer(properties, traceService, null, null);
+		MessageQueueConsumer consumer = config.messageQueueConsumer(properties, traceService, objectMapper, null, null);
 
 		// then
 		assertThat(consumer).isInstanceOf(TracingMessageQueueConsumer.class);
@@ -87,12 +89,14 @@ class MessageQueueConfigTest {
 		MessageQueueProperties properties = new MessageQueueProperties();
 		properties.setProvider("redis-stream");
 		MessageQueueTraceService traceService = mock(MessageQueueTraceService.class);
+		ObjectMapper objectMapper = new ObjectMapper();
 		StringRedisTemplate stringRedisTemplate = mock(StringRedisTemplate.class);
 		@SuppressWarnings("unchecked") StreamMessageListenerContainer<String, MapRecord<String, String, String>> listenerContainer = mock(
 			StreamMessageListenerContainer.class);
 
 		// when
-		MessageQueueConsumer consumer = config.messageQueueConsumer(properties, traceService, stringRedisTemplate,
+		MessageQueueConsumer consumer = config.messageQueueConsumer(properties, traceService, objectMapper,
+			stringRedisTemplate,
 			listenerContainer);
 
 		// then
@@ -107,10 +111,12 @@ class MessageQueueConfigTest {
 		properties.setEnabled(true);
 		properties.setProvider("redis-stream");
 		MessageQueueTraceService traceService = mock(MessageQueueTraceService.class);
+		ObjectMapper objectMapper = new ObjectMapper();
 		StringRedisTemplate stringRedisTemplate = mock(StringRedisTemplate.class);
 
 		// when & then
-		assertThatThrownBy(() -> config.messageQueueConsumer(properties, traceService, stringRedisTemplate, null))
+		assertThatThrownBy(
+			() -> config.messageQueueConsumer(properties, traceService, objectMapper, stringRedisTemplate, null))
 			.isInstanceOf(IllegalStateException.class)
 			.hasMessageContaining("StreamMessageListenerContainer");
 	}

--- a/app-api/src/test/java/com/tasteam/infra/messagequeue/NotificationMessageQueueConsumerRegistrarTest.java
+++ b/app-api/src/test/java/com/tasteam/infra/messagequeue/NotificationMessageQueueConsumerRegistrarTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import java.nio.charset.StandardCharsets;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.DisplayName;
@@ -80,7 +79,7 @@ class NotificationMessageQueueConsumerRegistrarTest {
 		capturedHandler.get().handle(QueueMessage.of(
 			QueueTopic.GROUP_MEMBER_JOINED.defaultMainTopic(),
 			"200",
-			objectMapper.writeValueAsBytes(payload)));
+			objectMapper.valueToTree(payload)));
 
 		verify(notificationService).createNotification(
 			eq(200L),
@@ -119,7 +118,7 @@ class NotificationMessageQueueConsumerRegistrarTest {
 			QueueMessage.of(
 				QueueTopic.GROUP_MEMBER_JOINED.defaultMainTopic(),
 				"200",
-				"{\"memberId\":\"invalid\"}".getBytes(StandardCharsets.UTF_8))))
+				new ObjectMapper().createObjectNode().put("memberId", "invalid"))))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("역직렬화");
 	}

--- a/app-api/src/test/java/com/tasteam/infra/messagequeue/NotificationMessageQueueFlowIntegrationTest.java
+++ b/app-api/src/test/java/com/tasteam/infra/messagequeue/NotificationMessageQueueFlowIntegrationTest.java
@@ -5,7 +5,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 
-import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 
 import org.junit.jupiter.api.DisplayName;
@@ -72,7 +71,7 @@ class NotificationMessageQueueFlowIntegrationTest {
 		assertThat(publishedMessage.key()).isEqualTo("20");
 		assertThat(publishedMessage.headers()).containsEntry("eventType", "GroupMemberJoinedEvent");
 
-		GroupMemberJoinedMessagePayload payload = objectMapper.readValue(
+		GroupMemberJoinedMessagePayload payload = objectMapper.treeToValue(
 			publishedMessage.payload(),
 			GroupMemberJoinedMessagePayload.class);
 		assertThat(payload.groupId()).isEqualTo(10L);
@@ -87,7 +86,7 @@ class NotificationMessageQueueFlowIntegrationTest {
 		handlerCaptor.getValue().handle(QueueMessage.of(
 			QueueTopic.GROUP_MEMBER_JOINED.defaultMainTopic(),
 			"20",
-			objectMapper.writeValueAsBytes(payload)));
+			objectMapper.valueToTree(payload)));
 
 		verify(notificationService).createNotification(
 			eq(20L),
@@ -110,7 +109,7 @@ class NotificationMessageQueueFlowIntegrationTest {
 			QueueMessage.of(
 				QueueTopic.GROUP_MEMBER_JOINED.defaultMainTopic(),
 				"20",
-				"{\"memberId\":\"invalid\"}".getBytes(StandardCharsets.UTF_8))))
+				objectMapper.readTree("{\"memberId\":\"invalid\"}"))))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("역직렬화");
 	}

--- a/app-api/src/test/java/com/tasteam/infra/messagequeue/QueueMessageTest.java
+++ b/app-api/src/test/java/com/tasteam/infra/messagequeue/QueueMessageTest.java
@@ -9,32 +9,39 @@ import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tasteam.config.annotation.UnitTest;
 
 @UnitTest
 @DisplayName("[유닛](Message) QueueMessage 단위 테스트")
 class QueueMessageTest {
 
+	private static final ObjectMapper MAPPER = new ObjectMapper();
+
 	@Test
 	@DisplayName("팩토리 메서드로 메시지를 만들면 기본 헤더와 식별 정보가 채워진다")
-	void of_createsMessageWithDefaults() {
+	void of_createsMessageWithDefaults() throws Exception {
+		// given
+		JsonNode payload = MAPPER.readTree("{\"type\":\"WELCOME\"}");
+
 		// when
-		QueueMessage message = QueueMessage.of("notification.created", "member-1", new byte[] {1, 2, 3});
+		QueueMessage message = QueueMessage.of("notification.created", "member-1", payload);
 
 		// then
 		assertThat(message.topic()).isEqualTo("notification.created");
 		assertThat(message.key()).isEqualTo("member-1");
-		assertThat(message.payload()).containsExactly(1, 2, 3);
+		assertThat(message.payload().get("type").asText()).isEqualTo("WELCOME");
 		assertThat(message.headers()).isEmpty();
 		assertThat(message.messageId()).isNotBlank();
 		assertThat(message.occurredAt()).isNotNull();
 	}
 
 	@Test
-	@DisplayName("생성 후 원본 payload와 headers를 변경해도 메시지 내부 값은 유지된다")
-	void constructor_defensivelyCopiesPayloadAndHeaders() {
+	@DisplayName("생성 후 원본 headers를 변경해도 메시지 내부 값은 유지된다")
+	void constructor_defensivelyCopiesHeaders() throws Exception {
 		// given
-		byte[] payload = new byte[] {9, 8, 7};
+		JsonNode payload = MAPPER.readTree("{\"key\":\"value\"}");
 		Map<String, String> headers = new HashMap<>();
 		headers.put("source", "test");
 
@@ -47,19 +54,29 @@ class QueueMessageTest {
 			null,
 			null);
 
-		payload[0] = 1;
 		headers.put("source", "changed");
 
 		// then
-		assertThat(message.payload()).containsExactly(9, 8, 7);
+		assertThat(message.payload().get("key").asText()).isEqualTo("value");
 		assertThat(message.headers().get("source")).isEqualTo("test");
 	}
 
 	@Test
-	@DisplayName("topic이 비어 있으면 메시지를 생성할 수 없다")
-	void constructor_blankTopic_throwsException() {
+	@DisplayName("payload가 null이면 메시지를 생성할 수 없다")
+	void constructor_nullPayload_throwsException() {
 		// when & then
-		assertThatThrownBy(() -> new QueueMessage(" ", "k", new byte[] {1}, Map.of(), null, null))
+		assertThatThrownBy(() -> new QueueMessage("topic", "key", null, Map.of(), null, null))
+			.isInstanceOf(NullPointerException.class);
+	}
+
+	@Test
+	@DisplayName("topic이 비어 있으면 메시지를 생성할 수 없다")
+	void constructor_blankTopic_throwsException() throws Exception {
+		// given
+		JsonNode payload = MAPPER.readTree("{}");
+
+		// when & then
+		assertThatThrownBy(() -> new QueueMessage(" ", "k", payload, Map.of(), null, null))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("topic은 필수");
 	}

--- a/app-api/src/test/java/com/tasteam/infra/messagequeue/RedisStreamMessageQueueConsumerTest.java
+++ b/app-api/src/test/java/com/tasteam/infra/messagequeue/RedisStreamMessageQueueConsumerTest.java
@@ -8,9 +8,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.nio.charset.StandardCharsets;
 import java.time.Instant;
-import java.util.Base64;
 import java.util.Map;
 
 import org.junit.jupiter.api.DisplayName;
@@ -50,7 +48,8 @@ class RedisStreamMessageQueueConsumerTest {
 		RedisStreamMessageQueueConsumer consumer = new RedisStreamMessageQueueConsumer(
 			redisTemplate,
 			listenerContainer,
-			properties);
+			properties,
+			new com.fasterxml.jackson.databind.ObjectMapper());
 		MessageQueueSubscription subscription = new MessageQueueSubscription("order.created", "group-1", "consumer-1");
 
 		// when
@@ -78,7 +77,8 @@ class RedisStreamMessageQueueConsumerTest {
 		RedisStreamMessageQueueConsumer consumer = new RedisStreamMessageQueueConsumer(
 			redisTemplate,
 			listenerContainer,
-			properties);
+			properties,
+			new com.fasterxml.jackson.databind.ObjectMapper());
 		MessageQueueSubscription subscription = new MessageQueueSubscription("order.created", "group-1", "consumer-1");
 		consumer.subscribe(subscription, message -> {});
 
@@ -110,7 +110,8 @@ class RedisStreamMessageQueueConsumerTest {
 		RedisStreamMessageQueueConsumer consumer = new RedisStreamMessageQueueConsumer(
 			redisTemplate,
 			listenerContainer,
-			properties);
+			properties,
+			new com.fasterxml.jackson.databind.ObjectMapper());
 		MessageQueueSubscription subscription = new MessageQueueSubscription("order.created", "group-1", "consumer-1");
 
 		java.util.concurrent.atomic.AtomicReference<QueueMessage> captured = new java.util.concurrent.atomic.AtomicReference<>();
@@ -128,7 +129,7 @@ class RedisStreamMessageQueueConsumerTest {
 			"topic", "order.created",
 			"key", "order-1",
 			"occurredAt", String.valueOf(Instant.parse("2026-02-14T00:00:00Z").toEpochMilli()),
-			"payload", Base64.getEncoder().encodeToString("payload".getBytes(StandardCharsets.UTF_8)),
+			"payload", "\"payload\"",
 			"header.source", "test"));
 
 		// when
@@ -138,7 +139,7 @@ class RedisStreamMessageQueueConsumerTest {
 		assertThat(captured.get()).isNotNull();
 		assertThat(captured.get().topic()).isEqualTo("order.created");
 		assertThat(captured.get().key()).isEqualTo("order-1");
-		assertThat(new String(captured.get().payload(), StandardCharsets.UTF_8)).isEqualTo("payload");
+		assertThat(captured.get().payload().asText()).isEqualTo("payload");
 		assertThat(captured.get().headers()).containsEntry("source", "test");
 		verify(streamOperations).acknowledge(eq("tasteam:order.created"), eq("group-1"), eq(RecordId.of("1-0")));
 	}
@@ -164,7 +165,8 @@ class RedisStreamMessageQueueConsumerTest {
 		RedisStreamMessageQueueConsumer consumer = new RedisStreamMessageQueueConsumer(
 			redisTemplate,
 			listenerContainer,
-			properties);
+			properties,
+			new com.fasterxml.jackson.databind.ObjectMapper());
 		MessageQueueSubscription subscription = new MessageQueueSubscription("order.created", "group-1", "consumer-1");
 
 		java.util.concurrent.atomic.AtomicReference<QueueMessage> captured = new java.util.concurrent.atomic.AtomicReference<>();
@@ -182,7 +184,7 @@ class RedisStreamMessageQueueConsumerTest {
 			"topic", "order.created",
 			"key", "order-2",
 			"occurredAt", "invalid-number",
-			"payload", Base64.getEncoder().encodeToString("payload".getBytes(StandardCharsets.UTF_8))));
+			"payload", "\"payload\""));
 
 		// when
 		listenerCaptor.getValue().onMessage(record);
@@ -211,7 +213,8 @@ class RedisStreamMessageQueueConsumerTest {
 		RedisStreamMessageQueueConsumer consumer = new RedisStreamMessageQueueConsumer(
 			redisTemplate,
 			listenerContainer,
-			properties);
+			properties,
+			new com.fasterxml.jackson.databind.ObjectMapper());
 		MessageQueueSubscription subscription = new MessageQueueSubscription("order.created", "group-1", "consumer-1");
 		consumer.subscribe(subscription, message -> {
 			throw new IllegalStateException("처리 실패");
@@ -228,7 +231,7 @@ class RedisStreamMessageQueueConsumerTest {
 			"topic", "order.created",
 			"key", "order-3",
 			"occurredAt", String.valueOf(Instant.parse("2026-02-14T00:00:00Z").toEpochMilli()),
-			"payload", Base64.getEncoder().encodeToString("payload".getBytes(StandardCharsets.UTF_8))));
+			"payload", "\"payload\""));
 
 		// when
 		listenerCaptor.getValue().onMessage(record);

--- a/app-api/src/test/java/com/tasteam/infra/messagequeue/RedisStreamMessageQueueProducerTest.java
+++ b/app-api/src/test/java/com/tasteam/infra/messagequeue/RedisStreamMessageQueueProducerTest.java
@@ -6,9 +6,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.nio.charset.StandardCharsets;
 import java.time.Instant;
-import java.util.Base64;
 import java.util.Map;
 
 import org.junit.jupiter.api.DisplayName;
@@ -18,6 +16,8 @@ import org.springframework.data.redis.connection.stream.MapRecord;
 import org.springframework.data.redis.core.StreamOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tasteam.config.annotation.UnitTest;
 
 @UnitTest
@@ -26,7 +26,7 @@ class RedisStreamMessageQueueProducerTest {
 
 	@Test
 	@DisplayName("메시지를 발행하면 topic-prefix 기반 stream 키로 저장한다")
-	void publish_writesRecordToPrefixedStreamKey() {
+	void publish_writesRecordToPrefixedStreamKey() throws Exception {
 		// given
 		StringRedisTemplate redisTemplate = mock(StringRedisTemplate.class);
 		@SuppressWarnings("unchecked") StreamOperations<String, Object, Object> streamOperations = mock(
@@ -37,10 +37,11 @@ class RedisStreamMessageQueueProducerTest {
 		properties.setTopicPrefix("tasteam");
 		RedisStreamMessageQueueProducer producer = new RedisStreamMessageQueueProducer(redisTemplate, properties);
 
+		JsonNode payload = new ObjectMapper().readTree("{\"data\":\"payload\"}");
 		QueueMessage message = new QueueMessage(
 			"order.created",
 			"order-1",
-			"payload".getBytes(StandardCharsets.UTF_8),
+			payload,
 			Map.of("source", "test"),
 			Instant.parse("2026-02-14T00:00:00Z"),
 			"msg-1");
@@ -59,7 +60,6 @@ class RedisStreamMessageQueueProducerTest {
 		assertThat(captured.getValue().get("topic")).isEqualTo("order.created");
 		assertThat(captured.getValue().get("key")).isEqualTo("order-1");
 		assertThat(captured.getValue().get("header.source")).isEqualTo("test");
-		assertThat(captured.getValue().get("payload"))
-			.isEqualTo(Base64.getEncoder().encodeToString("payload".getBytes(StandardCharsets.UTF_8)));
+		assertThat(captured.getValue().get("payload")).isEqualTo("{\"data\":\"payload\"}");
 	}
 }

--- a/app-api/src/test/java/com/tasteam/infra/messagequeue/TracingMessageQueueConsumerTest.java
+++ b/app-api/src/test/java/com/tasteam/infra/messagequeue/TracingMessageQueueConsumerTest.java
@@ -11,6 +11,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tasteam.config.annotation.UnitTest;
 import com.tasteam.infra.messagequeue.trace.MessageQueueTraceService;
 
@@ -30,7 +31,8 @@ class TracingMessageQueueConsumerTest {
 			traceService);
 		MessageQueueSubscription subscription = new MessageQueueSubscription("domain.group.member-joined", "group-1",
 			"consumer-1");
-		QueueMessage message = QueueMessage.of("domain.group.member-joined", "200", new byte[] {1});
+		QueueMessage message = QueueMessage.of("domain.group.member-joined", "200",
+			new ObjectMapper().createObjectNode());
 		AtomicReference<QueueMessageHandler> capturedHandler = new AtomicReference<>();
 		doAnswer(invocation -> {
 			QueueMessageHandler handler = invocation.getArgument(1);
@@ -59,7 +61,8 @@ class TracingMessageQueueConsumerTest {
 			traceService);
 		MessageQueueSubscription subscription = new MessageQueueSubscription("domain.group.member-joined", "group-1",
 			"consumer-1");
-		QueueMessage message = QueueMessage.of("domain.group.member-joined", "200", new byte[] {1});
+		QueueMessage message = QueueMessage.of("domain.group.member-joined", "200",
+			new ObjectMapper().createObjectNode());
 		AtomicReference<QueueMessageHandler> capturedHandler = new AtomicReference<>();
 		doAnswer(invocation -> {
 			QueueMessageHandler handler = invocation.getArgument(1);

--- a/app-api/src/test/java/com/tasteam/infra/messagequeue/TracingMessageQueueProducerTest.java
+++ b/app-api/src/test/java/com/tasteam/infra/messagequeue/TracingMessageQueueProducerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.verify;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tasteam.config.annotation.UnitTest;
 import com.tasteam.infra.messagequeue.trace.MessageQueueTraceService;
 
@@ -23,7 +24,7 @@ class TracingMessageQueueProducerTest {
 			delegate,
 			MessageQueueProviderType.REDIS_STREAM,
 			traceService);
-		QueueMessage message = QueueMessage.of("domain.review.created", "123", new byte[] {1});
+		QueueMessage message = QueueMessage.of("domain.review.created", "123", new ObjectMapper().createObjectNode());
 
 		// when
 		producer.publish(message);

--- a/app-api/src/test/java/com/tasteam/infra/messagequeue/UserActivityMessageQueueConsumerRegistrarTest.java
+++ b/app-api/src/test/java/com/tasteam/infra/messagequeue/UserActivityMessageQueueConsumerRegistrarTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
-import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Map;
 
@@ -67,7 +66,7 @@ class UserActivityMessageQueueConsumerRegistrarTest {
 			Map.of("groupId", 99L));
 		handlerCaptor.getValue().handle(
 			QueueMessage.of(topicNamingPolicy.main(QueueTopic.USER_ACTIVITY), "20",
-				objectMapper.writeValueAsBytes(event)));
+				objectMapper.valueToTree(event)));
 		verify(storeService).store(any(ActivityEvent.class));
 	}
 
@@ -125,7 +124,7 @@ class UserActivityMessageQueueConsumerRegistrarTest {
 			QueueMessage.of(
 				topicNamingPolicy.main(QueueTopic.USER_ACTIVITY),
 				"key",
-				"{\"eventId\":\"evt\"}".getBytes(StandardCharsets.UTF_8))))
+				new com.fasterxml.jackson.databind.ObjectMapper().readTree("{\"eventId\":\"evt\"}"))))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("역직렬화");
 		verifyNoInteractions(storeService);

--- a/app-api/src/test/java/com/tasteam/infra/messagequeue/UserActivityMessageQueueFlowIntegrationTest.java
+++ b/app-api/src/test/java/com/tasteam/infra/messagequeue/UserActivityMessageQueueFlowIntegrationTest.java
@@ -73,7 +73,7 @@ class UserActivityMessageQueueFlowIntegrationTest {
 		assertThat(published.topic()).isEqualTo(topicNamingPolicy.main(QueueTopic.USER_ACTIVITY));
 		assertThat(published.messageId()).isNotBlank();
 
-		ActivityEvent payload = objectMapper.readValue(published.payload(), ActivityEvent.class);
+		ActivityEvent payload = objectMapper.treeToValue(published.payload(), ActivityEvent.class);
 		assertThat(payload.eventName()).isEqualTo("review.created");
 		assertThat(((Number)payload.properties().get("restaurantId")).longValue()).isEqualTo(130L);
 

--- a/app-api/src/test/java/com/tasteam/infra/messagequeue/UserActivityMessageQueuePublisherTest.java
+++ b/app-api/src/test/java/com/tasteam/infra/messagequeue/UserActivityMessageQueuePublisherTest.java
@@ -63,7 +63,7 @@ class UserActivityMessageQueuePublisherTest {
 			.containsEntry("schemaVersion", "v1");
 
 		ActivityEvent payload = JsonMapper.builder().findAndAddModules().build()
-			.readValue(message.payload(), ActivityEvent.class);
+			.treeToValue(message.payload(), ActivityEvent.class);
 		assertThat(payload.eventId()).isEqualTo("evt-1");
 		assertThat(payload.eventName()).isEqualTo("group.joined");
 		assertThat(((Number)payload.properties().get("groupId")).longValue()).isEqualTo(10L);

--- a/app-api/src/test/java/com/tasteam/infra/messagequeue/serialization/JsonQueueMessageSerializerTest.java
+++ b/app-api/src/test/java/com/tasteam/infra/messagequeue/serialization/JsonQueueMessageSerializerTest.java
@@ -3,13 +3,13 @@ package com.tasteam.infra.messagequeue.serialization;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Map;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tasteam.config.annotation.UnitTest;
 import com.tasteam.infra.messagequeue.QueueMessage;
@@ -34,18 +34,19 @@ class JsonQueueMessageSerializerTest {
 		assertThat(message.topic()).isEqualTo("evt.notification.dispatch.v1");
 		assertThat(message.key()).isEqualTo("member-1");
 		assertThat(message.headers()).containsEntry("eventType", "NOTIFICATION_CREATED");
-		assertThat(new String(message.payload(), StandardCharsets.UTF_8)).contains("\"type\":\"WELCOME\"");
+		assertThat(message.payload().get("type").asText()).isEqualTo("WELCOME");
 		assertThat(message.messageId()).isNotBlank();
 	}
 
 	@Test
 	@DisplayName("메시지를 직렬화 후 역직렬화하면 핵심 필드가 유지된다")
-	void roundTrip_preservesMessageFields() {
+	void roundTrip_preservesMessageFields() throws Exception {
 		// given
+		JsonNode payload = new ObjectMapper().readTree("{\"type\":\"WELCOME\"}");
 		QueueMessage source = new QueueMessage(
 			"evt.notification.dispatch.v1",
 			"member-1",
-			"{\"type\":\"WELCOME\"}".getBytes(StandardCharsets.UTF_8),
+			payload,
 			Map.of("traceId", "trace-1"),
 			Instant.parse("2026-03-11T12:34:56Z"),
 			"msg-123");
@@ -57,7 +58,7 @@ class JsonQueueMessageSerializerTest {
 		// then
 		assertThat(restored.topic()).isEqualTo(source.topic());
 		assertThat(restored.key()).isEqualTo(source.key());
-		assertThat(restored.payload()).containsExactly(source.payload());
+		assertThat(restored.payload()).isEqualTo(source.payload());
 		assertThat(restored.headers()).isEqualTo(source.headers());
 		assertThat(restored.occurredAt()).isEqualTo(source.occurredAt());
 		assertThat(restored.messageId()).isEqualTo(source.messageId());

--- a/app-api/src/test/java/com/tasteam/infra/messagequeue/trace/MessageQueueTraceServiceTest.java
+++ b/app-api/src/test/java/com/tasteam/infra/messagequeue/trace/MessageQueueTraceServiceTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -17,6 +16,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tasteam.config.annotation.UnitTest;
 import com.tasteam.infra.messagequeue.MessageQueueProviderType;
 import com.tasteam.infra.messagequeue.QueueMessage;
@@ -33,7 +33,7 @@ class MessageQueueTraceServiceTest {
 		when(repository.save(any(MessageQueueTraceLog.class))).thenAnswer(invocation -> invocation.getArgument(0));
 		MessageQueueTraceService service = new MessageQueueTraceService(repository);
 		QueueMessage message = QueueMessage.of("domain.review.created", "123",
-			"payload".getBytes(StandardCharsets.UTF_8));
+			new ObjectMapper().createObjectNode());
 
 		// when
 		service.recordPublish(message, MessageQueueProviderType.REDIS_STREAM);
@@ -54,7 +54,7 @@ class MessageQueueTraceServiceTest {
 		when(repository.save(any(MessageQueueTraceLog.class))).thenAnswer(invocation -> invocation.getArgument(0));
 		MessageQueueTraceService service = new MessageQueueTraceService(repository);
 		QueueMessage message = QueueMessage.of("domain.group.member-joined", "200",
-			"payload".getBytes(StandardCharsets.UTF_8));
+			new ObjectMapper().createObjectNode());
 
 		// when
 		service.recordConsumeFail(

--- a/docs/spec/tech/user-activity/s3-data-interface-contract.md
+++ b/docs/spec/tech/user-activity/s3-data-interface-contract.md
@@ -1,0 +1,297 @@
+# 목차
+
+* [1. 문서 목적](#1-문서-목적)
+* [2. 시스템 역할 정의](#2-시스템-역할-정의)
+  * [API 서버 책임](#api-서버-책임)
+  * [AI 서버 책임](#ai-서버-책임)
+* [3. 전체 데이터 흐름](#3-전체-데이터-흐름)
+* [4. Raw Data 계약](#4-raw-data-계약)
+  * [4-1. 사용자 행동 이벤트](#4-1-사용자-행동-이벤트)
+  * [4-2. 음식점 데이터](#4-2-음식점-데이터)
+  * [4-3. 메뉴 집계 데이터](#4-3-메뉴-집계-데이터)
+* [5. 추천 결과 계약](#5-추천-결과-계약)
+* [6. 추천 결과 Import 계약](#6-추천-결과-import-계약)
+* [7. 모델 버전 관리](#7-모델-버전-관리)
+* [8. 추천 조회](#8-추천-조회)
+* [9. 추가 논의가 필요한 사항](#9-추가-논의가-필요한-사항)
+
+---
+
+# 1. 문서 목적
+
+본 문서는 **개인화 음식점 추천 시스템에서 AI 서버와 API 서버 간의 역할과 데이터 교환 방식**을 정의한다.
+
+목표는 다음과 같다.
+
+- 추천 시스템의 **Serving Layer와 ML Pipeline을 분리**
+- 데이터 계약을 명확히 하여 **양쪽 서버의 독립적인 개발을 가능하게 함**
+- 추천 결과 생성 및 서빙 과정에서 **의존성과 장애 전파를 최소화**
+
+---
+
+# 2. 시스템 역할 정의
+
+## API 서버 책임
+
+API 서버는 **Serving Layer**를 담당한다.
+
+주요 역할
+
+1. 사용자 행동 로그 수집
+2. raw 데이터 S3 적재
+3. 추천 결과 S3 → DB import
+4. 추천 결과 조회 API 제공
+
+API 서버는 다음을 수행하지 않는다.
+
+- 모델 학습
+- feature 생성
+- 추천 생성
+- 모델 관리
+
+---
+
+## AI 서버 책임
+
+AI 서버는 **ML Pipeline**을 담당한다.
+
+주요 역할
+
+1. S3 raw data 기반 feature 생성
+2. 학습 데이터셋 생성
+3. 모델 학습
+4. batch inference 수행
+5. 추천 결과 파일 S3 저장
+6. 모델 버전 관리
+
+AI 서버는 다음을 수행하지 않는다.
+
+- API 요청 처리
+- 추천 결과 DB 저장
+- 사용자 요청 처리
+
+---
+
+# 3. 전체 데이터 흐름
+
+<img alt="mermaid-diagram" src="https://github.com/user-attachments/assets/289894f7-33f3-4cb0-9a99-ff6374356e8f" />
+
+
+---
+
+# 4. Raw Data 계약
+
+API 서버는 다음 데이터를 **S3 Data Lake**에 저장한다.
+
+환경별 bucket
+
+```
+tasteam-prod-analytics
+tasteam-stg-analytics
+tasteam-dev-analytics
+```
+
+## 4-1. 사용자 행동 이벤트
+
+### S3 경로
+
+```
+s3://tasteam-{env}-analytics/
+	raw/
+		events/
+			dt=YYYY-MM-DD/
+				part-00001.csv
+				_SUCCESS
+```
+
+### 데이터 스키마
+
+| column | 설명 |
+| --- | --- |
+| event_id | 이벤트 UUID |
+| event_name | 이벤트 타입 (view / click / review 등) |
+| occurred_at | 이벤트 발생 시각 |
+| dining_type | 식사 유형 (SOLO / GROUP) |
+| distance_bucket | 사용자-음식점 거리 버킷 |
+| weather_bucket | 날씨 버킷 |
+| member_id | 로그인 사용자 ID |
+| anonymous_id | 비로그인 사용자 ID |
+| session_id | 세션 ID |
+| restaurant_id | 음식점 ID |
+| recommendation_id | 추천 노출 ID (nullable) |
+| platform | 플랫폼 (WEB / IOS / ANDROID) |
+| created_at | 이벤트 저장 시각 |
+
+## 4-2. 음식점 데이터
+
+### S3 경로
+
+```
+s3://tasteam-{env}-analytics/
+	raw/
+		restaurants/
+			dt=YYYY-MM-DD/
+				part-00001.csv
+				_SUCCESS
+```
+
+### 데이터 스키마
+
+| column | 설명 |
+| --- | --- |
+| restaurant_id | 음식점 ID |
+| restaurant_name | 음식점 이름 |
+| sido | 시도 |
+| sigungu | 시군구 |
+| eupmyeondong | 읍면동 |
+| geohash | 위치 geohash |
+| food_category_id | 음식 카테고리 ID |
+| food_category_name | 음식 카테고리 |
+
+## 4-3. 메뉴 집계 데이터
+
+### S3 경로
+
+```
+s3://tasteam-{env}-analytics/
+	raw/
+		menus/
+			dt=YYYY-MM-DD/
+				part-00001.csv
+				_SUCCESS
+```
+
+### 데이터 스키마
+
+| column | 설명 |
+| --- | --- |
+| restaurant_id | 음식점 ID |
+| menu_count | 메뉴 수 |
+| price_min | 최소 가격 |
+| price_max | 최대 가격 |
+| price_mean | 평균 가격 |
+| price_median | 중앙값 |
+| representative_menu_name | 대표 메뉴 |
+| top_menus | 주요 메뉴 JSON |
+| price_tier | 가격대 |
+
+---
+
+# 5. 추천 결과 계약
+
+AI 서버는 추천 결과를 **S3에 파일 형태로 저장한다.**
+
+### S3 경로
+
+```
+s3://tasteam-{env}-analytics/
+	recommendations/
+		pipeline_version=VERSION/
+			dt=YYYY-MM-DD/
+				part-00001.csv
+				_SUCCESS
+```
+
+### 데이터 스키마
+
+| column | 설명 |
+| --- | --- |
+| user_id | 사용자 ID |
+| anonymous_id | 익명 사용자 |
+| restaurant_id | 음식점 ID |
+| score | 추천 점수 |
+| rank | 추천 순위 |
+| context_snapshot | 추천 생성 시 context |
+| pipeline_version | 모델 파이프라인 버전 |
+| generated_at | 추천 생성 시각 |
+| expires_at | 추천 만료 시각(24시간) |
+
+---
+
+# 6. 추천 결과 Import 계약
+
+API 서버는 **S3 polling 기반으로 추천 결과를 DB에 적재한다.**
+
+### Import 절차
+
+1. S3 polling
+2. 새로운 `(pipeline_version, dt)` 탐색
+3. `_SUCCESS` 파일 확인
+4. 추천 결과 파일 import
+5. Recommendation DB 저장
+
+### 완료 마커
+
+AI 서버는 추천 생성 완료 후 `_SUCCESS` 파일을 생성한다.
+
+```
+recommendation_result/
+	pipeline_version=deepfm-1.0.20260227/
+		dt=2026-03-07/
+			part-00001.csv
+			_SUCCESS
+```
+
+### DB 저장 스키마
+
+| column | 설명 |
+| --- | --- |
+| user_id | 사용자 ID |
+| anonymous_id | 익명 사용자 |
+| restaurant_id | 음식점 ID |
+| score | 추천 점수 |
+| rank | 추천 순위 |
+| pipeline_version | 모델 버전 |
+| generated_at | 추천 생성 시각 |
+| expires_at | 추천 만료 시각 |
+
+---
+
+# 7. 모델 버전 관리
+
+모델 버전 관리는 **AI 서버 책임**이다.
+
+추천 결과는 항상 **pipeline_version을 포함해야 한다.**
+
+```
+deepfm-1.0.20260227
+deepfm-1.1.20260301
+```
+
+---
+
+# 8. 추천 조회
+
+API 서버는 **현재 활성 pipeline_version의 추천 결과만 반환한다.**
+
+```
+SELECT
+    rr.member_id,
+    rr.anonymous_id,
+    rr.restaurant_id,
+    rr.score,
+    rr.rank,
+    rr.pipeline_version,
+    rr.generated_at,
+    rr.expires_at
+FROM restaurant_recommendation rr
+JOIN restaurant_recommendation_model rrm
+  ON rrm.id = rr.model_id
+WHERE rr.member_id = :memberId
+  AND rrm.status = 'ACTIVE'
+ORDER BY rr.rank ASC
+LIMIT :limit;
+```
+
+---
+
+# 9. 추가 논의가 필요한 사항
+
+### 추천 생성 정책
+
+| 항목 | 정책 |
+| --- | --- |
+| 추천 생성 범위 | 전체 사용자 |
+| 추천 생성 방식 | batch inference |
+| 추천 생성 주기 | 하루 2회 |
+| 추천 TTL | 24시간 |

--- a/docs/spec/tech/user-activity/s3-ingest-pipeline.md
+++ b/docs/spec/tech/user-activity/s3-ingest-pipeline.md
@@ -1,0 +1,267 @@
+# 1. 문서 목적
+
+본 문서는 **사용자 행동 이벤트를 Kafka 기반 스트림으로 수집하고 S3 Data Lake에 적재하는 파이프라인 설계**를 정의한다.
+
+목표
+
+- 사용자 이벤트를 **신뢰성 있게 수집**
+- Kafka 기반 **비동기 이벤트 스트림 구축**
+- S3 기반 **분석 및 ML 파이프라인용 Data Lake 구축**
+- 이벤트 저장 구조를 **표준화하여 downstream 시스템과 데이터 계약을 명확히 함**
+
+---
+
+# 2. 이벤트 수집 파이프라인
+
+사용자 행동 이벤트는 다음 흐름으로 저장된다.
+
+```
+Client
+   ↓
+API Server
+   ↓
+Kafka Topic
+   ↓
+Kafka S3 Sink
+   ↓
+S3 Data Lake
+```
+
+설계 목표
+
+- 이벤트 수집을 **비동기 스트림 구조로 처리**
+- Kafka를 **내결함 이벤트 버퍼**로 활용
+- S3에 **분석 및 ML 파이프라인에서 사용할 Raw Data 저장**
+
+---
+
+# 3. Kafka Event Stream 설계
+
+### Topic
+
+```
+user-activity-events
+```
+
+### Partition Key
+
+```
+null
+```
+
+목적
+
+- 동일 사용자 이벤트 순서 유지 불필요
+- 라운드 로빈 방식으로 부하 분산
+
+---
+
+### Kafka 설정
+
+| 항목 | 값 |
+| --- | --- |
+| partition | 8 |
+| replication factor | 3 |
+| retention | 7일 |
+
+Kafka는 **이벤트 버퍼 및 재처리 가능한 로그 저장소 역할**을 수행한다.
+
+---
+
+# 4. Kafka → S3 Sink
+
+Kafka 이벤트는 Consumer를 통해 S3 Data Lake에 저장된다.
+
+**Kafka Connect S3 Sink** 사용하여 구현한다.
+
+이유
+
+- 안정적인 offset 관리
+- 자동 재처리
+- 운영 편의성
+
+---
+
+# 5. S3 Data Lake 구조
+
+환경별 bucket
+
+```
+tasteam-prod-analytics
+tasteam-stg-analytics
+tasteam-dev-analytics
+```
+
+사용자 행동 이벤트 저장 경로
+
+```
+s3://tasteam-{env}-analytics/
+    raw/
+        events/
+            dt=YYYY-MM-DD/
+                part-00001.csv
+                part-00002.csv
+                _SUCCESS
+```
+
+구성
+
+| 파일 | 설명 |
+| --- | --- |
+| part-xxxxx.csv | 이벤트 데이터 |
+| _SUCCESS | 데이터 생성 완료 마커 |
+
+---
+
+# 6. 사용자 이벤트 데이터 스키마
+
+Kafka 이벤트는 다음 스키마로 S3에 저장된다.
+
+| column | 설명 |
+| --- | --- |
+| event_id | 이벤트 UUID |
+| event_name | 이벤트 타입 |
+| event_version | 이벤트 스키마 버전 |
+| occurred_at | 이벤트 발생 시각 |
+| dining_type | 식사 유형 |
+| distance_bucket | 사용자-음식점 거리 버킷 |
+| weather_bucket | 날씨 버킷 |
+| member_id | 로그인 사용자 ID |
+| anonymous_id | 비로그인 사용자 ID |
+| session_id | 세션 ID |
+| restaurant_id | 음식점 ID |
+| recommendation_id | 추천 노출 ID |
+| platform | 플랫폼 |
+| created_at | 이벤트 저장 시각 |
+
+---
+
+# 7. 파일 생성 정책
+
+Kafka Sink는 이벤트를 일정 단위로 묶어 파일로 저장한다.
+
+| 항목 | 값 |
+| --- | --- |
+| flush interval | 60분 |
+| max events | 100,000 |
+| max file size | 100MB |
+
+목적
+
+- S3 small file 문제 방지
+- 분석 시스템 처리 효율 개선
+
+---
+
+# 8. 데이터 파티셔닝 정책
+
+데이터는 **event_time 기준으로 partition 된다.**
+
+```
+dt=YYYY-MM-DD
+```
+
+예시
+
+```
+s3://tasteam-prod-analytics/raw/events/dt=2026-03-11/
+```
+
+장점
+
+- Athena / Spark / Presto 분석 효율
+- 데이터 관리 용이
+
+---
+
+# 9. 완료 마커
+
+데이터 생성 완료를 나타내기 위해 `_SUCCESS` 파일을 사용한다.
+
+```
+part-00001.csv
+part-00002.csv
+_SUCCESS
+```
+
+downstream 시스템은 `_SUCCESS` 존재 시 데이터를 처리한다.
+
+---
+
+# 10. 장애 대응 전략
+
+## Kafka 장애
+
+- Kafka는 7일간 이벤트를 저장한다.
+- consumer 장애 발생 시 재처리 가능하다.
+
+## S3 Sink 장애
+
+- Sink 장애 발생 시 offset commit이 중단된다.
+- consumer 재시작 시 자동 재처리된다.
+
+## 이벤트 중복
+
+- Kafka는 **at-least-once delivery** 특성을 가진다.
+- 이벤트는 `event_id` 필드를 포함하여 downstream 시스템에서 dedup 가능하다.
+
+---
+
+# 11. 운영 모니터링
+
+## Kafka
+
+- consumer lag
+- produce rate
+- error rate
+
+## S3 Sink
+
+- upload latency
+- upload failure
+- file creation rate
+
+---
+
+# 12. Late Event 처리 정책
+
+## 파티션 기준
+
+이벤트 데이터의 S3 파티션은 **Kafka 수신 시각이 아니라** `occurred_at` **기준으로 결정한다.**
+
+즉 이벤트가 늦게 도착하더라도 `occurred_at`이 속한 날짜의 파티션에 저장한다.
+
+사용자 행동 분석 및 ML 학습 데이터 생성 시 데이터 의미를 유지하기 위해 사용한다. 
+
+## Grace Period 정책
+
+이벤트는 네트워크 지연, 애플리케이션 재시도, Kafka 처리 지연 등으로 인해 늦게 도착할 수 있다.
+
+이를 고려하여 각 날짜 파티션은 자정 즉시 종료하지 않고 **익일 일정 시간 동안 쓰기 가능 상태로 유지한다.**
+
+| 항목 | 값 |
+| --- | --- |
+| 파티션 기준 | occurred_at |
+| grace period | 익일 00:30 |
+| 파일 업로드 단위 | 5분 또는 100MB |
+
+## _SUCCESS 파일 생성 정책
+
+`_SUCCESS` 파일은 해당 dt **파티션 내의 파일 업로드 종료를 의미한다.**
+
+각 날짜 파티션은 grace period 종료 후 `_SUCCESS` 파일을 생성한다.
+
+`_SUCCESS` 파일 생성 이후에는 해당 파티션 내에 새로운 파일을 추가하지 않는다.
+
+---
+
+# 13. 데이터 재처리 전략
+
+## **Offset Commit 정책**
+
+Kafka → S3 파이프라인에서는 데이터 유실을 방지하기 위해 S3 업로드 완료 후 offset commit 원칙을 따른다.
+
+즉 이벤트는 Kafka에서 읽은 후 S3에 안전하게 저장된 뒤에만 offset을 commit한다.
+
+이 방식은 장애 발생 시 동일 이벤트가 재처리될 수 있는 **at-least-once delivery** 특성을 가지며, 
+데이터 유실보다 중복 가능성을 허용하는 방식이다.


### PR DESCRIPTION
## 📌 PR 요약

#### Summary
- QueueMessage payload를 byte[]에서 JsonNode로 변경하여 직렬화 구조 단순화
