### PR TITLE
refactor(config): Redis repository 자동 스캔 INFO 로그 제거

### DIFF
--- a/app-api/src/main/resources/application.yml
+++ b/app-api/src/main/resources/application.yml
@@ -23,6 +23,10 @@ spring:
 
   jpa:
     open-in-view: false
+  data:
+    redis:
+      repositories:
+        enabled: false
 
   security:
     cors:


### PR DESCRIPTION
## 📌 PR 요약

#### Summary
- Spring Data Redis가 JPA Repository를 Redis Repository 후보로 스캔하며 남기던 INFO 로그를 제거했습니다.
- Redis repository 자동 스캔만 비활성화하고, 기존 RedisTemplate/StringRedisTemplate 기반 기능은 유지했습니다.

### Issue
- close : #619

---

## ➕ 추가된 기능

1. 없음
2. 없음

## 🛠️ 수정/변경사항

1. `app-api/src/main/resources/application.yml`에 `spring.data.redis.repositories.enabled=false` 설정을 추가했습니다.
2. `./gradlew :app-api:test --tests com.tasteam.config.JpaAuditingConflictTest`로 Spring 컨텍스트 로드와 Redis 구성 유지 여부를 검증했습니다.

---

## ✅ 남은 작업

* [ ] GitHub Actions CI 결과 확인
