### PR TITLE
🐛 fix(deploy): JVM MaxRAMPercentage 75% → 60%로 조정 (OOM Kill 방지)

### DIFF
--- a/deploy/codedeploy/backend/docker-compose.backend.yml
+++ b/deploy/codedeploy/backend/docker-compose.backend.yml
@@ -10,6 +10,7 @@ services:
       - ${BACKEND_ENV_FILE:-/opt/tasteam/backend.env}
     ports:
       - "${CONTAINER_PORT:-8080}:8080"
+    entrypoint: ["java", "-XX:+UseContainerSupport", "-XX:MaxRAMPercentage=60.0", "-Xss256k", "-jar", "/app/app.jar"]
     extra_hosts:
       - "host.docker.internal:host-gateway"
     logging:


### PR DESCRIPTION
## Summary
- 부하테스트 시 JVM Heap(75%=768MB) + Non-Heap(~250MB) ≈ 1024MB로 Docker cgroup 한계 도달
- 커널 dmesg에서 java OOM Kill ~15회, alloy OOM Kill ~14회 확인 → 컨테이너 반복 재시작 → 메트릭 끊김 + 무지개 패턴
- docker-compose entrypoint로 MaxRAMPercentage를 60%(614MB)로 오버라이드하여 Non-Heap 여유 확보

## 변경 사항
- `docker-compose.backend.yml`에 entrypoint 추가 (Dockerfile 수정 없이 즉시 적용)

## Test plan
- [ ] stg 환경 배포 후 동일 부하테스트 재실행
- [ ] `sudo dmesg`에서 OOM Kill 미발생 확인
- [ ] Grafana에서 메트릭 끊김/무지개 패턴 해소 확인
- [ ] GC pressure 증가 여부 모니터링 (Heap 축소에 따른 부작용)