### PR TITLE
feat: 음식점 목록 조회 API 비활성화

### DIFF
--- a/app-api/src/main/java/com/tasteam/domain/restaurant/controller/RestaurantController.java
+++ b/app-api/src/main/java/com/tasteam/domain/restaurant/controller/RestaurantController.java
@@ -6,7 +6,6 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import com.tasteam.domain.restaurant.controller.docs.RestaurantControllerDocs;
-import com.tasteam.domain.restaurant.dto.request.NearbyRestaurantQueryParams;
 import com.tasteam.domain.restaurant.dto.request.RestaurantReviewListRequest;
 import com.tasteam.domain.restaurant.dto.request.ReviewResponse;
 import com.tasteam.domain.restaurant.dto.response.*;
@@ -15,6 +14,8 @@ import com.tasteam.domain.review.dto.request.ReviewCreateRequest;
 import com.tasteam.domain.review.dto.response.ReviewCreateResponse;
 import com.tasteam.domain.review.service.ReviewService;
 import com.tasteam.global.dto.api.SuccessResponse;
+import com.tasteam.global.exception.business.BusinessException;
+import com.tasteam.global.exception.code.RestaurantErrorCode;
 import com.tasteam.global.security.jwt.annotation.CurrentUser;
 
 import lombok.RequiredArgsConstructor;
@@ -28,13 +29,9 @@ public class RestaurantController implements RestaurantControllerDocs {
 	private final RestaurantService restaurantService;
 	private final ReviewService reviewService;
 
-	@ResponseStatus(HttpStatus.OK)
 	@GetMapping
-	public SuccessResponse<CursorPageResponse<RestaurantListItem>> getRestaurants(
-		@ModelAttribute @Validated
-		NearbyRestaurantQueryParams queryParams) {
-
-		return SuccessResponse.success(restaurantService.getRestaurants(queryParams));
+	public void getRestaurants() {
+		throw new BusinessException(RestaurantErrorCode.RESTAURANT_LIST_ENDPOINT_DISABLED);
 	}
 
 	@ResponseStatus(HttpStatus.OK)

--- a/app-api/src/main/java/com/tasteam/domain/restaurant/controller/docs/RestaurantControllerDocs.java
+++ b/app-api/src/main/java/com/tasteam/domain/restaurant/controller/docs/RestaurantControllerDocs.java
@@ -4,12 +4,10 @@ import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 
-import com.tasteam.domain.restaurant.dto.request.NearbyRestaurantQueryParams;
 import com.tasteam.domain.restaurant.dto.request.RestaurantReviewListRequest;
 import com.tasteam.domain.restaurant.dto.request.ReviewResponse;
 import com.tasteam.domain.restaurant.dto.response.CursorPageResponse;
 import com.tasteam.domain.restaurant.dto.response.RestaurantDetailResponse;
-import com.tasteam.domain.restaurant.dto.response.RestaurantListItem;
 import com.tasteam.domain.review.dto.request.ReviewCreateRequest;
 import com.tasteam.domain.review.dto.response.ReviewCreateResponse;
 import com.tasteam.global.dto.api.SuccessResponse;
@@ -30,11 +28,10 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @Tag(name = "Restaurant", description = "음식점 조회/관리 API")
 public interface RestaurantControllerDocs {
 
-	@Operation(summary = "음식점 목록 조회", description = "지정한 위치 조건으로 주변 음식점을 커서 기반으로 조회합니다.")
-	@ApiResponse(responseCode = "200", description = "조회 성공")
-	SuccessResponse<CursorPageResponse<RestaurantListItem>> getRestaurants(
-		@Validated @ParameterObject
-		NearbyRestaurantQueryParams queryParams);
+	@Operation(summary = "음식점 목록 조회 비활성화", description = "이 엔드포인트는 더 이상 지원하지 않습니다. main/search 계열 API를 사용하세요.")
+	@ApiResponse(responseCode = "410", description = "지원 종료")
+	@CustomErrorResponseDescription(value = RestaurantSwaggerErrorResponseDescription.class, group = "RESTAURANT_LIST_DISABLED")
+	void getRestaurants();
 
 	@Operation(summary = "음식점 상세 조회", description = "음식점 상세 정보를 조회합니다.")
 	@ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(schema = @Schema(implementation = RestaurantDetailResponse.class)))

--- a/app-api/src/main/java/com/tasteam/global/exception/code/RestaurantErrorCode.java
+++ b/app-api/src/main/java/com/tasteam/global/exception/code/RestaurantErrorCode.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum RestaurantErrorCode implements ErrorCode {
 
+	RESTAURANT_LIST_ENDPOINT_DISABLED(HttpStatus.GONE, "음식점 목록 조회 API는 더 이상 지원하지 않습니다."),
 	RESTAURANT_NOT_FOUND(HttpStatus.NOT_FOUND, "음식점 정보를 찾을 수 없습니다."),
 	FOOD_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "음식 카테고리 정보를 찾을 수 없습니다."),
 	MENU_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "메뉴 카테고리 정보를 찾을 수 없습니다.");

--- a/app-api/src/main/java/com/tasteam/global/swagger/error/code/restaurant/RestaurantSwaggerErrorResponseDescription.java
+++ b/app-api/src/main/java/com/tasteam/global/swagger/error/code/restaurant/RestaurantSwaggerErrorResponseDescription.java
@@ -13,8 +13,8 @@ import lombok.Getter;
 @Getter
 public enum RestaurantSwaggerErrorResponseDescription implements SwaggerErrorResponseDescription {
 
-	RESTAURANT_LIST_MOCK(new LinkedHashSet<>(Set.of(
-		CommonErrorCode.INVALID_REQUEST))),
+	RESTAURANT_LIST_DISABLED(new LinkedHashSet<>(Set.of(
+		RestaurantErrorCode.RESTAURANT_LIST_ENDPOINT_DISABLED))),
 	RESTAURANT_DETAIL(new LinkedHashSet<>(Set.of(
 		RestaurantErrorCode.RESTAURANT_NOT_FOUND))),
 	RESTAURANT_CREATE(new LinkedHashSet<>(Set.of(

--- a/app-api/src/test/java/com/tasteam/domain/restaurant/controller/RestaurantControllerTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/restaurant/controller/RestaurantControllerTest.java
@@ -27,7 +27,6 @@ import com.tasteam.domain.restaurant.dto.response.RestaurantAiSentimentResponse;
 import com.tasteam.domain.restaurant.dto.response.RestaurantAiSummaryResponse;
 import com.tasteam.domain.restaurant.dto.response.RestaurantDetailResponse;
 import com.tasteam.domain.restaurant.dto.response.RestaurantImageDto;
-import com.tasteam.domain.restaurant.dto.response.RestaurantListItem;
 import com.tasteam.domain.review.dto.response.ReviewCreateResponse;
 import com.tasteam.fixture.RestaurantRequestFixture;
 
@@ -39,144 +38,15 @@ class RestaurantControllerTest extends BaseControllerWebMvcTest {
 	class GetRestaurants {
 
 		@Test
-		@DisplayName("성공 응답은 고정 포맷을 따른다")
-		void 음식점_목록_조회_성공_응답_포맷_검증() throws Exception {
-			// given
-			CursorPageResponse<RestaurantListItem> response = new CursorPageResponse<>(
-				List.of(new RestaurantListItem(
-					1L,
-					"맛집식당",
-					"서울시 강남구",
-					500.0,
-					List.of("한식"),
-					List.of(new RestaurantImageDto(1L, "https://example.com/img.jpg")),
-					"맛집으로 유명한 식당입니다.")),
-				new CursorPageResponse.Pagination(null, false, 20));
-
-			given(restaurantService.getRestaurants(any())).willReturn(response);
-
-			// when & then
+		@DisplayName("목록 엔드포인트는 410 Gone으로 차단된다")
+		void 음식점_목록_엔드포인트_차단() throws Exception {
 			mockMvc.perform(get("/api/v1/restaurants")
 				.param("latitude", String.valueOf(RestaurantRequestFixture.DEFAULT_LAT))
 				.param("longitude", String.valueOf(RestaurantRequestFixture.DEFAULT_LNG)))
-				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.success").value(true))
-				.andExpect(jsonPath("$.data.items").isArray())
-				.andExpect(jsonPath("$.data.pagination").exists());
-		}
-
-		@Test
-		@DisplayName("좌표로 음식점 목록을 조회하면 커서 페이징 결과를 반환한다")
-		void 음식점_목록_조회_성공() throws Exception {
-			// given
-			CursorPageResponse<RestaurantListItem> response = new CursorPageResponse<>(
-				List.of(new RestaurantListItem(
-					1L,
-					"맛집식당",
-					"서울시 강남구",
-					500.0,
-					List.of("한식"),
-					List.of(new RestaurantImageDto(1L, "https://example.com/img.jpg")),
-					"맛집으로 유명한 식당입니다.")),
-				new CursorPageResponse.Pagination(null, false, 20));
-
-			given(restaurantService.getRestaurants(any())).willReturn(response);
-
-			// when & then
-			mockMvc.perform(get("/api/v1/restaurants")
-				.param("latitude", String.valueOf(RestaurantRequestFixture.DEFAULT_LAT))
-				.param("longitude", String.valueOf(RestaurantRequestFixture.DEFAULT_LNG))
-				.param("radius", String.valueOf(RestaurantRequestFixture.DEFAULT_RADIUS))
-				.param("size", String.valueOf(RestaurantRequestFixture.DEFAULT_SIZE)))
-				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.success").value(true))
-				.andExpect(jsonPath("$.data.items[0].id").value(1))
-				.andExpect(jsonPath("$.data.items[0].name").value("맛집식당"))
-				.andExpect(jsonPath("$.data.pagination.hasNext").value(false));
-		}
-
-		@Test
-		@DisplayName("groupId 없이도 음식점 목록을 조회할 수 있다")
-		void groupId_없이_조회_성공() throws Exception {
-			// given
-			CursorPageResponse<RestaurantListItem> response = new CursorPageResponse<>(
-				List.of(new RestaurantListItem(
-					1L,
-					"맛집식당",
-					"서울시 강남구",
-					500.0,
-					List.of("한식"),
-					List.of(new RestaurantImageDto(1L, "https://example.com/img.jpg")),
-					"맛집으로 유명한 식당입니다.")),
-				new CursorPageResponse.Pagination(null, false, 20));
-
-			given(restaurantService.getRestaurants(any())).willReturn(response);
-
-			// when & then
-			mockMvc.perform(get("/api/v1/restaurants")
-				.param("latitude", String.valueOf(RestaurantRequestFixture.DEFAULT_LAT))
-				.param("longitude", String.valueOf(RestaurantRequestFixture.DEFAULT_LNG)))
-				.andExpect(status().isOk());
-		}
-
-		@Test
-		@DisplayName("위도가 없으면 400 에러를 반환한다")
-		void 위도_누락시_400_에러() throws Exception {
-			// when & then
-			mockMvc.perform(get("/api/v1/restaurants")
-				.param("longitude", String.valueOf(RestaurantRequestFixture.DEFAULT_LNG)))
-				.andExpect(status().isBadRequest());
-		}
-
-		@Test
-		@DisplayName("경도가 없으면 400 에러를 반환한다")
-		void 경도_누락시_400_에러() throws Exception {
-			// when & then
-			mockMvc.perform(get("/api/v1/restaurants")
-				.param("latitude", String.valueOf(RestaurantRequestFixture.DEFAULT_LAT)))
-				.andExpect(status().isBadRequest());
-		}
-
-		@Test
-		@DisplayName("위도 타입이 올바르지 않으면 400 에러를 반환한다")
-		void 위도_타입_오류시_400_에러() throws Exception {
-			// when & then
-			mockMvc.perform(get("/api/v1/restaurants")
-				.param("latitude", "abc")
-				.param("longitude", String.valueOf(RestaurantRequestFixture.DEFAULT_LNG)))
-				.andExpect(status().isBadRequest());
-		}
-
-		@Test
-		@DisplayName("좌표 범위를 벗어나면 400 에러를 반환한다")
-		void 좌표_범위_검증_실패시_400_에러() throws Exception {
-			// when & then
-			mockMvc.perform(get("/api/v1/restaurants")
-				.param("latitude", "200")
-				.param("longitude", "200"))
-				.andExpect(status().isBadRequest());
-		}
-
-		@Test
-		@DisplayName("size가 0이면 400 에러를 반환한다")
-		void size가_0이면_400_에러() throws Exception {
-			// when & then
-			mockMvc.perform(get("/api/v1/restaurants")
-				.param("latitude", String.valueOf(RestaurantRequestFixture.DEFAULT_LAT))
-				.param("longitude", String.valueOf(RestaurantRequestFixture.DEFAULT_LNG))
-				.param("size", "0"))
-				.andExpect(status().isBadRequest());
-		}
-
-		@Test
-		@DisplayName("size가 음수면 400 에러를 반환한다")
-		void size가_음수면_400_에러() throws Exception {
-			// when & then
-			mockMvc.perform(get("/api/v1/restaurants")
-				.param("latitude", String.valueOf(RestaurantRequestFixture.DEFAULT_LAT))
-				.param("longitude", String.valueOf(RestaurantRequestFixture.DEFAULT_LNG))
-				.param("size", "-1"))
-				.andExpect(status().isBadRequest());
+				.andExpect(status().isGone())
+				.andExpect(jsonPath("$.success").value(false))
+				.andExpect(jsonPath("$.code").value("RESTAURANT_LIST_ENDPOINT_DISABLED"))
+				.andExpect(jsonPath("$.message").value("음식점 목록 조회 API는 더 이상 지원하지 않습니다."));
 		}
 	}
 


### PR DESCRIPTION
## 📌 PR 요약

#### Summary
- `GET /api/v1/restaurants` 목록 API를 410 Gone으로 비활성화했습니다.
- 전용 에러 코드와 Swagger 에러 응답 설명을 추가했습니다.
- 컨트롤러 테스트를 비활성화 시나리오 기준으로 정리했습니다.

### Issue
- close : #561

---

## ➕ 추가된 기능
1. `RestaurantErrorCode.RESTAURANT_LIST_ENDPOINT_DISABLED`를 추가했습니다.
2. 목록 API 비활성화 상태를 Swagger 문서에 반영했습니다.

## 🛠️ 수정/변경사항
1. `RestaurantController#getRestaurants`가 더 이상 서비스 조회를 호출하지 않고 410 Gone을 반환합니다.
2. `RestaurantControllerTest`의 기존 목록 조회 성공/검증 케이스를 제거하고 차단 응답 검증으로 교체했습니다.

---

## ✅ 남은 작업
* [ ] 목록 API를 호출하던 클라이언트가 있다면 main/search 계열 API로 마이그레이션 여부를 확인합니다.
