### PR TITLE
✨ feat: SEND당 DB 작업 과다문제 관측 메트릭 추가

### DIFF
--- a/app-api/src/main/java/com/tasteam/domain/chat/metrics/ChatSendDbQueryTracker.java
+++ b/app-api/src/main/java/com/tasteam/domain/chat/metrics/ChatSendDbQueryTracker.java
@@ -1,0 +1,157 @@
+package com.tasteam.domain.chat.metrics;
+
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Component;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+
+@Component
+public class ChatSendDbQueryTracker {
+
+	@Nullable
+	private final Counter postgresSelectCounter;
+	@Nullable
+	private final Counter postgresInsertCounter;
+
+	private final ThreadLocal<RequestCounter> requestCounter = new ThreadLocal<>();
+
+	public ChatSendDbQueryTracker(@Nullable
+	MeterRegistry meterRegistry) {
+		if (meterRegistry == null) {
+			this.postgresSelectCounter = null;
+			this.postgresInsertCounter = null;
+			return;
+		}
+		this.postgresSelectCounter = meterRegistry.counter("postgres_select_total");
+		this.postgresInsertCounter = meterRegistry.counter("postgres_insert_total");
+	}
+
+	public TrackingContext startTracking() {
+		RequestCounter previous = requestCounter.get();
+		RequestCounter current = new RequestCounter();
+		requestCounter.set(current);
+		return new TrackingContext(previous, current);
+	}
+
+	public DbQuerySnapshot stopTracking(TrackingContext context) {
+		RequestCounter current = context.current;
+		if (context.previous == null) {
+			requestCounter.remove();
+		} else {
+			requestCounter.set(context.previous);
+		}
+		if (current == null) {
+			return DbQuerySnapshot.empty();
+		}
+		return new DbQuerySnapshot(current.total, current.select, current.insert);
+	}
+
+	public void recordSql(@Nullable
+	String sql) {
+		QueryKind queryKind = classify(sql);
+		if (queryKind == QueryKind.SELECT && postgresSelectCounter != null) {
+			postgresSelectCounter.increment();
+		}
+		if (queryKind == QueryKind.INSERT && postgresInsertCounter != null) {
+			postgresInsertCounter.increment();
+		}
+
+		RequestCounter current = requestCounter.get();
+		if (current == null) {
+			return;
+		}
+		current.total++;
+		if (queryKind == QueryKind.SELECT) {
+			current.select++;
+		}
+		if (queryKind == QueryKind.INSERT) {
+			current.insert++;
+		}
+	}
+
+	private QueryKind classify(@Nullable
+	String sql) {
+		if (sql == null || sql.isBlank()) {
+			return QueryKind.OTHER;
+		}
+
+		String normalized = skipLeadingTrivia(sql).toLowerCase(java.util.Locale.ROOT);
+		if (normalized.startsWith("select")) {
+			return QueryKind.SELECT;
+		}
+		if (normalized.startsWith("insert")) {
+			return QueryKind.INSERT;
+		}
+		return QueryKind.OTHER;
+	}
+
+	private String skipLeadingTrivia(String sql) {
+		int length = sql.length();
+		int index = 0;
+
+		while (index < length) {
+			char current = sql.charAt(index);
+			if (Character.isWhitespace(current)) {
+				index++;
+				continue;
+			}
+
+			if (current == '-' && index + 1 < length && sql.charAt(index + 1) == '-') {
+				index += 2;
+				while (index < length && sql.charAt(index) != '\n') {
+					index++;
+				}
+				continue;
+			}
+
+			if (current == '/' && index + 1 < length && sql.charAt(index + 1) == '*') {
+				index += 2;
+				while (index + 1 < length && !(sql.charAt(index) == '*' && sql.charAt(index + 1) == '/')) {
+					index++;
+				}
+				if (index + 1 < length) {
+					index += 2;
+				}
+				continue;
+			}
+
+			break;
+		}
+
+		return index >= length ? "" : sql.substring(index);
+	}
+
+	private enum QueryKind {
+		SELECT,
+		INSERT,
+		OTHER
+	}
+
+	private static final class RequestCounter {
+		private long total;
+		private long select;
+		private long insert;
+	}
+
+	public static final class TrackingContext {
+		@Nullable
+		private final RequestCounter previous;
+		private final RequestCounter current;
+
+		private TrackingContext(@Nullable
+		RequestCounter previous, RequestCounter current) {
+			this.previous = previous;
+			this.current = current;
+		}
+	}
+
+	public record DbQuerySnapshot(
+		long total,
+		long select,
+		long insert) {
+		private static DbQuerySnapshot empty() {
+			return new DbQuerySnapshot(0L, 0L, 0L);
+		}
+	}
+}

--- a/app-api/src/main/java/com/tasteam/domain/chat/metrics/ChatSendMetricsCollector.java
+++ b/app-api/src/main/java/com/tasteam/domain/chat/metrics/ChatSendMetricsCollector.java
@@ -1,0 +1,202 @@
+package com.tasteam.domain.chat.metrics;
+
+import java.time.Duration;
+
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Component;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+
+@Component
+public class ChatSendMetricsCollector {
+
+	@Nullable
+	private final DistributionSummary sendDbQueriesPerRequest;
+	@Nullable
+	private final DistributionSummary sendDbSelectQueriesPerRequest;
+	@Nullable
+	private final DistributionSummary sendDbInsertQueriesPerRequest;
+	@Nullable
+	private final DistributionSummary sendTargetMemberCount;
+	@Nullable
+	private final DistributionSummary sendNotificationEventCount;
+	@Nullable
+	private final DistributionSummary sendProfileImageLookupCount;
+
+	@Nullable
+	private final Timer sendMessagePersistDuration;
+	@Nullable
+	private final Timer sendMemberFetchDuration;
+	@Nullable
+	private final Timer sendProfileImageFetchDuration;
+	@Nullable
+	private final Timer sendNotificationEventCreateDuration;
+	@Nullable
+	private final Timer sendTotalServiceDuration;
+	@Nullable
+	private final Counter chatSendFailureCounter;
+
+	@Nullable
+	private final Counter chatMemberCacheHitCounter;
+	@Nullable
+	private final Counter chatMemberCacheMissCounter;
+	@Nullable
+	private final Counter profileImageCacheHitCounter;
+	@Nullable
+	private final Counter profileImageCacheMissCounter;
+	@Nullable
+	private final Counter senderProfileCacheHitCounter;
+	@Nullable
+	private final Counter senderProfileCacheMissCounter;
+
+	public ChatSendMetricsCollector(@Nullable
+	MeterRegistry meterRegistry) {
+		if (meterRegistry == null) {
+			this.sendDbQueriesPerRequest = null;
+			this.sendDbSelectQueriesPerRequest = null;
+			this.sendDbInsertQueriesPerRequest = null;
+			this.sendTargetMemberCount = null;
+			this.sendNotificationEventCount = null;
+			this.sendProfileImageLookupCount = null;
+			this.sendMessagePersistDuration = null;
+			this.sendMemberFetchDuration = null;
+			this.sendProfileImageFetchDuration = null;
+			this.sendNotificationEventCreateDuration = null;
+			this.sendTotalServiceDuration = null;
+			this.chatSendFailureCounter = null;
+			this.chatMemberCacheHitCounter = null;
+			this.chatMemberCacheMissCounter = null;
+			this.profileImageCacheHitCounter = null;
+			this.profileImageCacheMissCounter = null;
+			this.senderProfileCacheHitCounter = null;
+			this.senderProfileCacheMissCounter = null;
+			return;
+		}
+
+		this.sendDbQueriesPerRequest = summary(meterRegistry, "chat_send_db_queries_per_request");
+		this.sendDbSelectQueriesPerRequest = summary(meterRegistry, "chat_send_db_select_queries_per_request");
+		this.sendDbInsertQueriesPerRequest = summary(meterRegistry, "chat_send_db_insert_queries_per_request");
+		this.sendTargetMemberCount = summary(meterRegistry, "chat_send_target_member_count");
+		this.sendNotificationEventCount = summary(meterRegistry, "chat_send_notification_event_count");
+		this.sendProfileImageLookupCount = summary(meterRegistry, "chat_send_profile_image_lookup_count");
+
+		this.sendMessagePersistDuration = timer(meterRegistry, "chat_send_message_persist_duration_seconds");
+		this.sendMemberFetchDuration = timer(meterRegistry, "chat_send_member_fetch_duration_seconds");
+		this.sendProfileImageFetchDuration = timer(meterRegistry, "chat_send_profile_image_fetch_duration_seconds");
+		this.sendNotificationEventCreateDuration = timer(meterRegistry,
+			"chat_send_notification_event_create_duration_seconds");
+		this.sendTotalServiceDuration = timer(meterRegistry, "chat_send_total_service_duration_seconds");
+		this.chatSendFailureCounter = meterRegistry.counter("chat_send_failure_total");
+
+		this.chatMemberCacheHitCounter = meterRegistry.counter("chat_member_cache_hit_total");
+		this.chatMemberCacheMissCounter = meterRegistry.counter("chat_member_cache_miss_total");
+		this.profileImageCacheHitCounter = meterRegistry.counter("profile_image_cache_hit_total");
+		this.profileImageCacheMissCounter = meterRegistry.counter("profile_image_cache_miss_total");
+		this.senderProfileCacheHitCounter = meterRegistry.counter("sender_profile_cache_hit_total");
+		this.senderProfileCacheMissCounter = meterRegistry.counter("sender_profile_cache_miss_total");
+	}
+
+	public void recordDbQueryCount(long total, long select, long insert) {
+		record(sendDbQueriesPerRequest, total);
+		record(sendDbSelectQueriesPerRequest, select);
+		record(sendDbInsertQueriesPerRequest, insert);
+	}
+
+	public void recordTargetMemberCount(int count) {
+		record(sendTargetMemberCount, count);
+	}
+
+	public void recordNotificationEventCount(int count) {
+		record(sendNotificationEventCount, count);
+	}
+
+	public void recordProfileImageLookupCount(int count) {
+		record(sendProfileImageLookupCount, count);
+	}
+
+	public void recordMessagePersistDuration(Duration duration) {
+		record(sendMessagePersistDuration, duration);
+	}
+
+	public void recordMemberFetchDuration(Duration duration) {
+		record(sendMemberFetchDuration, duration);
+	}
+
+	public void recordProfileImageFetchDuration(Duration duration) {
+		record(sendProfileImageFetchDuration, duration);
+	}
+
+	public void recordNotificationEventCreateDuration(Duration duration) {
+		record(sendNotificationEventCreateDuration, duration);
+	}
+
+	public void recordTotalServiceDuration(Duration duration) {
+		record(sendTotalServiceDuration, duration);
+	}
+
+	public void recordSendFailure() {
+		recordCounter(chatSendFailureCounter);
+	}
+
+	public void recordChatMemberCacheHit() {
+		recordCounter(chatMemberCacheHitCounter);
+	}
+
+	public void recordChatMemberCacheMiss() {
+		recordCounter(chatMemberCacheMissCounter);
+	}
+
+	public void recordProfileImageCacheHit() {
+		recordCounter(profileImageCacheHitCounter);
+	}
+
+	public void recordProfileImageCacheMiss() {
+		recordCounter(profileImageCacheMissCounter);
+	}
+
+	public void recordSenderProfileCacheHit() {
+		recordCounter(senderProfileCacheHitCounter);
+	}
+
+	public void recordSenderProfileCacheMiss() {
+		recordCounter(senderProfileCacheMissCounter);
+	}
+
+	private DistributionSummary summary(MeterRegistry meterRegistry, String metricName) {
+		return DistributionSummary.builder(metricName)
+			.publishPercentileHistogram()
+			.register(meterRegistry);
+	}
+
+	private Timer timer(MeterRegistry meterRegistry, String metricName) {
+		return Timer.builder(metricName)
+			.publishPercentileHistogram()
+			.register(meterRegistry);
+	}
+
+	private void record(@Nullable
+	DistributionSummary summary, long value) {
+		if (summary == null || value < 0) {
+			return;
+		}
+		summary.record(value);
+	}
+
+	private void record(@Nullable
+	Timer timer, Duration duration) {
+		if (timer == null || duration.isNegative()) {
+			return;
+		}
+		timer.record(duration);
+	}
+
+	private void recordCounter(@Nullable
+	Counter counter) {
+		if (counter != null) {
+			counter.increment();
+		}
+	}
+}

--- a/app-api/src/main/java/com/tasteam/domain/chat/metrics/HibernateSqlMetricsStatementInspector.java
+++ b/app-api/src/main/java/com/tasteam/domain/chat/metrics/HibernateSqlMetricsStatementInspector.java
@@ -1,0 +1,28 @@
+package com.tasteam.domain.chat.metrics;
+
+import java.util.Map;
+
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.resource.jdbc.spi.StatementInspector;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernatePropertiesCustomizer;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class HibernateSqlMetricsStatementInspector implements StatementInspector, HibernatePropertiesCustomizer {
+
+	private final ChatSendDbQueryTracker chatSendDbQueryTracker;
+
+	@Override
+	public String inspect(String sql) {
+		chatSendDbQueryTracker.recordSql(sql);
+		return sql;
+	}
+
+	@Override
+	public void customize(Map<String, Object> hibernateProperties) {
+		hibernateProperties.put(AvailableSettings.STATEMENT_INSPECTOR, this);
+	}
+}

--- a/app-api/src/main/java/com/tasteam/domain/chat/repository/ChatRoomMemberRepository.java
+++ b/app-api/src/main/java/com/tasteam/domain/chat/repository/ChatRoomMemberRepository.java
@@ -20,6 +20,8 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
 
 	boolean existsByChatRoomIdAndMemberIdAndDeletedAtIsNull(Long chatRoomId, Long memberId);
 
+	long countByChatRoomIdAndDeletedAtIsNull(Long chatRoomId);
+
 	@Query("""
 		select new com.tasteam.domain.chat.dto.ChatRoomMemberSnapshot(
 			m.memberId,

--- a/app-api/src/main/java/com/tasteam/domain/chat/service/ChatService.java
+++ b/app-api/src/main/java/com/tasteam/domain/chat/service/ChatService.java
@@ -1,5 +1,6 @@
 package com.tasteam.domain.chat.service;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -25,6 +26,8 @@ import com.tasteam.domain.chat.entity.ChatMessage;
 import com.tasteam.domain.chat.entity.ChatMessageFile;
 import com.tasteam.domain.chat.entity.ChatRoomMember;
 import com.tasteam.domain.chat.event.ChatMessageSentEvent;
+import com.tasteam.domain.chat.metrics.ChatSendDbQueryTracker;
+import com.tasteam.domain.chat.metrics.ChatSendMetricsCollector;
 import com.tasteam.domain.chat.repository.ChatMessageFileRepository;
 import com.tasteam.domain.chat.repository.ChatMessageRepository;
 import com.tasteam.domain.chat.repository.ChatRoomMemberRepository;
@@ -70,6 +73,8 @@ public class ChatService {
 	private final FileService fileService;
 	private final ChatStreamPublisher chatStreamPublisher;
 	private final ApplicationEventPublisher eventPublisher;
+	private final ChatSendMetricsCollector chatSendMetricsCollector;
+	private final ChatSendDbQueryTracker chatSendDbQueryTracker;
 
 	@Transactional(readOnly = true)
 	public ChatMessageListResponse getMessages(Long chatRoomId, Long memberId, String cursor, ChatMessageListMode mode,
@@ -161,48 +166,88 @@ public class ChatService {
 	@Transactional
 	@ObservedDbQueryCount(api = "send_chat_message")
 	public ChatMessageSendResponse sendMessage(Long chatRoomId, Long memberId, ChatMessageSendRequest request) {
-		ensureChatRoomExists(chatRoomId);
-		findMembershipOrThrow(chatRoomId, memberId);
+		long totalStartNanos = System.nanoTime();
+		ChatSendDbQueryTracker.TrackingContext dbTrackingContext = chatSendDbQueryTracker.startTracking();
+		try {
+			ensureChatRoomExists(chatRoomId);
+			findMembershipOrThrow(chatRoomId, memberId);
 
-		ChatMessageType messageType = request.messageType() == null ? ChatMessageType.TEXT : request.messageType();
-		validateMessageTypeAndContent(messageType, request.content(), request.files());
-		String content = messageType == ChatMessageType.TEXT ? request.content() : null;
+			ChatMessageType messageType = request.messageType() == null ? ChatMessageType.TEXT : request.messageType();
+			validateMessageTypeAndContent(messageType, request.content(), request.files());
+			String content = messageType == ChatMessageType.TEXT ? request.content() : null;
 
-		ChatMessage message = chatMessageRepository.save(ChatMessage.builder()
-			.chatRoomId(chatRoomId)
-			.memberId(memberId)
-			.type(messageType)
-			.content(content)
-			.deletedAt(null)
-			.build());
+			long messagePersistStartNanos = System.nanoTime();
+			ChatMessage message = chatMessageRepository.save(ChatMessage.builder()
+				.chatRoomId(chatRoomId)
+				.memberId(memberId)
+				.type(messageType)
+				.content(content)
+				.deletedAt(null)
+				.build());
 
-		List<ChatMessageFile> savedFiles = persistMessageFiles(message.getId(), request.files());
-		List<ChatMessageFileItemResponse> fileItems = buildFileResponses(savedFiles);
+			List<ChatMessageFile> savedFiles = persistMessageFiles(message.getId(), request.files());
+			List<ChatMessageFileItemResponse> fileItems = buildFileResponses(savedFiles);
+			chatSendMetricsCollector.recordMessagePersistDuration(
+				Duration.ofNanos(System.nanoTime() - messagePersistStartNanos));
 
-		Member member = memberRepository.findById(memberId)
-			.orElseThrow();
+			long memberFetchStartNanos = System.nanoTime();
+			Member member = memberRepository.findById(memberId)
+				.orElseThrow();
+			chatSendMetricsCollector.recordSenderProfileCacheMiss();
+			int targetMemberCount = Math
+				.toIntExact(chatRoomMemberRepository.countByChatRoomIdAndDeletedAtIsNull(chatRoomId));
+			chatSendMetricsCollector.recordChatMemberCacheMiss();
+			chatSendMetricsCollector.recordTargetMemberCount(targetMemberCount);
+			chatSendMetricsCollector.recordMemberFetchDuration(
+				Duration.ofNanos(System.nanoTime() - memberFetchStartNanos));
 
-		ChatMessageItemResponse item = new ChatMessageItemResponse(
-			message.getId(),
-			message.getMemberId(),
-			member.getNickname(),
-			fileService.getPrimaryDomainImageUrl(DomainType.MEMBER, memberId),
-			message.getContent(),
-			message.getType(),
-			fileItems,
-			message.getCreatedAt());
+			long profileImageFetchStartNanos = System.nanoTime();
+			String profileImageUrl = fileService.getPrimaryDomainImageUrl(DomainType.MEMBER, memberId);
+			chatSendMetricsCollector.recordProfileImageCacheMiss();
+			chatSendMetricsCollector.recordProfileImageLookupCount(1);
+			chatSendMetricsCollector.recordProfileImageFetchDuration(
+				Duration.ofNanos(System.nanoTime() - profileImageFetchStartNanos));
 
-		chatStreamPublisher.publish(chatRoomId, item);
-		eventPublisher.publishEvent(new ChatMessageSentEvent(
-			chatRoomId,
-			message.getId(),
-			memberId,
-			member.getNickname(),
-			message.getType(),
-			message.getContent(),
-			message.getCreatedAt()));
+			ChatMessageItemResponse item = new ChatMessageItemResponse(
+				message.getId(),
+				message.getMemberId(),
+				member.getNickname(),
+				profileImageUrl,
+				message.getContent(),
+				message.getType(),
+				fileItems,
+				message.getCreatedAt());
 
-		return new ChatMessageSendResponse(item);
+			chatStreamPublisher.publish(chatRoomId, item);
+
+			long notificationEventCreateStartNanos = System.nanoTime();
+			eventPublisher.publishEvent(new ChatMessageSentEvent(
+				chatRoomId,
+				message.getId(),
+				memberId,
+				member.getNickname(),
+				message.getType(),
+				message.getContent(),
+				message.getCreatedAt()));
+			int notificationEventCount = Math.max(0, targetMemberCount - 1);
+			chatSendMetricsCollector.recordNotificationEventCount(notificationEventCount);
+			chatSendMetricsCollector.recordNotificationEventCreateDuration(
+				Duration.ofNanos(System.nanoTime() - notificationEventCreateStartNanos));
+
+			return new ChatMessageSendResponse(item);
+		} catch (Throwable throwable) {
+			chatSendMetricsCollector.recordSendFailure();
+			throw throwable;
+		} finally {
+			ChatSendDbQueryTracker.DbQuerySnapshot dbQuerySnapshot = chatSendDbQueryTracker.stopTracking(
+				dbTrackingContext);
+			chatSendMetricsCollector.recordDbQueryCount(
+				dbQuerySnapshot.total(),
+				dbQuerySnapshot.select(),
+				dbQuerySnapshot.insert());
+			chatSendMetricsCollector.recordTotalServiceDuration(
+				Duration.ofNanos(System.nanoTime() - totalStartNanos));
+		}
 	}
 
 	@Transactional

--- a/app-api/src/main/java/com/tasteam/global/aop/TransactionMetricsAspect.java
+++ b/app-api/src/main/java/com/tasteam/global/aop/TransactionMetricsAspect.java
@@ -1,5 +1,7 @@
 package com.tasteam.global.aop;
 
+import java.sql.SQLTransientConnectionException;
+
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
@@ -51,6 +53,8 @@ public class TransactionMetricsAspect {
 	private static final String METRIC_DURATION = "tasteam.transaction.duration";
 	private static final String METRIC_QUERY_COUNT = "tasteam.transaction.query.count";
 	private static final String METRIC_TOTAL = "tasteam.transaction.total";
+	private static final String METRIC_HIKARI_TIMEOUT_TOTAL = "hikaricp_connection_timeout_total";
+	private static final String HIKARI_TIMEOUT_MESSAGE = "Connection is not available, request timed out";
 	private static final String UNKNOWN = "unknown";
 
 	@Nullable
@@ -77,6 +81,7 @@ public class TransactionMetricsAspect {
 			return result;
 		} catch (Throwable throwable) {
 			outcome = "error";
+			recordHikariConnectionTimeoutIfNeeded(throwable);
 			throw throwable;
 		} finally {
 			long queryCount = stats.getPrepareStatementCount() - startQueryCount;
@@ -127,6 +132,28 @@ public class TransactionMetricsAspect {
 	private void recordTotal(Tags tags) {
 		MetricLabelPolicy.validate(METRIC_TOTAL, toTagArray(tags));
 		meterRegistry.counter(METRIC_TOTAL, tags).increment();
+	}
+
+	private void recordHikariConnectionTimeoutIfNeeded(Throwable throwable) {
+		if (!isHikariConnectionTimeout(throwable)) {
+			return;
+		}
+		meterRegistry.counter(METRIC_HIKARI_TIMEOUT_TOTAL).increment();
+	}
+
+	private boolean isHikariConnectionTimeout(Throwable throwable) {
+		Throwable current = throwable;
+		while (current != null) {
+			if (current instanceof SQLTransientConnectionException) {
+				return true;
+			}
+			String message = current.getMessage();
+			if (message != null && message.contains(HIKARI_TIMEOUT_MESSAGE)) {
+				return true;
+			}
+			current = current.getCause();
+		}
+		return false;
 	}
 
 	private String resolveDomain(ProceedingJoinPoint joinPoint) {

--- a/app-api/src/main/java/com/tasteam/global/metrics/postgres/PostgresMetricsCollector.java
+++ b/app-api/src/main/java/com/tasteam/global/metrics/postgres/PostgresMetricsCollector.java
@@ -1,0 +1,172 @@
+package com.tasteam.global.metrics.postgres;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.hibernate.Session;
+import org.hibernate.stat.QueryStatistics;
+import org.hibernate.stat.Statistics;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.lang.Nullable;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import jakarta.annotation.PostConstruct;
+import jakarta.persistence.EntityManager;
+
+@Component
+public class PostgresMetricsCollector {
+
+	private static final String POSTGRES_CACHE_HIT_RATIO_SQL = """
+		select case
+			when (sum(blks_hit) + sum(blks_read)) = 0 then 1.0
+			else sum(blks_hit)::double precision / (sum(blks_hit) + sum(blks_read))
+		end
+		from pg_stat_database
+		where datname = current_database()
+		""";
+
+	private final EntityManager entityManager;
+	private final JdbcTemplate jdbcTemplate;
+	private final long slowQueryThresholdMillis;
+
+	private final Map<String, QuerySnapshot> previousSnapshot = new ConcurrentHashMap<>();
+	private final AtomicReference<Double> postgresCacheHitRatio = new AtomicReference<>(1.0d);
+
+	@Nullable
+	private final Timer queryDurationTimer;
+	@Nullable
+	private final Counter slowQueriesCounter;
+
+	public PostgresMetricsCollector(
+		EntityManager entityManager,
+		JdbcTemplate jdbcTemplate,
+		@Nullable
+		MeterRegistry meterRegistry,
+		@Value("${tasteam.metrics.postgres.slow-query-threshold-ms:500}")
+		long slowQueryThresholdMillis) {
+		this.entityManager = entityManager;
+		this.jdbcTemplate = jdbcTemplate;
+		this.slowQueryThresholdMillis = slowQueryThresholdMillis;
+
+		if (meterRegistry == null) {
+			this.queryDurationTimer = null;
+			this.slowQueriesCounter = null;
+			return;
+		}
+
+		this.queryDurationTimer = Timer.builder("postgres_query_duration_seconds")
+			.publishPercentileHistogram()
+			.register(meterRegistry);
+		this.slowQueriesCounter = meterRegistry.counter("postgres_slow_queries_total");
+		Gauge.builder("postgres_cache_hit_ratio", postgresCacheHitRatio, AtomicReference::get)
+			.register(meterRegistry);
+	}
+
+	@PostConstruct
+	void initialize() {
+		if (queryDurationTimer == null) {
+			return;
+		}
+		snapshotCurrentQueryStats();
+		refreshCacheHitRatio();
+	}
+
+	@Scheduled(fixedDelayString = "${tasteam.metrics.postgres.refresh-delay:30000}")
+	public void collect() {
+		if (queryDurationTimer == null) {
+			return;
+		}
+
+		collectQueryDurations();
+		refreshCacheHitRatio();
+	}
+
+	private void collectQueryDurations() {
+		Statistics statistics = resolveStatistics();
+		Map<String, QuerySnapshot> current = readQuerySnapshot(statistics);
+		long slowQueryDelta = 0L;
+
+		for (Map.Entry<String, QuerySnapshot> entry : current.entrySet()) {
+			String query = entry.getKey();
+			QuerySnapshot currentSnapshot = entry.getValue();
+			QuerySnapshot previous = previousSnapshot.get(query);
+			if (previous == null) {
+				continue;
+			}
+
+			long countDelta = currentSnapshot.executionCount - previous.executionCount;
+			long totalTimeDeltaMillis = currentSnapshot.executionTotalTimeMillis - previous.executionTotalTimeMillis;
+			if (countDelta <= 0 || totalTimeDeltaMillis < 0) {
+				continue;
+			}
+
+			double avgMillis = (double)totalTimeDeltaMillis / (double)countDelta;
+			Duration avgDuration = Duration.ofNanos(Math.max(1L, Math.round(avgMillis * 1_000_000d)));
+			for (long i = 0; i < countDelta; i++) {
+				queryDurationTimer.record(avgDuration);
+			}
+
+			if (avgMillis >= slowQueryThresholdMillis) {
+				slowQueryDelta += countDelta;
+			}
+		}
+
+		previousSnapshot.clear();
+		previousSnapshot.putAll(current);
+		if (slowQueryDelta > 0 && slowQueriesCounter != null) {
+			slowQueriesCounter.increment(slowQueryDelta);
+		}
+	}
+
+	private void snapshotCurrentQueryStats() {
+		previousSnapshot.clear();
+		previousSnapshot.putAll(readQuerySnapshot(resolveStatistics()));
+	}
+
+	private Map<String, QuerySnapshot> readQuerySnapshot(Statistics statistics) {
+		Map<String, QuerySnapshot> snapshot = new ConcurrentHashMap<>();
+		for (String query : statistics.getQueries()) {
+			if (query == null) {
+				continue;
+			}
+			QueryStatistics queryStatistics = statistics.getQueryStatistics(query);
+			snapshot.put(query, new QuerySnapshot(
+				queryStatistics.getExecutionCount(),
+				queryStatistics.getExecutionTotalTime()));
+		}
+		return snapshot;
+	}
+
+	private Statistics resolveStatistics() {
+		Statistics statistics = entityManager.unwrap(Session.class).getSessionFactory().getStatistics();
+		if (!statistics.isStatisticsEnabled()) {
+			statistics.setStatisticsEnabled(true);
+		}
+		return statistics;
+	}
+
+	private void refreshCacheHitRatio() {
+		try {
+			Double ratio = jdbcTemplate.queryForObject(POSTGRES_CACHE_HIT_RATIO_SQL, Double.class);
+			if (ratio == null || ratio.isNaN() || ratio.isInfinite()) {
+				return;
+			}
+			postgresCacheHitRatio.set(Math.max(0d, Math.min(1d, ratio)));
+		} catch (Exception ignored) {
+			// pg_stat_database 접근 권한/환경 차이로 실패할 수 있으므로 무시한다.
+		}
+	}
+
+	private record QuerySnapshot(
+		long executionCount,
+		long executionTotalTimeMillis) {
+	}
+}

--- a/app-api/src/main/resources/application.yml
+++ b/app-api/src/main/resources/application.yml
@@ -192,6 +192,10 @@ tasteam:
         enabled: ${TASTEAM_AOP_LOGGING_AI_ANALYSIS_PERFORMANCE_ENABLED:true}
     webhook:
       enabled: ${TASTEAM_AOP_WEBHOOK_ENABLED:true}
+  metrics:
+    postgres:
+      refresh-delay: ${TASTEAM_METRICS_POSTGRES_REFRESH_DELAY:30000}
+      slow-query-threshold-ms: ${TASTEAM_METRICS_POSTGRES_SLOW_QUERY_THRESHOLD_MS:500}
   local-cache:
     caffeine:
       maximum-size: ${LOCAL_CACHE_CAFFEINE_MAXIMUM_SIZE:1000}

--- a/docs/monitoring/chat-send-db-overhead-promql
+++ b/docs/monitoring/chat-send-db-overhead-promql
@@ -1,0 +1,107 @@
+# Chat Send DB Overhead PromQL
+
+`chat_send_failure_total`, `hikaricp_connection_timeout_total` 모니터링용 PromQL 모음입니다.
+
+## 사전 확인
+
+- `http_server_requests_seconds_count`: 수집됨
+  - 근거: `management.metrics.distribution.percentiles-histogram.http.server.requests: true`
+- `environment` 라벨: 공통 태그로 수집됨
+  - 근거: `management.metrics.tags.environment: ${spring.profiles.active:local}`
+
+## 1) Chat Send Failure (`chat_send_failure_total`)
+
+### 패널: 초당 실패 건수 (전체)
+```promql
+sum(rate(chat_send_failure_total{environment=~"$env", instance=~"$instance"}[1m]))
+```
+
+### 패널: 5분 누적 실패 건수 (전체)
+```promql
+sum(increase(chat_send_failure_total{environment=~"$env", instance=~"$instance"}[5m]))
+```
+
+### 패널: 인스턴스별 5분 누적 실패 건수
+```promql
+sum by (instance) (increase(chat_send_failure_total{environment=~"$env", instance=~"$instance"}[5m]))
+```
+
+### 패널: Chat SEND 실패율 (5m)
+```promql
+(
+  sum(rate(chat_send_failure_total{environment=~"$env", instance=~"$instance"}[5m]))
+)
+/
+clamp_min(
+  sum(rate(http_server_requests_seconds_count{
+    environment=~"$env",
+    instance=~"$instance",
+    method="POST",
+    uri="/api/v1/chat-rooms/{chatRoomId}/messages"
+  }[5m])),
+  1
+)
+```
+
+## 2) Hikari Connection Timeout (`hikaricp_connection_timeout_total`)
+
+### 패널: 초당 DB 커넥션 타임아웃 건수 (전체)
+```promql
+sum(rate(hikaricp_connection_timeout_total{environment=~"$env", instance=~"$instance"}[1m]))
+```
+
+### 패널: 5분 누적 DB 커넥션 타임아웃 건수 (전체)
+```promql
+sum(increase(hikaricp_connection_timeout_total{environment=~"$env", instance=~"$instance"}[5m]))
+```
+
+### 패널: 인스턴스별 5분 누적 DB 커넥션 타임아웃 건수
+```promql
+sum by (instance) (increase(hikaricp_connection_timeout_total{environment=~"$env", instance=~"$instance"}[5m]))
+```
+
+### 패널: Chat SEND 요청 대비 DB 커넥션 타임아웃 비율 (5m)
+```promql
+(
+  sum(rate(hikaricp_connection_timeout_total{environment=~"$env", instance=~"$instance"}[5m]))
+)
+/
+clamp_min(
+  sum(rate(http_server_requests_seconds_count{
+    environment=~"$env",
+    instance=~"$instance",
+    method="POST",
+    uri="/api/v1/chat-rooms/{chatRoomId}/messages"
+  }[5m])),
+  1
+)
+```
+
+## Alert 추천 (옵션)
+
+### Chat SEND 실패 급증
+```promql
+sum(increase(chat_send_failure_total{environment=~"$env", instance=~"$instance"}[5m])) >= 30
+```
+
+### DB 커넥션 타임아웃 발생 감지
+```promql
+sum(increase(hikaricp_connection_timeout_total{environment=~"$env", instance=~"$instance"}[5m])) >= 3
+```
+
+### Chat SEND 실패율 임계치 초과
+```promql
+(
+  sum(rate(chat_send_failure_total{environment=~"$env", instance=~"$instance"}[5m]))
+)
+/
+clamp_min(
+  sum(rate(http_server_requests_seconds_count{
+    environment=~"$env",
+    instance=~"$instance",
+    method="POST",
+    uri="/api/v1/chat-rooms/{chatRoomId}/messages"
+  }[5m])),
+  1
+) > 0.05
+```

--- a/loadtest/shared/scenarios.js
+++ b/loadtest/shared/scenarios.js
@@ -1,5 +1,6 @@
 import http from 'k6/http';
 import { check, sleep } from 'k6';
+import { Counter } from 'k6/metrics';
 
 // ============ Configuration ============
 export const BASE_URL = __ENV.BASE_URL || 'https://stg.tasteam.kr';
@@ -35,6 +36,7 @@ const GROUP_SEARCH_KEYWORDS = parseCsvEnv('GROUP_SEARCH_KEYWORDS').length > 0
 const GROUP_SEARCH_LIMIT = parsePositiveIntEnv('GROUP_SEARCH_LIMIT', 10);
 
 const TEST_RESTAURANT_ID = parsePositiveIntEnv('TEST_RESTAURANT_ID', -1);
+const wsMsgsSentCounter = new Counter('ws_msgs_sent');
 
 // ============ Hotspot Configuration ============
 const HOTSPOT_CONFIG = {
@@ -1136,6 +1138,9 @@ export function sendChatMessage(token, chatRoomId, content) {
         { headers: getHeaders(token), tags: { name: 'send_chat_message', type: 'write' } }
     );
     check(res, { '채팅 메시지 전송 성공 (200 or 201)': (r) => r.status === 200 || r.status === 201 });
+    if (res.status === 200 || res.status === 201) {
+        wsMsgsSentCounter.add(1);
+    }
     return res;
 }
 


### PR DESCRIPTION
 ## 📌 PR 요약

  #### Summary

  - 채팅 SEND 경로의 DB 과다 작업/병목을 관측하기 위한 메트릭 수집을 추가.
  - SEND 단계별 처리시간, 요청당 DB 쿼리량, 실패/타임아웃 지표, Postgres 분포 지표, k6 보조 지표를 함께 수집하도록 반영
  - 운영 확인용 PromQL 문서를 작성.

  ### Issue

  - close : # 

  ———

  ## ➕ 추가된 기능

  1. 채팅 SEND 관측 메트릭 신규 추가
  2. chat_send_failure_total, hikaricp_connection_timeout_total 추가
  3. Postgres 분포 수집기 추가 (postgres_query_duration_seconds, postgres_slow_queries_total,
     postgres_cache_hit_ratio)
  4. Hibernate SQL Inspector 기반 쿼리 추적 추가 (postgres_select_total, postgres_insert_total)
  5. k6 커스텀 카운터 추가 (k6_ws_msgs_sent_total로 노출되는 ws_msgs_sent)
  6. 모니터링 문서 추가: docs/monitoring/chat-send-db-overhead-promql

  ## 🛠️ 수정/변경사항

  1. ChatService.sendMessage에 단계별 타이머/카운터 계측 로직 추가
  2. ChatRoomMemberRepository에 활성 멤버 수 카운트 메서드 추가
  3. TransactionMetricsAspect에 Hikari 커넥션 타임아웃 감지/카운팅 로직 추가
  4. application.yml에 Postgres 메트릭 수집 주기/슬로우쿼리 임계치 설정 추가
  5. PromQL 문서에 http_server_requests_seconds_count, environment 라벨 확인사항 및 Alert 임계치 조정 반영

  ———

  ## ✅ 남은 작업

  - [ ] STG/운영 /actuator/prometheus에서 신규 메트릭 실제 노출 확인
  - [ ] Grafana 패널/Alert Rule에 신규 PromQL 반영
  - [ ] 부하테스트 1회 실행 후 임계치(실패 급증, timeout >= 3) 최종 튜닝
