### PR TITLE
fix(chat): 채팅 시퀀스 불일치로 인한 PK 충돌 수정

### DIFF
--- a/app-api/src/main/resources/db/migration/V202603141730__align_chat_sequence_defaults.sql
+++ b/app-api/src/main/resources/db/migration/V202603141730__align_chat_sequence_defaults.sql
@@ -1,0 +1,46 @@
+-- V1__init에서 chat_* 시퀀스를 먼저 만들고,
+-- 이후 BIGSERIAL로 chat_* 테이블을 생성하면서 *_seq1 기본 시퀀스가 추가 생성되었다.
+-- 애플리케이션은 기존 *_seq를 사용하므로 컬럼 기본값과 시퀀스를 동일하게 맞춘다.
+DO $$
+DECLARE
+    max_chat_room_id BIGINT;
+    max_chat_room_member_id BIGINT;
+    max_chat_message_id BIGINT;
+    max_chat_message_file_id BIGINT;
+BEGIN
+    SELECT COALESCE(MAX(id), 0) INTO max_chat_room_id FROM chat_room;
+    IF max_chat_room_id = 0 THEN
+        PERFORM setval('chat_room_id_seq', 1, false);
+    ELSE
+        PERFORM setval('chat_room_id_seq', max_chat_room_id, true);
+    END IF;
+    ALTER TABLE chat_room ALTER COLUMN id SET DEFAULT nextval('chat_room_id_seq'::regclass);
+    ALTER SEQUENCE chat_room_id_seq OWNED BY chat_room.id;
+
+    SELECT COALESCE(MAX(id), 0) INTO max_chat_room_member_id FROM chat_room_member;
+    IF max_chat_room_member_id = 0 THEN
+        PERFORM setval('chat_room_member_id_seq', 1, false);
+    ELSE
+        PERFORM setval('chat_room_member_id_seq', max_chat_room_member_id, true);
+    END IF;
+    ALTER TABLE chat_room_member ALTER COLUMN id SET DEFAULT nextval('chat_room_member_id_seq'::regclass);
+    ALTER SEQUENCE chat_room_member_id_seq OWNED BY chat_room_member.id;
+
+    SELECT COALESCE(MAX(id), 0) INTO max_chat_message_id FROM chat_message;
+    IF max_chat_message_id = 0 THEN
+        PERFORM setval('chat_message_id_seq', 1, false);
+    ELSE
+        PERFORM setval('chat_message_id_seq', max_chat_message_id, true);
+    END IF;
+    ALTER TABLE chat_message ALTER COLUMN id SET DEFAULT nextval('chat_message_id_seq'::regclass);
+    ALTER SEQUENCE chat_message_id_seq OWNED BY chat_message.id;
+
+    SELECT COALESCE(MAX(id), 0) INTO max_chat_message_file_id FROM chat_message_file;
+    IF max_chat_message_file_id = 0 THEN
+        PERFORM setval('chat_message_file_id_seq', 1, false);
+    ELSE
+        PERFORM setval('chat_message_file_id_seq', max_chat_message_file_id, true);
+    END IF;
+    ALTER TABLE chat_message_file ALTER COLUMN id SET DEFAULT nextval('chat_message_file_id_seq'::regclass);
+    ALTER SEQUENCE chat_message_file_id_seq OWNED BY chat_message_file.id;
+END $$;

--- a/app-api/src/test/java/com/tasteam/domain/chat/repository/ChatSequenceAlignmentRepositoryTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/chat/repository/ChatSequenceAlignmentRepositoryTest.java
@@ -1,0 +1,153 @@
+package com.tasteam.domain.chat.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Connection;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.support.EncodedResource;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DataSourceUtils;
+import org.springframework.jdbc.datasource.init.ScriptUtils;
+
+import com.tasteam.config.annotation.RepositoryJpaTest;
+import com.tasteam.domain.chat.entity.ChatMessage;
+import com.tasteam.domain.chat.type.ChatMessageType;
+
+import jakarta.persistence.EntityManager;
+
+@RepositoryJpaTest
+@DisplayName("[유닛](Chat) Chat 시퀀스 정렬 테스트")
+class ChatSequenceAlignmentRepositoryTest {
+
+	@Autowired
+	private DataSource dataSource;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@Autowired
+	private EntityManager entityManager;
+
+	@Autowired
+	private ChatMessageRepository chatMessageRepository;
+
+	@Test
+	@DisplayName("채팅 시퀀스 정렬 마이그레이션은 JPA 시퀀스와 테이블 기본 시퀀스를 하나로 맞춘다")
+	void alignChatSequences_unifiesJpaAndColumnDefaults() throws Exception {
+		// given
+		insertChatFixtures();
+		createConflictingDefaultSequences();
+
+		// when
+		executeMigration("db/migration/V202603141730__align_chat_sequence_defaults.sql");
+
+		// then
+		assertDefaultSequence("chat_room", "chat_room_id_seq");
+		assertDefaultSequence("chat_room_member", "chat_room_member_id_seq");
+		assertDefaultSequence("chat_message", "chat_message_id_seq");
+		assertDefaultSequence("chat_message_file", "chat_message_file_id_seq");
+
+		ChatMessage savedMessage = chatMessageRepository.saveAndFlush(ChatMessage.builder()
+			.chatRoomId(4001L)
+			.memberId(1001L)
+			.type(ChatMessageType.TEXT)
+			.content("JPA message")
+			.deletedAt(null)
+			.build());
+
+		Number sqlInsertedId = (Number)entityManager.createNativeQuery("""
+			INSERT INTO chat_message (chat_room_id, member_id, type, content, created_at)
+			VALUES (4001, 1001, 'TEXT', 'SQL message', now())
+			RETURNING id
+			""").getSingleResult();
+
+		assertThat(savedMessage.getId()).isGreaterThan(5001L);
+		assertThat(sqlInsertedId.longValue()).isGreaterThan(savedMessage.getId());
+	}
+
+	private void insertChatFixtures() {
+		entityManager.createNativeQuery("""
+			INSERT INTO member (id, nickname, role, status, created_at, updated_at)
+			VALUES (1001, '채팅회원', 'USER', 'ACTIVE', now(), now())
+			""").executeUpdate();
+		entityManager.createNativeQuery("""
+			INSERT INTO "group" (id, name, type, address, location, join_type, status, created_at, updated_at)
+			VALUES (2001, '채팅그룹', 'UNOFFICIAL', '서울특별시 마포구',
+			        ST_SetSRID(ST_MakePoint(126.9, 37.5), 4326), 'PASSWORD', 'ACTIVE', now(), now())
+			""").executeUpdate();
+		entityManager.createNativeQuery("""
+			INSERT INTO subgroup (id, group_id, name, join_type, status, member_count, created_at, updated_at)
+			VALUES (3001, 2001, '채팅서브그룹', 'OPEN', 'ACTIVE', 1, now(), now())
+			""").executeUpdate();
+		entityManager.createNativeQuery("""
+			INSERT INTO chat_room (id, subgroup_id, created_at)
+			VALUES (4001, 3001, now())
+			""").executeUpdate();
+		entityManager.createNativeQuery("""
+			INSERT INTO chat_message (id, chat_room_id, member_id, type, content, created_at)
+			VALUES (5001, 4001, 1001, 'TEXT', 'seed message', now())
+			""").executeUpdate();
+		entityManager.flush();
+		entityManager.clear();
+	}
+
+	private void createConflictingDefaultSequences() {
+		jdbcTemplate.execute("CREATE SEQUENCE IF NOT EXISTS chat_room_id_seq1 START WITH 1");
+		jdbcTemplate.execute("CREATE SEQUENCE IF NOT EXISTS chat_room_member_id_seq1 START WITH 1");
+		jdbcTemplate.execute("CREATE SEQUENCE IF NOT EXISTS chat_message_id_seq1 START WITH 1");
+		jdbcTemplate.execute("CREATE SEQUENCE IF NOT EXISTS chat_message_file_id_seq1 START WITH 1");
+
+		jdbcTemplate
+			.execute("ALTER TABLE chat_room ALTER COLUMN id SET DEFAULT nextval('chat_room_id_seq1'::regclass)");
+		jdbcTemplate.execute(
+			"ALTER TABLE chat_room_member ALTER COLUMN id SET DEFAULT nextval('chat_room_member_id_seq1'::regclass)");
+		jdbcTemplate.execute(
+			"ALTER TABLE chat_message ALTER COLUMN id SET DEFAULT nextval('chat_message_id_seq1'::regclass)");
+		jdbcTemplate.execute(
+			"ALTER TABLE chat_message_file ALTER COLUMN id SET DEFAULT nextval('chat_message_file_id_seq1'::regclass)");
+
+		entityManager.createNativeQuery("SELECT setval('chat_room_id_seq', 1, true)").getSingleResult();
+		entityManager.createNativeQuery("SELECT setval('chat_room_member_id_seq', 1, true)").getSingleResult();
+		entityManager.createNativeQuery("SELECT setval('chat_message_id_seq', 1, true)").getSingleResult();
+		entityManager.createNativeQuery("SELECT setval('chat_message_file_id_seq', 1, true)").getSingleResult();
+		entityManager.createNativeQuery("SELECT setval('chat_room_id_seq1', 4001, true)").getSingleResult();
+		entityManager.createNativeQuery("SELECT setval('chat_message_id_seq1', 5001, true)").getSingleResult();
+		entityManager.flush();
+		entityManager.clear();
+	}
+
+	private void executeMigration(String classpathLocation) throws Exception {
+		ClassPathResource resource = new ClassPathResource(classpathLocation);
+		Connection connection = DataSourceUtils.getConnection(dataSource);
+		try {
+			ScriptUtils.executeSqlScript(connection, new EncodedResource(resource), false, false,
+				ScriptUtils.DEFAULT_COMMENT_PREFIX, ScriptUtils.EOF_STATEMENT_SEPARATOR,
+				ScriptUtils.DEFAULT_BLOCK_COMMENT_START_DELIMITER, ScriptUtils.DEFAULT_BLOCK_COMMENT_END_DELIMITER);
+		} finally {
+			DataSourceUtils.releaseConnection(connection, dataSource);
+		}
+	}
+
+	private void assertDefaultSequence(String tableName, String expectedSequenceName) {
+		String actualSequence = jdbcTemplate.queryForObject(
+			"SELECT pg_get_serial_sequence(?, 'id')",
+			String.class,
+			tableName);
+		String actualDefault = jdbcTemplate.queryForObject("""
+			SELECT column_default
+			FROM information_schema.columns
+			WHERE table_schema = 'public'
+			  AND table_name = ?
+			  AND column_name = 'id'
+			""", String.class, tableName);
+
+		assertThat(actualSequence).isEqualTo("public." + expectedSequenceName);
+		assertThat(actualDefault).isEqualTo("nextval('" + expectedSequenceName + "'::regclass)");
+	}
+}

--- a/docs/troubleshooting/troubleshooting-chat-message-sequence-mismatch.md
+++ b/docs/troubleshooting/troubleshooting-chat-message-sequence-mismatch.md
@@ -1,0 +1,105 @@
+# Chat - chat_message PK 중복 시퀀스 불일치 문제
+
+## 증상
+
+스테이징 환경에서 채팅 메시지 전송 시 아래 예외가 반복 발생했다.
+
+```text
+ERROR: duplicate key value violates unique constraint "chat_message_pkey"
+Detail: Key (id)=(7812) already exists.
+```
+
+- 발생 지점: `ChatController.sendMessage(..)` -> `ChatService.sendMessage(..)`
+- 영향: 메시지 저장 실패, 채팅 전송 API 500 응답
+
+## 원인
+
+문제의 본질은 `chat_message.id` 컬럼 기본 시퀀스와 JPA 엔티티가 참조하는 시퀀스가 서로 달라진 상태였다.
+
+### 1. 스키마 생성 순서에서 시퀀스가 이중화됨
+
+- [V1__init.sql](/Users/devon.woo/Workspace/Tasteam/3-team-Tasteam-be/app-api/src/main/resources/db/migration/V1__init.sql) 에서 `chat_message_id_seq`, `chat_room_id_seq` 같은 chat 계열 시퀀스를 먼저 생성했다.
+- 이후 [V202602111000__create_chat_tables.sql](/Users/devon.woo/Workspace/Tasteam/3-team-Tasteam-be/app-api/src/main/resources/db/migration/V202602111000__create_chat_tables.sql) 에서 `BIGSERIAL`로 chat 테이블을 만들었다.
+- PostgreSQL은 이미 같은 이름의 시퀀스가 존재하므로, 컬럼 기본 시퀀스로 `chat_message_id_seq1` 같은 새 시퀀스를 추가 생성했다.
+
+### 2. 애플리케이션은 기존 시퀀스를 계속 사용함
+
+- [ChatMessage.java](/Users/devon.woo/Workspace/Tasteam/3-team-Tasteam-be/app-api/src/main/java/com/tasteam/domain/chat/entity/ChatMessage.java) 는 `chat_message_id_seq`를 `@SequenceGenerator`로 사용한다.
+- 결과적으로:
+  - 테이블 기본값: `chat_message_id_seq1`
+  - JPA insert 시 사용 시퀀스: `chat_message_id_seq`
+
+### 3. 스테이징 DB에서 직접 확인한 값
+
+```sql
+SELECT COUNT(*), MAX(id) FROM chat_message;
+-- 33233, 33233
+
+SELECT last_value, is_called FROM chat_message_id_seq;
+-- 7812, true
+
+SELECT pg_get_serial_sequence('chat_message', 'id');
+-- public.chat_message_id_seq1
+
+SELECT column_default
+FROM information_schema.columns
+WHERE table_schema = 'public'
+  AND table_name = 'chat_message'
+  AND column_name = 'id';
+-- nextval('chat_message_id_seq1'::regclass)
+```
+
+즉, JPA는 `7804 ~ 7812` 같은 이미 존재하는 PK를 계속 시도했고, 그 결과 `chat_message_pkey` 충돌이 발생했다.
+
+## 왜 `setval`만으로는 부족했는가
+
+`chat_message_id_seq`를 `MAX(id)`로 한 번만 보정하면 당장 `chat_message` insert는 통과할 수 있다.
+
+하지만 이 경우에도 문제는 남는다.
+
+- 테이블 기본값은 여전히 `chat_message_id_seq1`
+- 애플리케이션은 계속 `chat_message_id_seq`
+- SQL 직접 insert, 배치, 관리성 쿼리, 후속 마이그레이션이 두 시퀀스를 번갈아 사용할 수 있음
+
+즉, `setval`만으로는 증상 완화만 되고, 시퀀스 분기 자체는 제거되지 않는다.
+
+## 해결
+
+### 1. chat 테이블 4종의 기본 시퀀스를 하나로 통일
+
+다음 테이블을 모두 정리했다.
+
+- `chat_room`
+- `chat_room_member`
+- `chat_message`
+- `chat_message_file`
+
+추가한 마이그레이션: [V202603141730__align_chat_sequence_defaults.sql](/Users/devon.woo/Workspace/Tasteam/3-team-Tasteam-be/app-api/src/main/resources/db/migration/V202603141730__align_chat_sequence_defaults.sql)
+
+이 마이그레이션은 각 테이블에 대해:
+
+1. `MAX(id)`를 조회
+2. 애플리케이션이 참조하는 `*_id_seq`를 `MAX(id)`로 맞춤
+3. 컬럼 기본값을 `nextval('<expected_seq>'::regclass)`로 변경
+4. `OWNED BY`를 다시 연결
+
+### 2. 회귀 테스트 추가
+
+[ChatSequenceAlignmentRepositoryTest.java](/Users/devon.woo/Workspace/Tasteam/3-team-Tasteam-be/app-api/src/test/java/com/tasteam/domain/chat/repository/ChatSequenceAlignmentRepositoryTest.java) 에서 다음을 검증한다.
+
+- 충돌 상태(`*_seq1` 기본값 + JPA는 `*_seq`)를 재현
+- 마이그레이션 SQL 실행
+- JPA 저장과 SQL 기본 insert가 같은 시퀀스를 타는지 확인
+
+실행 명령:
+
+```bash
+./gradlew :app-api:test --tests com.tasteam.domain.chat.repository.ChatSequenceAlignmentRepositoryTest
+```
+
+## 재발 방지 포인트
+
+- 시퀀스를 명시적으로 선생성한 테이블에는 `BIGSERIAL` 대신 `BIGINT DEFAULT nextval('...')` 또는 명시적 시퀀스 전략을 일관되게 사용한다.
+- 스키마 생성 SQL과 엔티티 `@SequenceGenerator` 이름이 실제 DB 기본값과 일치하는지 반드시 확인한다.
+- 운영 DB 확인 시에는 `setval`보다 먼저 `pg_get_serial_sequence`와 `column_default`를 같이 본다.
+- 유사 패턴이 있는 테이블은 한 번에 정리한다. 이번 케이스도 `chat_message`만 수정하지 않고 chat 4개 테이블을 함께 맞췄다.


### PR DESCRIPTION
## 📌 PR 요약

#### Summary
- 채팅 관련 테이블 4종의 `id` 기본 시퀀스를 애플리케이션이 참조하는 `*_id_seq`로 통일하는 Flyway 마이그레이션을 추가했습니다.
- 시퀀스 분기 상태를 재현하고 마이그레이션 적용 후 JPA/SQL insert가 같은 시퀀스를 타는지 검증하는 회귀 테스트를 추가했습니다.
- 원인 분석, DB 확인 쿼리, 복구 절차를 트러블슈팅 문서와 위키에 정리했습니다.

### Issue
- close : #591

---

## ➕ 추가된 기능

1. 채팅 시퀀스 정렬 검증용 저장소 회귀 테스트 추가
2. `chat_message` PK 중복 이슈 트러블슈팅 문서 및 위키 페이지 추가

## 🛠️ 수정/변경사항

1. `chat_room`, `chat_room_member`, `chat_message`, `chat_message_file`의 `id` 기본 시퀀스를 `*_id_seq`로 통일하고 현재 `MAX(id)` 기준으로 보정하는 Flyway 마이그레이션을 추가했습니다.
2. 스테이징에서 확인한 `*_seq` / `*_seq1` 분기 상태를 재현하는 테스트를 추가해 동일 계열 회귀를 막았습니다.

---

## ✅ 남은 작업

* [ ] 스테이징 배포 후 채팅 메시지 전송 재검증
* [ ] 동일 배포본 기준으로 chat 관련 테이블 4종 시퀀스 상태 최종 점검
