### PR TITLE
✨ feat: Redis Pub/Sub 기반 WS 브로드캐스트 경로 추가 및 Stream ACK 분기 개선

### DIFF
--- a/app-api/src/main/java/com/tasteam/domain/chat/config/ChatStreamProperties.java
+++ b/app-api/src/main/java/com/tasteam/domain/chat/config/ChatStreamProperties.java
@@ -16,7 +16,9 @@ public record ChatStreamProperties(
 	int maxAllowedPartitions,
 	boolean partitionConsumeEnabled,
 	boolean dualWriteEnabled,
-	boolean legacyRoomConsumeEnabled) {
+	boolean legacyRoomConsumeEnabled,
+	boolean wsPubSubBroadcastEnabled,
+	String wsPubSubChannel) {
 	public ChatStreamProperties() {
 		this(
 			true,
@@ -29,6 +31,8 @@ public record ChatStreamProperties(
 			128,
 			true,
 			true,
-			false);
+			false,
+			false,
+			"chat:websocket:broadcast");
 	}
 }

--- a/app-api/src/main/java/com/tasteam/domain/chat/stream/ChatStreamConfig.java
+++ b/app-api/src/main/java/com/tasteam/domain/chat/stream/ChatStreamConfig.java
@@ -2,12 +2,15 @@ package com.tasteam.domain.chat.stream;
 
 import java.time.Duration;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.listener.PatternTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 import org.springframework.data.redis.stream.StreamMessageListenerContainer;
 import org.springframework.data.redis.stream.StreamMessageListenerContainer.StreamMessageListenerContainerOptions;
@@ -45,5 +48,21 @@ public class ChatStreamConfig {
 			.build();
 
 		return StreamMessageListenerContainer.create(connectionFactory, options);
+	}
+
+	@Bean(destroyMethod = "destroy")
+	@ConditionalOnProperty(name = "chat.stream.ws-pubsub-broadcast-enabled", havingValue = "true")
+	public RedisMessageListenerContainer chatWsBroadcastListenerContainer(
+		RedisConnectionFactory connectionFactory,
+		ChatWsBroadcastSubscriber chatWsBroadcastSubscriber,
+		@Qualifier("chatStreamExecutor")
+		ThreadPoolTaskExecutor chatStreamExecutor,
+		ChatStreamProperties properties) {
+		RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+		container.setConnectionFactory(connectionFactory);
+		container.setTaskExecutor(chatStreamExecutor);
+		container.setSubscriptionExecutor(chatStreamExecutor);
+		container.addMessageListener(chatWsBroadcastSubscriber, new PatternTopic(properties.wsPubSubChannel()));
+		return container;
 	}
 }

--- a/app-api/src/main/java/com/tasteam/domain/chat/stream/ChatStreamSubscriber.java
+++ b/app-api/src/main/java/com/tasteam/domain/chat/stream/ChatStreamSubscriber.java
@@ -65,6 +65,7 @@ public class ChatStreamSubscriber {
 	private final ChatStreamGroupNameProvider groupNameProvider;
 	private final SimpMessagingTemplate messagingTemplate;
 	private final ChatStreamProperties chatStreamProperties;
+	private final ChatWsBroadcastPublisher chatWsBroadcastPublisher;
 	@Nullable
 	private final MeterRegistry meterRegistry;
 
@@ -82,6 +83,7 @@ public class ChatStreamSubscriber {
 		ChatStreamGroupNameProvider groupNameProvider,
 		SimpMessagingTemplate messagingTemplate,
 		ChatStreamProperties chatStreamProperties,
+		ChatWsBroadcastPublisher chatWsBroadcastPublisher,
 		@Nullable
 		MeterRegistry meterRegistry) {
 		this.container = container;
@@ -91,6 +93,7 @@ public class ChatStreamSubscriber {
 		this.groupNameProvider = groupNameProvider;
 		this.messagingTemplate = messagingTemplate;
 		this.chatStreamProperties = chatStreamProperties;
+		this.chatWsBroadcastPublisher = chatWsBroadcastPublisher;
 		this.meterRegistry = meterRegistry;
 	}
 
@@ -226,12 +229,14 @@ public class ChatStreamSubscriber {
 
 	private void logConfiguration() {
 		log.info(
-			"Chat stream config: partitionCount={}, executorThreads={}, partitionConsumeEnabled={}, legacyRoomConsumeEnabled={}, dualWriteEnabled={}",
+			"Chat stream config: partitionCount={}, executorThreads={}, partitionConsumeEnabled={}, legacyRoomConsumeEnabled={}, dualWriteEnabled={}, wsPubSubBroadcastEnabled={}, wsPubSubChannel={}",
 			chatStreamProperties.partitionCount(),
 			chatStreamProperties.executorThreadPoolSize(),
 			chatStreamProperties.partitionConsumeEnabled(),
 			chatStreamProperties.legacyRoomConsumeEnabled(),
-			chatStreamProperties.dualWriteEnabled());
+			chatStreamProperties.dualWriteEnabled(),
+			chatStreamProperties.wsPubSubBroadcastEnabled(),
+			chatStreamProperties.wsPubSubChannel());
 
 		double ratio = (double)chatStreamProperties.partitionCount() / chatStreamProperties.executorThreadPoolSize();
 		if (chatStreamProperties.partitionConsumeEnabled() && ratio > 8.0d) {
@@ -375,8 +380,9 @@ public class ChatStreamSubscriber {
 
 		try {
 			ChatStreamPayload payload = ChatStreamPayload.fromMap(record.getValue());
-			ChatMessageItemResponse itemResponse = payload.toMessageItem();
-			messagingTemplate.convertAndSend("/topic/chat-rooms/" + payload.chatRoomId(), itemResponse);
+			if (!broadcastToWebSocket(payload, partitionLabel, streamKey, record.getId())) {
+				return;
+			}
 			if (ack(record)) {
 				recordSuccessMetrics(partitionLabel, streamKey, Duration.ofNanos(System.nanoTime() - startNanos));
 			}
@@ -408,6 +414,31 @@ public class ChatStreamSubscriber {
 				ex);
 			recordErrorMetric(partitionLabel, streamKey, "processing_error");
 		}
+	}
+
+	private boolean broadcastToWebSocket(
+		ChatStreamPayload payload,
+		String partitionLabel,
+		String streamKey,
+		RecordId recordId) {
+		if (chatStreamProperties.wsPubSubBroadcastEnabled()) {
+			boolean published = chatWsBroadcastPublisher.publish(payload);
+			if (!published) {
+				log.warn(
+					"Failed to process chat stream record. partitionId={}, streamKey={}, errorType={}, recordId={}",
+					partitionLabel,
+					streamKey,
+					"ws_pubsub_publish_failed",
+					recordId);
+				recordErrorMetric(partitionLabel, streamKey, "ws_pubsub_publish_failed");
+				return false;
+			}
+			return true;
+		}
+
+		ChatMessageItemResponse itemResponse = payload.toMessageItem();
+		messagingTemplate.convertAndSend("/topic/chat-rooms/" + payload.chatRoomId(), itemResponse);
+		return true;
 	}
 
 	private void claimAndHandle(String streamKey, List<RecordId> recordIds, boolean deadLetter, @Nullable

--- a/app-api/src/main/java/com/tasteam/domain/chat/stream/ChatWsBroadcastEvent.java
+++ b/app-api/src/main/java/com/tasteam/domain/chat/stream/ChatWsBroadcastEvent.java
@@ -1,0 +1,40 @@
+package com.tasteam.domain.chat.stream;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.util.StringUtils;
+
+public record ChatWsBroadcastEvent(
+	Long chatRoomId,
+	Map<String, String> payload,
+	Instant publishedAt,
+	String sourceInstance) {
+
+	public static ChatWsBroadcastEvent from(ChatStreamPayload payload, String sourceInstance) {
+		return new ChatWsBroadcastEvent(
+			payload.chatRoomId(),
+			new HashMap<>(payload.toMap()),
+			Instant.now(),
+			sourceInstance);
+	}
+
+	public Long resolveChatRoomId() {
+		if (chatRoomId != null) {
+			return chatRoomId;
+		}
+		if (payload == null) {
+			return null;
+		}
+		String chatRoomIdValue = payload.get("chatRoomId");
+		if (!StringUtils.hasText(chatRoomIdValue) || "null".equalsIgnoreCase(chatRoomIdValue.trim())) {
+			return null;
+		}
+		return Long.valueOf(chatRoomIdValue);
+	}
+
+	public ChatStreamPayload toPayload() {
+		return ChatStreamPayload.fromMap(payload == null ? Map.of() : payload);
+	}
+}

--- a/app-api/src/main/java/com/tasteam/domain/chat/stream/ChatWsBroadcastPublisher.java
+++ b/app-api/src/main/java/com/tasteam/domain/chat/stream/ChatWsBroadcastPublisher.java
@@ -1,0 +1,44 @@
+package com.tasteam.domain.chat.stream;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tasteam.domain.chat.config.ChatStreamProperties;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "spring.data.redis.enabled", havingValue = "true", matchIfMissing = true)
+public class ChatWsBroadcastPublisher {
+
+	private final StringRedisTemplate stringRedisTemplate;
+	private final ObjectMapper objectMapper;
+	private final ChatStreamProperties chatStreamProperties;
+	private final ChatStreamGroupNameProvider groupNameProvider;
+
+	public boolean publish(ChatStreamPayload payload) {
+		ChatWsBroadcastEvent event = ChatWsBroadcastEvent.from(payload, groupNameProvider.consumerName());
+		String message;
+		try {
+			message = objectMapper.writeValueAsString(event);
+		} catch (JsonProcessingException ex) {
+			log.warn("Failed to serialize chat websocket broadcast event. roomId={}", payload.chatRoomId(), ex);
+			return false;
+		}
+
+		try {
+			stringRedisTemplate.convertAndSend(chatStreamProperties.wsPubSubChannel(), message);
+			return true;
+		} catch (Exception ex) {
+			log.warn("Failed to publish chat websocket broadcast event. channel={}",
+				chatStreamProperties.wsPubSubChannel(), ex);
+			return false;
+		}
+	}
+}

--- a/app-api/src/main/java/com/tasteam/domain/chat/stream/ChatWsBroadcastSubscriber.java
+++ b/app-api/src/main/java/com/tasteam/domain/chat/stream/ChatWsBroadcastSubscriber.java
@@ -1,0 +1,42 @@
+package com.tasteam.domain.chat.stream;
+
+import java.nio.charset.StandardCharsets;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tasteam.domain.chat.dto.response.ChatMessageItemResponse;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "chat.stream.ws-pubsub-broadcast-enabled", havingValue = "true")
+public class ChatWsBroadcastSubscriber implements MessageListener {
+
+	private final SimpMessagingTemplate messagingTemplate;
+	private final ObjectMapper objectMapper;
+
+	@Override
+	public void onMessage(Message message, byte[] pattern) {
+		String raw = new String(message.getBody(), StandardCharsets.UTF_8);
+		try {
+			ChatWsBroadcastEvent event = objectMapper.readValue(raw, ChatWsBroadcastEvent.class);
+			Long chatRoomId = event.resolveChatRoomId();
+			if (chatRoomId == null) {
+				log.warn("Ignore invalid chat websocket broadcast event. reason=missing_chat_room_id");
+				return;
+			}
+			ChatMessageItemResponse itemResponse = event.toPayload().toMessageItem();
+			messagingTemplate.convertAndSend("/topic/chat-rooms/" + chatRoomId, itemResponse);
+		} catch (Exception ex) {
+			log.warn("Failed to handle chat websocket broadcast event", ex);
+		}
+	}
+}

--- a/app-api/src/main/resources/application.prod.yml
+++ b/app-api/src/main/resources/application.prod.yml
@@ -109,6 +109,8 @@ chat:
     partition-consume-enabled: ${CHAT_STREAM_PARTITION_CONSUME_ENABLED:true}
     dual-write-enabled: ${CHAT_STREAM_DUAL_WRITE_ENABLED:true}
     legacy-room-consume-enabled: ${CHAT_STREAM_LEGACY_ROOM_CONSUME_ENABLED:false}
+    ws-pubsub-broadcast-enabled: ${CHAT_STREAM_WS_PUBSUB_BROADCAST_ENABLED:false}
+    ws-pubsub-channel: ${CHAT_STREAM_WS_PUBSUB_CHANNEL:chat:websocket:broadcast}
 
 tasteam:
   notification:

--- a/app-api/src/main/resources/application.stg.yml
+++ b/app-api/src/main/resources/application.stg.yml
@@ -107,6 +107,8 @@ chat:
     partition-consume-enabled: ${CHAT_STREAM_PARTITION_CONSUME_ENABLED:true}
     dual-write-enabled: ${CHAT_STREAM_DUAL_WRITE_ENABLED:true}
     legacy-room-consume-enabled: ${CHAT_STREAM_LEGACY_ROOM_CONSUME_ENABLED:false}
+    ws-pubsub-broadcast-enabled: ${CHAT_STREAM_WS_PUBSUB_BROADCAST_ENABLED:false}
+    ws-pubsub-channel: ${CHAT_STREAM_WS_PUBSUB_CHANNEL:chat:websocket:broadcast}
 
 tasteam:
   auth:

--- a/app-api/src/main/resources/application.yml
+++ b/app-api/src/main/resources/application.yml
@@ -92,6 +92,8 @@ chat:
     partition-consume-enabled: ${CHAT_STREAM_PARTITION_CONSUME_ENABLED:true}
     dual-write-enabled: ${CHAT_STREAM_DUAL_WRITE_ENABLED:true}
     legacy-room-consume-enabled: ${CHAT_STREAM_LEGACY_ROOM_CONSUME_ENABLED:false}
+    ws-pubsub-broadcast-enabled: ${CHAT_STREAM_WS_PUBSUB_BROADCAST_ENABLED:false}
+    ws-pubsub-channel: ${CHAT_STREAM_WS_PUBSUB_CHANNEL:chat:websocket:broadcast}
 
 tasteam:
   admin:

--- a/app-api/src/test/java/com/tasteam/domain/chat/stream/ChatStreamPublisherTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/chat/stream/ChatStreamPublisherTest.java
@@ -46,7 +46,9 @@ class ChatStreamPublisherTest {
 			128,
 			true,
 			false,
-			false);
+			false,
+			false,
+			"chat:websocket:broadcast");
 
 		ChatStreamPublisher publisher = new ChatStreamPublisher(redisTemplate, keyResolver, properties);
 		publisher.publish(33L, sampleMessage());
@@ -78,7 +80,9 @@ class ChatStreamPublisherTest {
 			128,
 			true,
 			true,
-			false);
+			false,
+			false,
+			"chat:websocket:broadcast");
 
 		ChatStreamPublisher publisher = new ChatStreamPublisher(redisTemplate, keyResolver, properties);
 		publisher.publish(33L, sampleMessage());
@@ -111,7 +115,9 @@ class ChatStreamPublisherTest {
 			128,
 			false,
 			true,
-			true);
+			true,
+			false,
+			"chat:websocket:broadcast");
 
 		ChatStreamPublisher publisher = new ChatStreamPublisher(redisTemplate, keyResolver, properties);
 		publisher.publish(33L, sampleMessage());

--- a/app-api/src/test/java/com/tasteam/domain/chat/stream/ChatStreamSubscriberPubSubTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/chat/stream/ChatStreamSubscriberPubSubTest.java
@@ -1,0 +1,147 @@
+package com.tasteam.domain.chat.stream;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.RecordId;
+import org.springframework.data.redis.core.StreamOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.stream.StreamMessageListenerContainer;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.tasteam.config.annotation.UnitTest;
+import com.tasteam.domain.chat.config.ChatStreamProperties;
+import com.tasteam.domain.chat.dto.response.ChatMessageItemResponse;
+import com.tasteam.domain.chat.repository.ChatRoomRepository;
+import com.tasteam.domain.chat.type.ChatMessageType;
+
+@UnitTest
+@DisplayName("[유닛](Chat) ChatStreamSubscriber Pub/Sub ACK 분기 테스트")
+class ChatStreamSubscriberPubSubTest {
+
+	@Test
+	@DisplayName("ws-pubsub 활성화 + Pub/Sub 발행 성공 시 ACK 한다")
+	void handleRecord_pubSubSuccess_ack() {
+		ChatWsBroadcastPublisher wsBroadcastPublisher = mock(ChatWsBroadcastPublisher.class);
+		when(wsBroadcastPublisher.publish(any(ChatStreamPayload.class))).thenReturn(true);
+
+		TestFixture fixture = new TestFixture(wsBroadcastPublisher, sampleProperties(true));
+		MapRecord<String, String, String> record = fixture.sampleRecord();
+
+		ReflectionTestUtils.invokeMethod(
+			fixture.subscriber,
+			"handleRecord",
+			record,
+			Integer.valueOf(3),
+			"chat:partition:3");
+
+		verify(wsBroadcastPublisher).publish(any(ChatStreamPayload.class));
+		verify(fixture.streamOperations).acknowledge(anyString(), anyString(), any(RecordId.class));
+		verifyNoInteractions(fixture.messagingTemplate);
+	}
+
+	@Test
+	@DisplayName("ws-pubsub 활성화 + Pub/Sub 발행 실패 시 ACK 하지 않는다")
+	void handleRecord_pubSubFail_noAck() {
+		ChatWsBroadcastPublisher wsBroadcastPublisher = mock(ChatWsBroadcastPublisher.class);
+		when(wsBroadcastPublisher.publish(any(ChatStreamPayload.class))).thenReturn(false);
+
+		TestFixture fixture = new TestFixture(wsBroadcastPublisher, sampleProperties(true));
+		MapRecord<String, String, String> record = fixture.sampleRecord();
+
+		ReflectionTestUtils.invokeMethod(
+			fixture.subscriber,
+			"handleRecord",
+			record,
+			Integer.valueOf(3),
+			"chat:partition:3");
+
+		verify(wsBroadcastPublisher).publish(any(ChatStreamPayload.class));
+		verify(fixture.streamOperations, never()).acknowledge(anyString(), anyString(), any(RecordId.class));
+		verifyNoInteractions(fixture.messagingTemplate);
+	}
+
+	private ChatStreamProperties sampleProperties(boolean wsPubSubBroadcastEnabled) {
+		return new ChatStreamProperties(
+			true,
+			true,
+			100,
+			1000,
+			4,
+			256,
+			16,
+			128,
+			true,
+			true,
+			false,
+			wsPubSubBroadcastEnabled,
+			"chat:websocket:broadcast");
+	}
+
+	private ChatMessageItemResponse sampleMessage() {
+		return new ChatMessageItemResponse(
+			101L,
+			7L,
+			"member",
+			null,
+			"hello",
+			ChatMessageType.TEXT,
+			List.of(),
+			Instant.parse("2026-03-11T00:00:00Z"));
+	}
+
+	private class TestFixture {
+		private final ChatStreamSubscriber subscriber;
+		private final StreamOperations<String, Object, Object> streamOperations;
+		private final SimpMessagingTemplate messagingTemplate;
+
+		@SuppressWarnings("unchecked")
+		private TestFixture(ChatWsBroadcastPublisher wsBroadcastPublisher, ChatStreamProperties properties) {
+			StreamMessageListenerContainer<String, MapRecord<String, String, String>> container = mock(
+				StreamMessageListenerContainer.class);
+			StringRedisTemplate redisTemplate = mock(StringRedisTemplate.class);
+			this.streamOperations = mock(StreamOperations.class);
+			lenient().when(redisTemplate.opsForStream()).thenReturn(streamOperations);
+			lenient().when(streamOperations.acknowledge(anyString(), anyString(), any(RecordId.class))).thenReturn(1L);
+
+			ChatRoomRepository chatRoomRepository = mock(ChatRoomRepository.class);
+			ChatStreamKeyResolver keyResolver = new ChatStreamKeyResolver();
+			ChatStreamGroupNameProvider groupNameProvider = mock(ChatStreamGroupNameProvider.class);
+			lenient().when(groupNameProvider.groupName()).thenReturn("chat-group-tasteam-api");
+			lenient().when(groupNameProvider.consumerName()).thenReturn("instance-a");
+
+			this.messagingTemplate = mock(SimpMessagingTemplate.class);
+			this.subscriber = new ChatStreamSubscriber(
+				container,
+				redisTemplate,
+				chatRoomRepository,
+				keyResolver,
+				groupNameProvider,
+				messagingTemplate,
+				properties,
+				wsBroadcastPublisher,
+				null);
+		}
+
+		private MapRecord<String, String, String> sampleRecord() {
+			MapRecord<String, String, String> record = mock(MapRecord.class);
+			when(record.getValue()).thenReturn(ChatStreamPayload.from(3L, sampleMessage()).toMap());
+			lenient().when(record.getStream()).thenReturn("chat:partition:3");
+			when(record.getId()).thenReturn(RecordId.of("1-0"));
+			return record;
+		}
+	}
+}

--- a/app-api/src/test/java/com/tasteam/domain/chat/stream/ChatWsBroadcastEventTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/chat/stream/ChatWsBroadcastEventTest.java
@@ -1,0 +1,48 @@
+package com.tasteam.domain.chat.stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.tasteam.config.annotation.UnitTest;
+import com.tasteam.domain.chat.dto.response.ChatMessageItemResponse;
+import com.tasteam.domain.chat.type.ChatMessageType;
+
+@UnitTest
+@DisplayName("[유닛](Chat) ChatWsBroadcastEvent 단위 테스트")
+class ChatWsBroadcastEventTest {
+
+	private final ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+
+	@Test
+	@DisplayName("이벤트는 JSON 직렬화/역직렬화 후 payload를 복원할 수 있다")
+	void serializeDeserialize_success() throws Exception {
+		ChatStreamPayload payload = ChatStreamPayload.from(3L, sampleMessage());
+		ChatWsBroadcastEvent event = ChatWsBroadcastEvent.from(payload, "instance-a");
+
+		String json = objectMapper.writeValueAsString(event);
+		ChatWsBroadcastEvent restored = objectMapper.readValue(json, ChatWsBroadcastEvent.class);
+
+		assertThat(restored.resolveChatRoomId()).isEqualTo(3L);
+		assertThat(restored.toPayload().chatRoomId()).isEqualTo(3L);
+		assertThat(restored.toPayload().messageId()).isEqualTo(101L);
+	}
+
+	private ChatMessageItemResponse sampleMessage() {
+		return new ChatMessageItemResponse(
+			101L,
+			7L,
+			"member",
+			null,
+			"hello",
+			ChatMessageType.TEXT,
+			List.of(),
+			Instant.parse("2026-03-11T00:00:00Z"));
+	}
+}

--- a/app-api/src/test/java/com/tasteam/domain/chat/stream/ChatWsBroadcastPublisherTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/chat/stream/ChatWsBroadcastPublisherTest.java
@@ -1,0 +1,124 @@
+package com.tasteam.domain.chat.stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.tasteam.config.annotation.UnitTest;
+import com.tasteam.domain.chat.config.ChatStreamProperties;
+import com.tasteam.domain.chat.dto.response.ChatMessageItemResponse;
+import com.tasteam.domain.chat.type.ChatMessageType;
+
+@UnitTest
+@DisplayName("[유닛](Chat) ChatWsBroadcastPublisher 단위 테스트")
+class ChatWsBroadcastPublisherTest {
+
+	@Test
+	@DisplayName("Pub/Sub 발행 성공 시 true를 반환한다")
+	void publish_success() {
+		StringRedisTemplate redisTemplate = Mockito.mock(StringRedisTemplate.class);
+		ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+		ChatStreamGroupNameProvider groupNameProvider = Mockito.mock(ChatStreamGroupNameProvider.class);
+		when(groupNameProvider.consumerName()).thenReturn("instance-a");
+
+		ChatWsBroadcastPublisher publisher = new ChatWsBroadcastPublisher(
+			redisTemplate,
+			objectMapper,
+			sampleProperties(),
+			groupNameProvider);
+
+		boolean result = publisher.publish(ChatStreamPayload.from(3L, sampleMessage()));
+
+		assertThat(result).isTrue();
+		verify(redisTemplate).convertAndSend(eq("chat:websocket:broadcast"), anyString());
+	}
+
+	@Test
+	@DisplayName("직렬화 실패 시 false를 반환한다")
+	void publish_serializeFail() throws Exception {
+		StringRedisTemplate redisTemplate = Mockito.mock(StringRedisTemplate.class);
+		ObjectMapper objectMapper = Mockito.mock(ObjectMapper.class);
+		when(objectMapper.writeValueAsString(org.mockito.ArgumentMatchers.any()))
+			.thenThrow(new JsonProcessingException("serialize failed") {});
+		ChatStreamGroupNameProvider groupNameProvider = Mockito.mock(ChatStreamGroupNameProvider.class);
+		when(groupNameProvider.consumerName()).thenReturn("instance-a");
+
+		ChatWsBroadcastPublisher publisher = new ChatWsBroadcastPublisher(
+			redisTemplate,
+			objectMapper,
+			sampleProperties(),
+			groupNameProvider);
+
+		boolean result = publisher.publish(ChatStreamPayload.from(3L, sampleMessage()));
+
+		assertThat(result).isFalse();
+		verifyNoInteractions(redisTemplate);
+	}
+
+	@Test
+	@DisplayName("Redis 발행 실패 시 false를 반환한다")
+	void publish_redisFail() {
+		StringRedisTemplate redisTemplate = Mockito.mock(StringRedisTemplate.class);
+		ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+		ChatStreamGroupNameProvider groupNameProvider = Mockito.mock(ChatStreamGroupNameProvider.class);
+		when(groupNameProvider.consumerName()).thenReturn("instance-a");
+		doThrow(new RuntimeException("redis down"))
+			.when(redisTemplate)
+			.convertAndSend(eq("chat:websocket:broadcast"), anyString());
+
+		ChatWsBroadcastPublisher publisher = new ChatWsBroadcastPublisher(
+			redisTemplate,
+			objectMapper,
+			sampleProperties(),
+			groupNameProvider);
+
+		boolean result = publisher.publish(ChatStreamPayload.from(3L, sampleMessage()));
+
+		assertThat(result).isFalse();
+		verify(redisTemplate).convertAndSend(eq("chat:websocket:broadcast"), anyString());
+	}
+
+	private ChatStreamProperties sampleProperties() {
+		return new ChatStreamProperties(
+			true,
+			true,
+			100,
+			1000,
+			4,
+			256,
+			16,
+			128,
+			true,
+			true,
+			false,
+			true,
+			"chat:websocket:broadcast");
+	}
+
+	private ChatMessageItemResponse sampleMessage() {
+		return new ChatMessageItemResponse(
+			101L,
+			7L,
+			"member",
+			null,
+			"hello",
+			ChatMessageType.TEXT,
+			List.of(),
+			Instant.parse("2026-03-11T00:00:00Z"));
+	}
+}

--- a/app-api/src/test/java/com/tasteam/domain/chat/stream/ChatWsBroadcastSubscriberTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/chat/stream/ChatWsBroadcastSubscriberTest.java
@@ -1,0 +1,89 @@
+package com.tasteam.domain.chat.stream;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.data.redis.connection.DefaultMessage;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.tasteam.config.annotation.UnitTest;
+import com.tasteam.domain.chat.dto.response.ChatMessageItemResponse;
+import com.tasteam.domain.chat.type.ChatMessageType;
+
+@UnitTest
+@DisplayName("[유닛](Chat) ChatWsBroadcastSubscriber 단위 테스트")
+class ChatWsBroadcastSubscriberTest {
+
+	private final ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+
+	@Test
+	@DisplayName("유효한 Pub/Sub 이벤트를 수신하면 /topic/chat-rooms/{id}로 브로드캐스트한다")
+	void onMessage_success() throws Exception {
+		SimpMessagingTemplate messagingTemplate = Mockito.mock(SimpMessagingTemplate.class);
+		ChatWsBroadcastSubscriber subscriber = new ChatWsBroadcastSubscriber(messagingTemplate, objectMapper);
+		ChatWsBroadcastEvent event = ChatWsBroadcastEvent.from(ChatStreamPayload.from(3L, sampleMessage()),
+			"instance-a");
+		Message message = new DefaultMessage(
+			"chat:websocket:broadcast".getBytes(StandardCharsets.UTF_8),
+			objectMapper.writeValueAsBytes(event));
+
+		subscriber.onMessage(message, null);
+
+		verify(messagingTemplate).convertAndSend(eq("/topic/chat-rooms/3"), any(ChatMessageItemResponse.class));
+	}
+
+	@Test
+	@DisplayName("chatRoomId가 없으면 브로드캐스트하지 않는다")
+	void onMessage_missingRoomId() throws Exception {
+		SimpMessagingTemplate messagingTemplate = Mockito.mock(SimpMessagingTemplate.class);
+		ChatWsBroadcastSubscriber subscriber = new ChatWsBroadcastSubscriber(messagingTemplate, objectMapper);
+		ChatWsBroadcastEvent event = new ChatWsBroadcastEvent(null, Map.of("chatRoomId", "null"), Instant.now(),
+			"instance-a");
+		Message message = new DefaultMessage(
+			"chat:websocket:broadcast".getBytes(StandardCharsets.UTF_8),
+			objectMapper.writeValueAsBytes(event));
+
+		subscriber.onMessage(message, null);
+
+		verifyNoInteractions(messagingTemplate);
+	}
+
+	@Test
+	@DisplayName("역직렬화 실패 시 브로드캐스트하지 않는다")
+	void onMessage_deserializeFail() {
+		SimpMessagingTemplate messagingTemplate = Mockito.mock(SimpMessagingTemplate.class);
+		ChatWsBroadcastSubscriber subscriber = new ChatWsBroadcastSubscriber(messagingTemplate, objectMapper);
+		Message invalidMessage = new DefaultMessage(
+			"chat:websocket:broadcast".getBytes(StandardCharsets.UTF_8),
+			"not-json".getBytes(StandardCharsets.UTF_8));
+
+		subscriber.onMessage(invalidMessage, null);
+
+		verifyNoInteractions(messagingTemplate);
+	}
+
+	private ChatMessageItemResponse sampleMessage() {
+		return new ChatMessageItemResponse(
+			101L,
+			7L,
+			"member",
+			null,
+			"hello",
+			ChatMessageType.TEXT,
+			List.of(),
+			Instant.parse("2026-03-11T00:00:00Z"));
+	}
+}


### PR DESCRIPTION
• ## 📌 PR 요약

  #### Summary

  - 채팅 Redis Stream 소비 이후 WebSocket 브로드캐스트를 Redis Pub/Sub 기반으로 동기화하는 경로를 추가
  - ws-pubsub-broadcast-enabled 플래그로 점진 배포/즉시 롤백이 가능하도록 구성
  - ACK 정책을 개선하여 Pub/Sub 발행 성공 시에만 ACK, 실패 시 pending 재처리 경로로 유지되도록 반영

  ### Issue

  - close : #

  ## ➕ 추가된 기능

  1. Redis Pub/Sub 브로드캐스트 이벤트 모델/발행/구독 컴포넌트 추가
  2. chat.stream.ws-pubsub-broadcast-enabled, chat.stream.ws-pubsub-channel 설정 추가 및 환경별 yml 반영
  3. RedisMessageListenerContainer 등록(메시지 dispatch/subscription executor 명시)
  4. Pub/Sub 활성화 시 /topic/chat-rooms/{chatRoomId} 로컬 브로드캐스트 경로 연결

  ## 🛠️ 수정/변경사항

  1. ChatStreamSubscriber 처리 경로 변경
      - direct convertAndSend 단일 경로에서, Pub/Sub 분기 경로로 전환
      - Pub/Sub 성공 시 ACK, 실패 시 no-ACK(재시도/DLQ 기존 정책 유지)
  2. ChatStreamConfig 보완
      - Pub/Sub listener container bean 추가
      - 누락된 @Qualifier import 보완
  3. ChatWsBroadcastSubscriber 조건식 단순화
      - chat.stream.ws-pubsub-broadcast-enabled=true 기반으로 활성화
  4. 테스트 보강
      - 이벤트 직렬화/역직렬화 테스트
      - Pub/Sub publish 성공/실패 테스트
      - Subscriber 수신 후 /topic 전송 테스트
      - ACK 분기 테스트 추가
      - ChatStreamProperties 생성자 변경에 따른 기존 테스트 수정

  ———

  ## ✅ 남은 작업

  - [ ] STG에서 CHAT_STREAM_WS_PUBSUB_BROADCAST_ENABLED=true 활성화 후 멀티 인스턴스 교차 수신 검증
  - [ ] 운영 메트릭/로그 기반 안정성 확인 후 PROD 점진 활성화
  - [ ] 장애 대응 가이드(플래그 즉시 롤백 절차) 운영 문서화
