### PR TITLE
🐛 fix(dummy): notification 삽입 실패 수정 - NotificationType 실제 enum 값으로 교체

### DIFF
--- a/app-api/src/main/java/com/tasteam/batch/dummy/repository/DummyDataJdbcRepository.java
+++ b/app-api/src/main/java/com/tasteam/batch/dummy/repository/DummyDataJdbcRepository.java
@@ -422,7 +422,7 @@ public class DummyDataJdbcRepository {
 	}
 
 	private static final String[] NOTIFICATION_TYPES = {
-		"REVIEW_COMMENT", "REVIEW_LIKE", "GROUP_JOIN", "ANNOUNCEMENT", "PROMOTION"
+		"CHAT", "SYSTEM", "NOTICE"
 	};
 
 	/**


### PR DESCRIPTION

## 📌 PR 요약

#### Summary
- REVIEW_COMMENT 등 존재하지 않는 type을 사용해 DB 제약 위반이 발생함.
- 실제 NotificationType enum 값(CHAT, SYSTEM, NOTICE)으로 교체.

