### PR TITLE
feat(main): 메인 섹션 조회 타임아웃 폴백 처리

### DIFF
--- a/app-api/src/main/java/com/tasteam/domain/main/service/MainService.java
+++ b/app-api/src/main/java/com/tasteam/domain/main/service/MainService.java
@@ -6,7 +6,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
 
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
@@ -29,6 +33,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class MainService {
 
+	private static final long MAIN_QUERY_TIMEOUT_SECONDS = 3L;
+
 	private final MainDataService mainDataService;
 	private final MainMetadataLoader metadataLoader;
 	private final MainGroupRepository groupRepository;
@@ -46,11 +52,12 @@ public class MainService {
 		CompletableFuture<List<MainRestaurantDistanceProjection>> aiFuture = CompletableFuture.supplyAsync(
 			() -> fetchAiSection(location), mainQueryExecutor);
 
-		CompletableFuture.allOf(hotFuture, newFuture, aiFuture).join();
-
-		List<MainRestaurantDistanceProjection> hotRestaurants = hotFuture.join();
-		List<MainRestaurantDistanceProjection> newRestaurants = newFuture.join();
-		List<MainRestaurantDistanceProjection> aiRestaurants = aiFuture.join();
+		List<MainRestaurantDistanceProjection> hotRestaurants = getWithTimeout(hotFuture,
+			() -> mainDataService.fetchHotSectionAll());
+		List<MainRestaurantDistanceProjection> newRestaurants = getWithTimeout(newFuture,
+			() -> mainDataService.fetchNewSectionAll());
+		List<MainRestaurantDistanceProjection> aiRestaurants = getWithTimeout(aiFuture,
+			() -> mainDataService.fetchAiSectionAll());
 
 		SectionMetadata metadata = fetchMetadata(collectAllIds(hotRestaurants, newRestaurants, aiRestaurants));
 
@@ -74,10 +81,10 @@ public class MainService {
 		CompletableFuture<List<MainRestaurantDistanceProjection>> hotFuture = CompletableFuture.supplyAsync(
 			() -> fetchHotSection(location), mainQueryExecutor);
 
-		CompletableFuture.allOf(newFuture, hotFuture).join();
-
-		List<MainRestaurantDistanceProjection> newRestaurants = newFuture.join();
-		List<MainRestaurantDistanceProjection> hotRestaurants = hotFuture.join();
+		List<MainRestaurantDistanceProjection> newRestaurants = getWithTimeout(newFuture,
+			() -> mainDataService.fetchNewSectionAll());
+		List<MainRestaurantDistanceProjection> hotRestaurants = getWithTimeout(hotFuture,
+			() -> mainDataService.fetchHotSectionAll());
 
 		SectionMetadata metadata = fetchMetadata(collectAllIds(newRestaurants, hotRestaurants));
 
@@ -94,9 +101,9 @@ public class MainService {
 	public AiRecommendResponse getAiRecommend(Long memberId, MainPageRequest request) {
 		LocationContext location = resolveLocation(memberId, request);
 
-		List<MainRestaurantDistanceProjection> aiRestaurants = CompletableFuture
-			.supplyAsync(() -> fetchAiSection(location), mainQueryExecutor)
-			.join();
+		List<MainRestaurantDistanceProjection> aiRestaurants = getWithTimeout(
+			CompletableFuture.supplyAsync(() -> fetchAiSection(location), mainQueryExecutor),
+			() -> mainDataService.fetchAiSectionAll());
 
 		SectionMetadata metadata = fetchMetadata(collectAllIds(aiRestaurants));
 
@@ -177,8 +184,28 @@ public class MainService {
 		CompletableFuture<Map<Long, String>> summaryFuture = CompletableFuture.supplyAsync(
 			() -> metadataLoader.loadSummaries(allIds), mainQueryExecutor);
 
-		CompletableFuture.allOf(catFuture, thumbFuture, summaryFuture).join();
-		return new SectionMetadata(catFuture.join(), thumbFuture.join(), summaryFuture.join());
+		Map<Long, List<String>> categories = getWithTimeout(catFuture, Map::of);
+		Map<Long, String> thumbnails = getWithTimeout(thumbFuture, Map::of);
+		Map<Long, String> summaries = getWithTimeout(summaryFuture, Map::of);
+		return new SectionMetadata(categories, thumbnails, summaries);
+	}
+
+	private <T> T getWithTimeout(CompletableFuture<T> future, Supplier<T> fallback) {
+		try {
+			return future.get(MAIN_QUERY_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			return fallback.get();
+		} catch (TimeoutException e) {
+			future.cancel(true);
+			return fallback.get();
+		} catch (ExecutionException e) {
+			Throwable cause = e.getCause();
+			if (cause instanceof RuntimeException re) {
+				throw re;
+			}
+			return fallback.get();
+		}
 	}
 
 	private List<MainSectionItem> toSectionItems(


### PR DESCRIPTION
## 📌 PR 요약

#### Summary
- 메인/홈/AI 추천 섹션 조회를 3초 timeout 기반으로 감싸고, 지연 시 섹션별 폴백 데이터를 반환하도록 변경했습니다.
- 검증: `./gradlew test --tests com.tasteam.domain.main.service.MainServiceTest --tests com.tasteam.domain.main.service.MainServiceIntegrationTest`

### Issue
- close : #604

---

## ➕ 추가된 기능
1. MainService에 `getWithTimeout()` 헬퍼를 추가해 섹션별 timeout 처리와 fallback 반환을 공통화했습니다.
2. HOT/NEW/AI 섹션과 메타데이터 로딩에 각각 안전한 fallback 경로를 연결했습니다.

## 🛠️ 수정/변경사항
1. `CompletableFuture.allOf().join()` 중심 흐름을 제거하고 future별 결과를 개별 timeout/fallback으로 수집하도록 바꿨습니다.
2. `InterruptedException`, `TimeoutException`, `ExecutionException` 처리 시나리오를 분리해 전체 응답 실패 전파를 줄였습니다.

---

## ✅ 남은 작업
* [ ] 운영 환경에서 timeout/fallback 로그 및 지표 노출 여부 점검
