### PR TITLE
refactor(restaurant): AI JSONB 파싱 공통화 및 레거시 요약 호환 정리

### DIFF
--- a/app-api/src/main/java/com/tasteam/domain/main/service/MainService.java
+++ b/app-api/src/main/java/com/tasteam/domain/main/service/MainService.java
@@ -1,5 +1,7 @@
 package com.tasteam.domain.main.service;
 
+import static com.tasteam.domain.restaurant.service.RestaurantAiJsonParser.extractSummaryText;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -258,19 +260,11 @@ public class MainService {
 		return restaurantReviewSummaryRepository
 			.findByRestaurantIdIn(restaurantIds)
 			.stream()
-			.filter(summary -> toSummaryString(summary.getSummaryJson()) != null)
+			.filter(summary -> extractSummaryText(summary.getSummaryJson()) != null)
 			.collect(Collectors.toMap(
 				RestaurantReviewSummary::getRestaurantId,
-				s -> toSummaryString(s.getSummaryJson()),
+				s -> extractSummaryText(s.getSummaryJson()),
 				(existing, replacement) -> existing));
-	}
-
-	private static String toSummaryString(Map<String, Object> summaryJson) {
-		if (summaryJson == null) {
-			return null;
-		}
-		Object overall = summaryJson.get("overall_summary");
-		return overall != null ? overall.toString() : null;
 	}
 
 	private List<SectionItem> toSectionItems(

--- a/app-api/src/main/java/com/tasteam/domain/restaurant/service/RestaurantAiJsonParser.java
+++ b/app-api/src/main/java/com/tasteam/domain/restaurant/service/RestaurantAiJsonParser.java
@@ -1,0 +1,196 @@
+package com.tasteam.domain.restaurant.service;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.tasteam.domain.restaurant.dto.RestaurantAiCategoryComparison;
+import com.tasteam.domain.restaurant.dto.RestaurantAiCategorySummary;
+import com.tasteam.domain.restaurant.dto.RestaurantAiComparison;
+import com.tasteam.domain.restaurant.dto.RestaurantAiEvidence;
+import com.tasteam.domain.restaurant.dto.RestaurantAiSummary;
+import com.tasteam.domain.restaurant.type.AiReviewCategory;
+
+public final class RestaurantAiJsonParser {
+
+	private static final int MAX_EVIDENCES = 3;
+	private static final List<AiReviewCategory> COMPARISON_DISPLAY_ORDER = List.of(
+		AiReviewCategory.SERVICE,
+		AiReviewCategory.PRICE);
+
+	private RestaurantAiJsonParser() {}
+
+	public static String extractSummaryText(Map<String, Object> summaryJson) {
+		if (summaryJson == null || summaryJson.isEmpty()) {
+			return null;
+		}
+
+		String overall = toNonBlankString(summaryJson.get("overall_summary"));
+		if (overall != null) {
+			return overall;
+		}
+
+		return toNonBlankString(summaryJson.get("summary"));
+	}
+
+	public static String extractSummaryTextOrDefault(Map<String, Object> summaryJson, String defaultValue) {
+		String summary = extractSummaryText(summaryJson);
+		return summary != null ? summary : defaultValue;
+	}
+
+	public static RestaurantAiSummary parseSummary(Map<String, Object> summaryJson) {
+		if (summaryJson == null) {
+			return null;
+		}
+
+		Map<AiReviewCategory, RestaurantAiCategorySummary> categoryDetails = parseCategorySummaries(
+			asStringObjectMap(summaryJson.get("categories")));
+		return new RestaurantAiSummary(extractSummaryText(summaryJson), categoryDetails);
+	}
+
+	public static RestaurantAiComparison parseComparison(Map<String, Object> comparisonJson) {
+		if (comparisonJson == null) {
+			return null;
+		}
+
+		List<String> comparisonDisplay = parseStrings(
+			firstPresent(comparisonJson, "comparison_display", "strength_display"));
+		Map<AiReviewCategory, RestaurantAiCategoryComparison> categoryDetails = parseCategoryComparisons(
+			asStringObjectMap(comparisonJson.get("category_lift")),
+			comparisonDisplay);
+		return new RestaurantAiComparison(categoryDetails);
+	}
+
+	private static Map<AiReviewCategory, RestaurantAiCategorySummary> parseCategorySummaries(
+		Map<String, Object> categoriesRaw) {
+		if (categoriesRaw == null || categoriesRaw.isEmpty()) {
+			return Map.of();
+		}
+
+		Map<AiReviewCategory, RestaurantAiCategorySummary> result = new LinkedHashMap<>();
+		for (Map.Entry<String, Object> entry : categoriesRaw.entrySet()) {
+			AiReviewCategory.fromJsonKey(entry.getKey()).ifPresent(category -> {
+				RestaurantAiCategorySummary detail = parseCategorySummary(entry.getValue());
+				if (detail != null) {
+					result.put(category, detail);
+				}
+			});
+		}
+		return result;
+	}
+
+	private static RestaurantAiCategorySummary parseCategorySummary(Object value) {
+		Map<String, Object> map = asStringObjectMap(value);
+		if (map == null) {
+			return null;
+		}
+
+		return new RestaurantAiCategorySummary(
+			toNonBlankString(map.get("summary")),
+			parseStrings(map.get("bullets")),
+			parseEvidences(map.get("evidence")));
+	}
+
+	private static Map<AiReviewCategory, RestaurantAiCategoryComparison> parseCategoryComparisons(
+		Map<String, Object> categoryLift,
+		List<String> comparisonDisplay) {
+		if (categoryLift == null || categoryLift.isEmpty()) {
+			return Map.of();
+		}
+
+		Map<AiReviewCategory, RestaurantAiCategoryComparison> result = new LinkedHashMap<>();
+		for (int i = 0; i < COMPARISON_DISPLAY_ORDER.size(); i++) {
+			AiReviewCategory category = COMPARISON_DISPLAY_ORDER.get(i);
+			result.put(category, new RestaurantAiCategoryComparison(
+				i < comparisonDisplay.size() ? comparisonDisplay.get(i) : null,
+				List.of(),
+				List.of(),
+				toDouble(categoryLift.get(category.getJsonKey()))));
+		}
+		return result;
+	}
+
+	private static List<String> parseStrings(Object value) {
+		if (!(value instanceof List<?> list)) {
+			return List.of();
+		}
+
+		return list.stream()
+			.map(RestaurantAiJsonParser::toNonBlankString)
+			.filter(text -> text != null)
+			.toList();
+	}
+
+	private static List<RestaurantAiEvidence> parseEvidences(Object value) {
+		if (!(value instanceof List<?> list)) {
+			return List.of();
+		}
+
+		return list.stream()
+			.limit(MAX_EVIDENCES)
+			.map(RestaurantAiJsonParser::asStringObjectMap)
+			.filter(map -> map != null)
+			.map(evidence -> new RestaurantAiEvidence(
+				parseReviewId(evidence.get("review_id")),
+				toNonBlankString(evidence.get("snippet")),
+				null,
+				null,
+				null))
+			.toList();
+	}
+
+	private static Object firstPresent(Map<String, Object> source, String... keys) {
+		for (String key : keys) {
+			Object value = source.get(key);
+			if (value != null) {
+				return value;
+			}
+		}
+		return null;
+	}
+
+	@SuppressWarnings("unchecked")
+	private static Map<String, Object> asStringObjectMap(Object value) {
+		if (!(value instanceof Map<?, ?> map)) {
+			return null;
+		}
+		return (Map<String, Object>)map;
+	}
+
+	private static Long parseReviewId(Object value) {
+		if (value == null) {
+			return null;
+		}
+		if (value instanceof Number number) {
+			return number.longValue();
+		}
+		try {
+			return Long.parseLong(value.toString());
+		} catch (NumberFormatException e) {
+			return null;
+		}
+	}
+
+	private static Double toDouble(Object value) {
+		if (value == null) {
+			return null;
+		}
+		if (value instanceof Number number) {
+			return number.doubleValue();
+		}
+		try {
+			return Double.parseDouble(value.toString());
+		} catch (NumberFormatException e) {
+			return null;
+		}
+	}
+
+	private static String toNonBlankString(Object value) {
+		if (value == null) {
+			return null;
+		}
+
+		String text = value.toString();
+		return text.isBlank() ? null : text;
+	}
+}

--- a/app-api/src/main/java/com/tasteam/domain/restaurant/service/RestaurantAiSummaryService.java
+++ b/app-api/src/main/java/com/tasteam/domain/restaurant/service/RestaurantAiSummaryService.java
@@ -1,5 +1,9 @@
 package com.tasteam.domain.restaurant.service;
 
+import static com.tasteam.domain.restaurant.service.RestaurantAiJsonParser.extractSummaryTextOrDefault;
+import static com.tasteam.domain.restaurant.service.RestaurantAiJsonParser.parseComparison;
+import static com.tasteam.domain.restaurant.service.RestaurantAiJsonParser.parseSummary;
+
 import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -11,7 +15,6 @@ import java.util.stream.Stream;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.tasteam.domain.restaurant.dto.RestaurantAiCategoryComparison;
 import com.tasteam.domain.restaurant.dto.RestaurantAiCategorySummary;
 import com.tasteam.domain.restaurant.dto.RestaurantAiComparison;
 import com.tasteam.domain.restaurant.dto.RestaurantAiDetails;
@@ -32,7 +35,6 @@ import lombok.RequiredArgsConstructor;
 public class RestaurantAiSummaryService {
 
 	private static final String REVIEW_SUMMARY_FALLBACK = "리뷰가 더 모이면 AI 요약이 제공됩니다.";
-	private static final int MAX_EVIDENCES = 3;
 
 	private final RestaurantComparisonRepository restaurantComparisonRepository;
 	private final RestaurantReviewSummaryRepository restaurantReviewSummaryRepository;
@@ -46,10 +48,11 @@ public class RestaurantAiSummaryService {
 				s.getPositivePercent() != null ? s.getPositivePercent().intValue() : null))
 			.orElse(null);
 		RestaurantAiSummary summary = restaurantReviewSummaryRepository.findByRestaurantId(restaurantId)
-			.map(s -> toRestaurantAiSummary(s.getSummaryJson()))
+			.map(s -> parseSummary(s.getSummaryJson()))
+			.map(this::enrichSummary)
 			.orElse(null);
 		RestaurantAiComparison comparison = restaurantComparisonRepository.findByRestaurantId(restaurantId)
-			.map(c -> toRestaurantAiComparison(c.getComparisonJson()))
+			.map(c -> parseComparison(c.getComparisonJson()))
 			.orElse(null);
 		return new RestaurantAiDetails(sentiment, summary, comparison);
 	}
@@ -60,7 +63,7 @@ public class RestaurantAiSummaryService {
 			.stream()
 			.collect(Collectors.toMap(
 				s -> s.getRestaurantId(),
-				s -> toSummaryStringOrFallback(s.getSummaryJson()),
+				s -> extractSummaryTextOrDefault(s.getSummaryJson(), REVIEW_SUMMARY_FALLBACK),
 				(existing, replacement) -> existing,
 				LinkedHashMap::new));
 
@@ -72,29 +75,30 @@ public class RestaurantAiSummaryService {
 				LinkedHashMap::new));
 	}
 
-	private RestaurantAiSummary toRestaurantAiSummary(Map<String, Object> summaryJson) {
-		if (summaryJson == null) {
-			return null;
+	private RestaurantAiSummary enrichSummary(RestaurantAiSummary summary) {
+		if (summary == null || summary.categoryDetails() == null || summary.categoryDetails().isEmpty()) {
+			return summary;
 		}
-		String overallSummary = extractSummaryText(summaryJson);
-		@SuppressWarnings("unchecked") Map<String, Object> categoriesRaw = (Map<String, Object>)summaryJson
-			.get("categories");
-		Map<AiReviewCategory, RestaurantAiCategorySummary> categoryDetails = parseCategorySummaries(categoriesRaw);
-		if (categoryDetails != null && !categoryDetails.isEmpty()) {
-			Set<Long> reviewIds = categoryDetails.values().stream()
-				.flatMap(d -> d.evidences() != null ? d.evidences().stream() : Stream.of())
-				.map(RestaurantAiEvidence::reviewId)
-				.filter(id -> id != null)
-				.collect(Collectors.toSet());
-			if (!reviewIds.isEmpty()) {
-				Map<Long, Review> reviewMap = reviewRepository.findByIdInAndDeletedAtIsNull(reviewIds).stream()
-					.collect(Collectors.toMap(Review::getId, r -> r));
-				categoryDetails = categoryDetails.entrySet().stream()
-					.collect(Collectors.toMap(Map.Entry::getKey, e -> enrichCategorySummary(e.getValue(), reviewMap),
-						(a, b) -> a, LinkedHashMap::new));
-			}
+
+		Map<AiReviewCategory, RestaurantAiCategorySummary> categoryDetails = summary.categoryDetails();
+		Set<Long> reviewIds = categoryDetails.values().stream()
+			.flatMap(detail -> detail.evidences() != null ? detail.evidences().stream() : Stream.of())
+			.map(RestaurantAiEvidence::reviewId)
+			.filter(id -> id != null)
+			.collect(Collectors.toSet());
+		if (reviewIds.isEmpty()) {
+			return summary;
 		}
-		return new RestaurantAiSummary(overallSummary, categoryDetails != null ? categoryDetails : Map.of());
+
+		Map<Long, Review> reviewMap = reviewRepository.findByIdInAndDeletedAtIsNull(reviewIds).stream()
+			.collect(Collectors.toMap(Review::getId, review -> review));
+		Map<AiReviewCategory, RestaurantAiCategorySummary> enriched = categoryDetails.entrySet().stream()
+			.collect(Collectors.toMap(
+				Map.Entry::getKey,
+				entry -> enrichCategorySummary(entry.getValue(), reviewMap),
+				(existing, replacement) -> existing,
+				LinkedHashMap::new));
+		return new RestaurantAiSummary(summary.overallSummary(), enriched);
 	}
 
 	private RestaurantAiCategorySummary enrichCategorySummary(
@@ -117,164 +121,5 @@ public class RestaurantAiSummaryService {
 		String authorName = review.getMember() != null ? review.getMember().getNickname() : null;
 		Instant createdAt = review.getCreatedAt();
 		return new RestaurantAiEvidence(ev.reviewId(), ev.snippet(), authorId, authorName, createdAt);
-	}
-
-	private Map<AiReviewCategory, RestaurantAiCategorySummary> parseCategorySummaries(
-		Map<String, Object> categoriesRaw) {
-		if (categoriesRaw == null || categoriesRaw.isEmpty()) {
-			return Map.of();
-		}
-		Map<AiReviewCategory, RestaurantAiCategorySummary> result = new LinkedHashMap<>();
-		for (Map.Entry<String, Object> entry : categoriesRaw.entrySet()) {
-			AiReviewCategory.fromJsonKey(entry.getKey()).ifPresent(category -> {
-				RestaurantAiCategorySummary detail = parseCategorySummary(entry.getValue());
-				if (detail != null) {
-					result.put(category, detail);
-				}
-			});
-		}
-		return result;
-	}
-
-	@SuppressWarnings("unchecked")
-	private RestaurantAiCategorySummary parseCategorySummary(Object value) {
-		if (!(value instanceof Map<?, ?> map)) {
-			return null;
-		}
-		Map<String, Object> m = (Map<String, Object>)map;
-		String summary = m.get("summary") != null ? m.get("summary").toString() : null;
-		List<String> bullets = parseBullets(m.get("bullets"));
-		List<RestaurantAiEvidence> evidences = parseEvidences(m.get("evidence"));
-		return new RestaurantAiCategorySummary(summary, bullets, evidences);
-	}
-
-	private List<String> parseBullets(Object value) {
-		if (!(value instanceof List<?> list)) {
-			return List.of();
-		}
-		return list.stream()
-			.map(o -> o != null ? o.toString() : null)
-			.filter(s -> s != null)
-			.toList();
-	}
-
-	@SuppressWarnings("unchecked")
-	private List<RestaurantAiEvidence> parseEvidences(Object value) {
-		if (!(value instanceof List<?> list)) {
-			return List.of();
-		}
-		return list.stream()
-			.limit(MAX_EVIDENCES)
-			.filter(item -> item instanceof Map<?, ?>)
-			.map(item -> (Map<String, Object>)item)
-			.map(e -> new RestaurantAiEvidence(
-				parseReviewId(e.get("review_id")),
-				e.get("snippet") != null ? e.get("snippet").toString() : null,
-				null,
-				null,
-				null))
-			.toList();
-	}
-
-	private Long parseReviewId(Object value) {
-		if (value == null) {
-			return null;
-		}
-		if (value instanceof Number n) {
-			return n.longValue();
-		}
-		try {
-			return Long.parseLong(value.toString());
-		} catch (NumberFormatException e) {
-			return null;
-		}
-	}
-
-	private RestaurantAiComparison toRestaurantAiComparison(Map<String, Object> comparisonJson) {
-		if (comparisonJson == null) {
-			return null;
-		}
-		Object displayObj = comparisonJson.get("comparison_display");
-		List<String> comparisonDisplay = toDisplayList(displayObj);
-		Map<AiReviewCategory, RestaurantAiCategoryComparison> categoryDetails = parseCategoryComparisons(
-			comparisonJson.get("category_lift"), comparisonDisplay);
-		return new RestaurantAiComparison(categoryDetails != null ? categoryDetails : Map.of());
-	}
-
-	@SuppressWarnings("unchecked")
-	private List<String> toDisplayList(Object comparisonDisplay) {
-		if (!(comparisonDisplay instanceof List<?> list)) {
-			return List.of();
-		}
-		return list.stream()
-			.map(o -> o != null ? o.toString() : null)
-			.toList();
-	}
-
-	/**
-	 * comparison_display 순서([0]=서비스, [1]=가격)에 맞춰 고정 카테고리 순서로 매핑.
-	 * Map.entrySet() 순서는 보장되지 않으므로, 인덱스로 문장을 매칭하면 가격/서비스가 바뀌는 문제가 발생함.
-	 */
-	@SuppressWarnings("unchecked")
-	private Map<AiReviewCategory, RestaurantAiCategoryComparison> parseCategoryComparisons(
-		Object categoryLiftObj,
-		List<String> comparisonDisplay) {
-		if (!(categoryLiftObj instanceof Map<?, ?> map)) {
-			return Map.of();
-		}
-		Map<String, Object> m = (Map<String, Object>)map;
-		Map<AiReviewCategory, RestaurantAiCategoryComparison> result = new LinkedHashMap<>();
-		// AI 응답 순서: comparison_display[0]=서비스, [1]=가격
-		List<AiReviewCategory> displayOrder = List.of(AiReviewCategory.SERVICE, AiReviewCategory.PRICE);
-		for (int i = 0; i < displayOrder.size(); i++) {
-			AiReviewCategory category = displayOrder.get(i);
-			Object liftValue = m.get(category.getJsonKey());
-			Double liftScore = toDouble(liftValue);
-			String summary = i < comparisonDisplay.size() ? comparisonDisplay.get(i) : null;
-			result.put(category, new RestaurantAiCategoryComparison(
-				summary, List.of(), List.of(), liftScore));
-		}
-		return result;
-	}
-
-	private Double toDouble(Object value) {
-		if (value == null) {
-			return null;
-		}
-		if (value instanceof Number n) {
-			return n.doubleValue();
-		}
-		try {
-			return Double.parseDouble(value.toString());
-		} catch (NumberFormatException e) {
-			return null;
-		}
-	}
-
-	private static String toSummaryString(Map<String, Object> summaryJson) {
-		return extractSummaryText(summaryJson);
-	}
-
-	private static String toSummaryStringOrFallback(Map<String, Object> summaryJson) {
-		String summary = toSummaryString(summaryJson);
-		return summary != null ? summary : REVIEW_SUMMARY_FALLBACK;
-	}
-
-	private static String extractSummaryText(Map<String, Object> summaryJson) {
-		if (summaryJson == null || summaryJson.isEmpty()) {
-			return null;
-		}
-
-		Object overall = summaryJson.get("overall_summary");
-		if (overall != null && !overall.toString().isBlank()) {
-			return overall.toString();
-		}
-
-		Object legacy = summaryJson.get("summary");
-		if (legacy != null && !legacy.toString().isBlank()) {
-			return legacy.toString();
-		}
-
-		return null;
 	}
 }

--- a/app-api/src/test/java/com/tasteam/domain/main/service/MainServiceTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/main/service/MainServiceTest.java
@@ -1,0 +1,85 @@
+package com.tasteam.domain.main.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executor;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.tasteam.config.annotation.UnitTest;
+import com.tasteam.domain.file.dto.response.DomainImageItem;
+import com.tasteam.domain.file.entity.DomainType;
+import com.tasteam.domain.file.service.FileService;
+import com.tasteam.domain.group.repository.GroupMemberRepository;
+import com.tasteam.domain.main.dto.request.MainPageRequest;
+import com.tasteam.domain.main.dto.response.AiRecommendResponse;
+import com.tasteam.domain.promotion.service.PromotionService;
+import com.tasteam.domain.restaurant.entity.RestaurantReviewSummary;
+import com.tasteam.domain.restaurant.repository.RestaurantFoodCategoryRepository;
+import com.tasteam.domain.restaurant.repository.RestaurantReviewSummaryRepository;
+import com.tasteam.domain.restaurant.repository.projection.MainRestaurantDistanceProjection;
+import com.tasteam.domain.restaurant.repository.projection.RestaurantCategoryProjection;
+
+@UnitTest
+@DisplayName("[유닛](Main) MainService 단위 테스트")
+class MainServiceTest {
+
+	private static final Instant NOW = Instant.parse("2026-03-13T00:00:00Z");
+
+	@Test
+	@DisplayName("AI 추천 조회 시 legacy summary 키를 reviewSummary로 노출한다")
+	void getAiRecommend_usesLegacySummaryKey() {
+		// given
+		MainDataService mainDataService = mock(MainDataService.class);
+		RestaurantFoodCategoryRepository categoryRepository = mock(RestaurantFoodCategoryRepository.class);
+		RestaurantReviewSummaryRepository summaryRepository = mock(RestaurantReviewSummaryRepository.class);
+		FileService fileService = mock(FileService.class);
+		Executor executor = Runnable::run;
+
+		MainRestaurantDistanceProjection restaurant = projection(1L, "레거시 맛집");
+		when(mainDataService.fetchAiSectionAll()).thenReturn(List.of(restaurant));
+
+		RestaurantCategoryProjection category = mock(RestaurantCategoryProjection.class);
+		when(category.getRestaurantId()).thenReturn(1L);
+		when(category.getCategoryName()).thenReturn("한식");
+		when(categoryRepository.findCategoriesByRestaurantIds(List.of(1L))).thenReturn(List.of(category));
+
+		when(summaryRepository.findByRestaurantIdIn(List.of(1L))).thenReturn(List.of(
+			RestaurantReviewSummary.create(1L, 0L, "dummy-v1", Map.of("summary", "레거시 AI 요약"), NOW)));
+
+		when(fileService.getDomainImageUrls(eq(DomainType.RESTAURANT), eq(List.of(1L))))
+			.thenReturn(Map.of(1L, List.of(new DomainImageItem(11L, "https://cdn.example.com/legacy.webp"))));
+
+		MainService service = new MainService(
+			mainDataService,
+			categoryRepository,
+			summaryRepository,
+			mock(GroupMemberRepository.class),
+			fileService,
+			mock(PromotionService.class),
+			executor);
+
+		// when
+		AiRecommendResponse response = service.getAiRecommend(null, new MainPageRequest(null, null));
+
+		// then
+		assertThat(response.section().items()).hasSize(1);
+		assertThat(response.section().items().getFirst().restaurantId()).isEqualTo(1L);
+		assertThat(response.section().items().getFirst().reviewSummary()).isEqualTo("레거시 AI 요약");
+	}
+
+	private MainRestaurantDistanceProjection projection(Long id, String name) {
+		MainRestaurantDistanceProjection projection = mock(MainRestaurantDistanceProjection.class);
+		when(projection.getId()).thenReturn(id);
+		when(projection.getName()).thenReturn(name);
+		when(projection.getDistanceMeter()).thenReturn(null);
+		return projection;
+	}
+}

--- a/app-api/src/test/java/com/tasteam/domain/restaurant/service/RestaurantAiJsonParserTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/restaurant/service/RestaurantAiJsonParserTest.java
@@ -1,0 +1,67 @@
+package com.tasteam.domain.restaurant.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.tasteam.config.annotation.UnitTest;
+import com.tasteam.domain.restaurant.dto.RestaurantAiComparison;
+import com.tasteam.domain.restaurant.dto.RestaurantAiSummary;
+import com.tasteam.domain.restaurant.type.AiReviewCategory;
+
+@UnitTest
+@DisplayName("[유닛](Restaurant) RestaurantAiJsonParser 단위 테스트")
+class RestaurantAiJsonParserTest {
+
+	@Test
+	@DisplayName("요약 JSON 파싱 시 overall_summary가 없으면 legacy summary 키를 사용한다")
+	void parseSummary_usesLegacySummaryKey() {
+		// given
+		Map<String, Object> summaryJson = Map.of(
+			"summary", "레거시 요약",
+			"categories", Map.of(
+				"food", Map.of(
+					"summary", "맛이 진하다",
+					"bullets", List.of("불향", "양이 많다"),
+					"evidence", List.of(
+						Map.of("review_id", "101", "snippet", "불향이 좋아요"),
+						Map.of("review_id", 102L, "snippet", "양이 많아요"),
+						Map.of("review_id", 103L, "snippet", "세 번째 근거"),
+						Map.of("review_id", 104L, "snippet", "잘려야 하는 근거")))));
+
+		// when
+		RestaurantAiSummary result = RestaurantAiJsonParser.parseSummary(summaryJson);
+
+		// then
+		assertThat(result.overallSummary()).isEqualTo("레거시 요약");
+		assertThat(result.categoryDetails()).containsKey(AiReviewCategory.TASTE);
+		assertThat(result.categoryDetails().get(AiReviewCategory.TASTE).summary()).isEqualTo("맛이 진하다");
+		assertThat(result.categoryDetails().get(AiReviewCategory.TASTE).bullets()).containsExactly("불향", "양이 많다");
+		assertThat(result.categoryDetails().get(AiReviewCategory.TASTE).evidences()).hasSize(3);
+		assertThat(result.categoryDetails().get(AiReviewCategory.TASTE).evidences().getFirst().reviewId())
+			.isEqualTo(101L);
+	}
+
+	@Test
+	@DisplayName("비교 JSON 파싱 시 strength_display alias도 공통 규칙으로 처리한다")
+	void parseComparison_supportsStrengthDisplayAlias() {
+		// given
+		Map<String, Object> comparisonJson = Map.of(
+			"category_lift", Map.of("service", 1.7, "price", "0.8"),
+			"strength_display", List.of("서비스 강점", "가격 강점"));
+
+		// when
+		RestaurantAiComparison result = RestaurantAiJsonParser.parseComparison(comparisonJson);
+
+		// then
+		assertThat(result.categoryDetails()).containsKeys(AiReviewCategory.SERVICE, AiReviewCategory.PRICE);
+		assertThat(result.categoryDetails().get(AiReviewCategory.SERVICE).summary()).isEqualTo("서비스 강점");
+		assertThat(result.categoryDetails().get(AiReviewCategory.SERVICE).liftScore()).isEqualTo(1.7d);
+		assertThat(result.categoryDetails().get(AiReviewCategory.PRICE).summary()).isEqualTo("가격 강점");
+		assertThat(result.categoryDetails().get(AiReviewCategory.PRICE).liftScore()).isEqualTo(0.8d);
+	}
+}


### PR DESCRIPTION
## 📌 PR 요약

#### Summary
- AI summary/comparison JSONB 파싱 규칙을 `RestaurantAiJsonParser`로 공통화했습니다.
- `RestaurantAiSummaryService`와 `MainService`가 동일한 parser와 fallback 규칙을 사용하도록 정리했습니다.
- `overall_summary`가 없을 때 `summary`를 사용하는 legacy 포맷 호환과 관련 테스트를 추가했습니다.

### Issue
- close : #568

---

## ➕ 추가된 기능

1. `RestaurantAiJsonParser`를 추가해 summary/comparison JSONB 해석, `strength_display` alias 처리, evidence 제한 규칙을 한 곳에서 관리하도록 했습니다.
2. `RestaurantAiJsonParserTest`, `MainServiceTest`를 추가해 legacy summary 키와 comparison alias 파싱 회귀를 검증했습니다.

## 🛠️ 수정/변경사항

1. `RestaurantAiSummaryService`의 중복 파싱 로직을 제거하고 공통 parser 호출 후 review evidence 보강만 담당하도록 정리했습니다.
2. `MainService`의 AI 추천 요약 조회도 공통 parser를 사용하도록 변경해 `overall_summary`와 `summary` fallback 규칙을 일관되게 맞췄습니다.

---

## ✅ 남은 작업

* [x] 없음