### PR TITLE
refactor(main): 홈 응답에 배너와 스플래시 추가 (#594)

### DIFF
--- a/app-api/src/main/java/com/tasteam/domain/main/dto/response/HomePageResponse.java
+++ b/app-api/src/main/java/com/tasteam/domain/main/dto/response/HomePageResponse.java
@@ -2,7 +2,27 @@ package com.tasteam.domain.main.dto.response;
 
 import java.util.List;
 
-public record HomePageResponse(List<Section> sections) {
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.tasteam.domain.promotion.dto.response.SplashPromotionResponse;
+
+public record HomePageResponse(
+	Banners banners,
+	List<Section> sections,
+
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	SplashPromotionResponse splashPromotion) {
+
+	public record Banners(
+		boolean enabled,
+		List<BannerItem> items) {
+	}
+
+	public record BannerItem(
+		Long id,
+		String imageUrl,
+		String landingUrl,
+		Integer order) {
+	}
 
 	public record Section(
 		String type,

--- a/app-api/src/main/java/com/tasteam/domain/main/service/MainService.java
+++ b/app-api/src/main/java/com/tasteam/domain/main/service/MainService.java
@@ -157,7 +157,19 @@ public class MainService {
 				toHomeSectionItems(hotRestaurants, categoriesByRestaurant, thumbnailByRestaurant,
 					summaryByRestaurant)));
 
-		return new HomePageResponse(sections);
+		Banners mainBanners = fetchBanners();
+		HomePageResponse.Banners banners = new HomePageResponse.Banners(
+			mainBanners.enabled(),
+			mainBanners.items().stream()
+				.map(item -> new HomePageResponse.BannerItem(
+					item.id(),
+					item.imageUrl(),
+					item.landingUrl(),
+					item.order()))
+				.toList());
+		SplashPromotionResponse splashPromotion = promotionService.getSplashPromotion().orElse(null);
+
+		return new HomePageResponse(banners, sections, splashPromotion);
 	}
 
 	public AiRecommendResponse getAiRecommend(Long memberId, MainPageRequest request) {

--- a/app-api/src/test/java/com/tasteam/domain/main/controller/MainControllerTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/main/controller/MainControllerTest.java
@@ -6,6 +6,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.time.Instant;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -19,6 +20,7 @@ import com.tasteam.domain.main.dto.response.MainPageResponse;
 import com.tasteam.domain.main.dto.response.MainPageResponse.Banners;
 import com.tasteam.domain.main.dto.response.MainPageResponse.Section;
 import com.tasteam.domain.main.dto.response.MainPageResponse.SectionItem;
+import com.tasteam.domain.promotion.dto.response.SplashPromotionResponse;
 import com.tasteam.fixture.MainPageRequestFixture;
 
 @DisplayName("[유닛](Main) MainController 단위 테스트")
@@ -41,9 +43,20 @@ class MainControllerTest extends BaseControllerWebMvcTest {
 		HomePageResponse.SectionItem item = new HomePageResponse.SectionItem(
 			1L, "맛집1", 120.0, List.of("한식", "국밥"), "https://example.com/img1.jpg", "요약");
 		return new HomePageResponse(
+			new HomePageResponse.Banners(
+				true,
+				List.of(new HomePageResponse.BannerItem(10L, "https://example.com/banner.jpg", "/events/10", 1))),
 			List.of(
 				new HomePageResponse.Section("NEW", "신규 개장", List.of(item)),
-				new HomePageResponse.Section("HOT", "이번주 Hot", List.of(item))));
+				new HomePageResponse.Section("HOT", "이번주 Hot", List.of(item))),
+			new SplashPromotionResponse(
+				99L,
+				"스플래시 제목",
+				"스플래시 내용",
+				"https://example.com/splash-thumb.jpg",
+				Instant.parse("2026-03-01T00:00:00Z"),
+				Instant.parse("2026-03-31T23:59:59Z"),
+				List.of("https://example.com/splash-detail.jpg")));
 	}
 
 	private AiRecommendResponse createAiResponse() {
@@ -106,7 +119,7 @@ class MainControllerTest extends BaseControllerWebMvcTest {
 	class GetHome {
 
 		@Test
-		@DisplayName("홈 페이지를 조회하면 NEW/HOT 두 섹션만 반환한다")
+		@DisplayName("홈 페이지를 조회하면 배너, 스플래시와 함께 NEW/HOT 두 섹션을 반환한다")
 		void 홈_페이지_조회_성공() throws Exception {
 			// given
 			given(mainService.getHome(any(), any())).willReturn(createHomeResponse());
@@ -117,6 +130,9 @@ class MainControllerTest extends BaseControllerWebMvcTest {
 				.param("longitude", String.valueOf(MainPageRequestFixture.DEFAULT_LONGITUDE)))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.banners.enabled").value(true))
+				.andExpect(jsonPath("$.data.banners.items[0].id").value(10))
+				.andExpect(jsonPath("$.data.splashPromotion.id").value(99))
 				.andExpect(jsonPath("$.data.sections").isArray())
 				.andExpect(jsonPath("$.data.sections.length()").value(2))
 				.andExpect(jsonPath("$.data.sections[0].type").value("NEW"))

--- a/app-api/src/test/java/com/tasteam/domain/main/service/MainServiceIntegrationTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/main/service/MainServiceIntegrationTest.java
@@ -87,6 +87,7 @@ class MainServiceIntegrationTest {
 
 			HomePageResponse response = mainService.getHome(null, new MainPageRequest(null, null));
 
+			assertThat(response.banners()).isNotNull();
 			assertThat(response.sections()).hasSize(2);
 		}
 	}


### PR DESCRIPTION
## 변경 요약
- /api/v1/main/home 반환 스펙에 와 을 추가해 홈 화면에서 바로 렌더링 가능하도록 조정했습니다.
- 배너 조회/스플래시 조회는 home 응답 생성 시 동일 트랜잭션 내에서 조회해 기존 home flow와 정합성 확보했습니다.
- 홈 API 통합 테스트 및 서비스 통합 테스트에서 응답 데이터 보강을 검증하도록 보강했습니다.

Closes #594
