### PR TITLE
✨ feat: 채팅 부하테스트 수집 메트릭 추가

### DIFF
--- a/app-api/src/main/java/com/tasteam/domain/chat/service/ChatService.java
+++ b/app-api/src/main/java/com/tasteam/domain/chat/service/ChatService.java
@@ -42,6 +42,7 @@ import com.tasteam.domain.file.repository.ImageRepository;
 import com.tasteam.domain.file.service.FileService;
 import com.tasteam.domain.member.entity.Member;
 import com.tasteam.domain.member.repository.MemberRepository;
+import com.tasteam.global.aop.ObservedDbQueryCount;
 import com.tasteam.global.exception.business.BusinessException;
 import com.tasteam.global.exception.code.ChatErrorCode;
 import com.tasteam.global.exception.code.CommonErrorCode;
@@ -158,6 +159,7 @@ public class ChatService {
 	}
 
 	@Transactional
+	@ObservedDbQueryCount(api = "send_chat_message")
 	public ChatMessageSendResponse sendMessage(Long chatRoomId, Long memberId, ChatMessageSendRequest request) {
 		ensureChatRoomExists(chatRoomId);
 		findMembershipOrThrow(chatRoomId, memberId);

--- a/app-api/src/main/java/com/tasteam/domain/chat/stream/ChatStreamSubscriber.java
+++ b/app-api/src/main/java/com/tasteam/domain/chat/stream/ChatStreamSubscriber.java
@@ -655,6 +655,15 @@ public class ChatStreamSubscriber {
 		partitionPendingMessages.computeIfAbsent(partitionId, id -> {
 			AtomicLong gaugeValue = new AtomicLong();
 			MetricLabelPolicy.validate(
+				"chat.stream.pending.messages",
+				"partition",
+				String.valueOf(id));
+			meterRegistry.gauge(
+				"chat.stream.pending.messages",
+				Tags.of("partition", String.valueOf(id)),
+				gaugeValue);
+
+			MetricLabelPolicy.validate(
 				"chat_stream_partition_pending_messages",
 				"partitionId",
 				String.valueOf(id),

--- a/app-api/src/main/java/com/tasteam/global/aop/DbQueryCountAspect.java
+++ b/app-api/src/main/java/com/tasteam/global/aop/DbQueryCountAspect.java
@@ -1,0 +1,57 @@
+package com.tasteam.global.aop;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.hibernate.Session;
+import org.hibernate.stat.Statistics;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.core.annotation.Order;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Component;
+
+import com.tasteam.global.metrics.MetricLabelPolicy;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+
+@Aspect
+@Component
+@Order(11)
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "tasteam.aop.metrics", name = "enabled", havingValue = "true", matchIfMissing = true)
+public class DbQueryCountAspect {
+
+	private static final String METRIC_QUERY_COUNT = "db.query.count";
+
+	@Nullable
+	private final MeterRegistry meterRegistry;
+
+	private final EntityManager entityManager;
+
+	@Around("@annotation(observedDbQueryCount)")
+	public Object measureDbQueryCount(
+		ProceedingJoinPoint joinPoint,
+		ObservedDbQueryCount observedDbQueryCount) throws Throwable {
+		if (meterRegistry == null) {
+			return joinPoint.proceed();
+		}
+
+		Statistics stats = entityManager.unwrap(Session.class).getSessionFactory().getStatistics();
+		if (!stats.isStatisticsEnabled()) {
+			stats.setStatisticsEnabled(true);
+		}
+		long startQueryCount = stats.getPrepareStatementCount();
+		try {
+			return joinPoint.proceed();
+		} finally {
+			long queryCount = Math.max(0L, stats.getPrepareStatementCount() - startQueryCount);
+			if (queryCount > 0L) {
+				String api = observedDbQueryCount.api();
+				MetricLabelPolicy.validate(METRIC_QUERY_COUNT, "api", api);
+				meterRegistry.counter(METRIC_QUERY_COUNT, "api", api).increment(queryCount);
+			}
+		}
+	}
+}

--- a/app-api/src/main/java/com/tasteam/global/aop/NotificationProcessingMetricsAspect.java
+++ b/app-api/src/main/java/com/tasteam/global/aop/NotificationProcessingMetricsAspect.java
@@ -1,0 +1,55 @@
+package com.tasteam.global.aop;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.core.annotation.Order;
+import org.springframework.lang.Nullable;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import com.tasteam.global.metrics.MetricLabelPolicy;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import lombok.RequiredArgsConstructor;
+
+@Aspect
+@Component
+@Order(12)
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "tasteam.aop.metrics", name = "enabled", havingValue = "true", matchIfMissing = true)
+public class NotificationProcessingMetricsAspect {
+
+	private static final String METRIC_PROCESSING_LATENCY = "notification.processing.latency";
+	private static final String NOTIFICATION_EXECUTOR = "notificationExecutor";
+
+	@Nullable
+	private final MeterRegistry meterRegistry;
+
+	@Around("@annotation(async) && @annotation(org.springframework.context.event.EventListener)")
+	public Object measureNotificationProcessingLatency(
+		ProceedingJoinPoint joinPoint,
+		Async async) throws Throwable {
+		if (meterRegistry == null || !NOTIFICATION_EXECUTOR.equals(async.value())) {
+			return joinPoint.proceed();
+		}
+
+		Timer.Sample sample = Timer.start(meterRegistry);
+		String outcome = "success";
+		try {
+			return joinPoint.proceed();
+		} catch (Throwable throwable) {
+			outcome = "error";
+			throw throwable;
+		} finally {
+			MetricLabelPolicy.validate(METRIC_PROCESSING_LATENCY, "outcome", outcome);
+			sample.stop(
+				Timer.builder(METRIC_PROCESSING_LATENCY)
+					.publishPercentileHistogram()
+					.tag("outcome", outcome)
+					.register(meterRegistry));
+		}
+	}
+}

--- a/app-api/src/main/java/com/tasteam/global/aop/ObservedDbQueryCount.java
+++ b/app-api/src/main/java/com/tasteam/global/aop/ObservedDbQueryCount.java
@@ -1,0 +1,13 @@
+package com.tasteam.global.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ObservedDbQueryCount{
+
+	String api();
+}

--- a/app-api/src/main/java/com/tasteam/global/config/AsyncConfig.java
+++ b/app-api/src/main/java/com/tasteam/global/config/AsyncConfig.java
@@ -5,10 +5,12 @@ import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ThreadPoolExecutor;
 
 import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.task.support.TaskExecutorAdapter;
+import org.springframework.lang.Nullable;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
@@ -32,8 +34,28 @@ public class AsyncConfig implements AsyncConfigurer {
 	}
 
 	@Bean(name = "notificationExecutor")
-	public Executor notificationExecutor() {
-		return new TaskExecutorAdapter(java.util.concurrent.Executors.newVirtualThreadPerTaskExecutor());
+	@ObservedExecutor(name = "notification")
+	public Executor notificationExecutor(
+		@Value("${tasteam.notification.executor.core-pool-size:8}")
+		int corePoolSize,
+		@Value("${tasteam.notification.executor.max-pool-size:32}")
+		int maxPoolSize,
+		@Value("${tasteam.notification.executor.queue-capacity:1000}")
+		int queueCapacity,
+		@Nullable
+		MeterRegistry meterRegistry) {
+		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+		executor.setCorePoolSize(Math.max(1, corePoolSize));
+		executor.setMaxPoolSize(Math.max(Math.max(1, corePoolSize), maxPoolSize));
+		executor.setQueueCapacity(Math.max(0, queueCapacity));
+		executor.setThreadNamePrefix("notification-");
+		if (meterRegistry != null) {
+			meterRegistry.gauge(
+				"notification.executor.queue.size",
+				executor,
+				this::resolveQueueSize);
+		}
+		return executor;
 	}
 
 	@Bean(name = "searchQueryExecutor")
@@ -136,5 +158,20 @@ public class AsyncConfig implements AsyncConfigurer {
 				}
 				return (double)queueSize / queueCapacity;
 			});
+	}
+
+	private double resolveQueueSize(ThreadPoolTaskExecutor executor) {
+		if (executor == null) {
+			return 0.0;
+		}
+		try {
+			ThreadPoolExecutor delegate = executor.getThreadPoolExecutor();
+			if (delegate == null) {
+				return 0.0;
+			}
+			return delegate.getQueue().size();
+		} catch (IllegalStateException ignored) {
+			return 0.0;
+		}
 	}
 }

--- a/app-api/src/main/java/com/tasteam/global/metrics/MetricLabelPolicy.java
+++ b/app-api/src/main/java/com/tasteam/global/metrics/MetricLabelPolicy.java
@@ -10,6 +10,7 @@ public final class MetricLabelPolicy {
 	private static final Set<String> ALLOWED_LABELS = Set.of(
 		"environment",
 		"instance",
+		"api",
 		"cache",
 		"result",
 		"state",
@@ -27,6 +28,7 @@ public final class MetricLabelPolicy {
 		"outcome",
 		"read_only",
 		"method_name",
+		"partition",
 		"partitionId",
 		"streamKey",
 		"errorType");

--- a/docs/monitoring/chat-bottleneck-promql.md
+++ b/docs/monitoring/chat-bottleneck-promql.md
@@ -1,0 +1,142 @@
+# Chat Bottleneck PromQL
+
+신규 메트릭 4종 기준으로 Grafana 패널/알림에 바로 사용할 PromQL 모음입니다.
+
+## 1) DB Query Count (`db_query_count_total`)
+
+### 패널: `send_chat_message` 초당 DB 쿼리 수
+```promql
+sum(rate(db_query_count_total{api="send_chat_message", environment=~"$env", instance=~"$instance"}[1m]))
+```
+
+### 패널: 인스턴스별 `send_chat_message` 초당 DB 쿼리 수
+```promql
+sum by (instance) (rate(db_query_count_total{api="send_chat_message", environment=~"$env", instance=~"$instance"}[1m]))
+```
+
+### 패널: 요청 1건당 평균 DB 쿼리 수 (5m)
+```promql
+(
+  sum(rate(db_query_count_total{api="send_chat_message", environment=~"$env", instance=~"$instance"}[5m]))
+)
+/
+clamp_min(
+  sum(rate(http_server_requests_seconds_count{
+    environment=~"$env",
+    instance=~"$instance",
+    method="POST",
+    uri="/api/v1/chat-rooms/{chatRoomId}/messages"
+  }[5m])),
+  1
+)
+```
+
+## 2) Redis Stream Pending (`chat_stream_pending_messages`)
+
+### 패널: 전체 pending 합계
+```promql
+sum(chat_stream_pending_messages{environment=~"$env", instance=~"$instance"})
+```
+
+### 패널: 파티션별 pending
+```promql
+sum by (partition) (chat_stream_pending_messages{environment=~"$env", instance=~"$instance"})
+```
+
+### 패널: 최악 파티션 Top 5
+```promql
+topk(5, sum by (partition) (chat_stream_pending_messages{environment=~"$env", instance=~"$instance"}))
+```
+
+## 3) Notification Executor Queue (`notification_executor_queue_size`)
+
+### 패널: 현재 queue size
+```promql
+sum(notification_executor_queue_size{environment=~"$env", instance=~"$instance"})
+```
+
+### 패널: 인스턴스별 queue size
+```promql
+sum by (instance) (notification_executor_queue_size{environment=~"$env", instance=~"$instance"})
+```
+
+### 패널: 최근 10분 최대 queue size
+```promql
+max_over_time(
+  sum(notification_executor_queue_size{environment=~"$env", instance=~"$instance"})[10m:]
+)
+```
+
+## 4) Notification Processing Latency (`notification_processing_latency_seconds_*`)
+
+### 패널: p95 latency (전체)
+```promql
+histogram_quantile(
+  0.95,
+  sum(rate(notification_processing_latency_seconds_bucket{environment=~"$env", instance=~"$instance"}[5m])) by (le)
+)
+```
+
+### 패널: p99 latency (전체)
+```promql
+histogram_quantile(
+  0.99,
+  sum(rate(notification_processing_latency_seconds_bucket{environment=~"$env", instance=~"$instance"}[5m])) by (le)
+)
+```
+
+### 패널: outcome별 처리량
+```promql
+sum by (outcome) (
+  rate(notification_processing_latency_seconds_count{environment=~"$env", instance=~"$instance"}[5m])
+)
+```
+
+### 패널: 에러율
+```promql
+(
+  sum(rate(notification_processing_latency_seconds_count{outcome="error", environment=~"$env", instance=~"$instance"}[5m]))
+)
+/
+clamp_min(
+  sum(rate(notification_processing_latency_seconds_count{environment=~"$env", instance=~"$instance"}[5m])),
+  1
+)
+```
+
+## Alert 추천 (옵션)
+
+### Stream pending backlog 증가
+```promql
+sum(chat_stream_pending_messages{environment=~"$env", instance=~"$instance"}) > 1000
+```
+
+### Notification queue 적체
+```promql
+sum(notification_executor_queue_size{environment=~"$env", instance=~"$instance"}) > 200
+```
+
+### Notification p95 지연
+```promql
+histogram_quantile(
+  0.95,
+  sum(rate(notification_processing_latency_seconds_bucket{environment=~"$env", instance=~"$instance"}[5m])) by (le)
+) > 1.0
+```
+
+### `send_chat_message` 1건당 DB 쿼리 급증
+```promql
+(
+  sum(rate(db_query_count_total{api="send_chat_message", environment=~"$env", instance=~"$instance"}[5m]))
+)
+/
+clamp_min(
+  sum(rate(http_server_requests_seconds_count{
+    environment=~"$env",
+    instance=~"$instance",
+    method="POST",
+    uri="/api/v1/chat-rooms/{chatRoomId}/messages"
+  }[5m])),
+  1
+) > 20
+```


### PR DESCRIPTION
 ## 📌 PR 요약

  #### Summary

  - 채팅 병목 식별을 위한 커스텀 메트릭 4종(db.query.count, chat.stream.pending.messages, notification.executor.queue.size, notification.processing.latency)을 추가했습니다.
  - send_chat_message 경로 DB 쿼리 수 계측(AOP+Annotation), Redis Stream pending gauge(파티션 태그), notification executor queue gauge, notification async 처리 latency timer를 적용
    했습니다.
  - Grafana 패널/알림용 PromQL 문서를 추가했습니다.

  ### Issue

  - close : #

  ———

  ## ➕ 추가된 기능

  1. send_chat_message API DB 쿼리 수 계측 기능 추가
  2. Redis Stream pending 메시지 gauge(partition 태그) 추가
  3. Notification executor queue size gauge 추가
  4. Notification async 이벤트 처리 latency timer 추가
  5. 신규 메트릭 기반 Grafana PromQL 가이드 문서 추가(docs/monitoring/chat-bottleneck-promql.md)

  ## 🛠️ 수정/변경사항

  1. notificationExecutor를 TaskExecutorAdapter(virtual thread)에서 ThreadPoolTaskExecutor 기반으로 변경하고 queue 계측 추가
  2. 메트릭 라벨 정책(MetricLabelPolicy)에 api, partition 라벨 허용 추가
  3. ChatService.sendMessage()에 @ObservedDbQueryCount(api = "send_chat_message") 적용
  4. Notification 이벤트 리스너(@Async("notificationExecutor") + @EventListener) 전체를 공통 AOP로 latency 계측하도록 변경

  ———

  ## ✅ 남은 작업

  - [ ] /actuator/prometheus에서 신규 메트릭 4종 노출/증가 동작 확인
  - [ ] Grafana 대시보드 JSON에 PromQL 패널 실제 반영
