### PR TITLE
⚡️ perf(search): 검색 API 성능 저하 개선

### DIFF
--- a/app-api/src/main/java/com/tasteam/domain/search/repository/executor/NativeSearchExecutorSupport.java
+++ b/app-api/src/main/java/com/tasteam/domain/search/repository/executor/NativeSearchExecutorSupport.java
@@ -113,7 +113,9 @@ public abstract class NativeSearchExecutorSupport extends QueryDslSupport implem
 
 		query.setParameter("kw", keywordLower);
 		query.setParameter("size", size);
-		query.setParameter("text_candidate_limit", Math.max(size, textCandidateLimit));
+		if (sql.contains(":text_candidate_limit")) {
+			query.setParameter("text_candidate_limit", Math.max(size, textCandidateLimit));
+		}
 		query.setParameter("cursor_score", cursorScore);
 		query.setParameter("cursor_updated_at", cursor == null ? null : cursor.updatedAt());
 		query.setParameter("cursor_id", cursor == null ? null : cursor.id());

--- a/app-api/src/main/java/com/tasteam/domain/search/repository/executor/nativesql/FtsMvRankedExecutor.java
+++ b/app-api/src/main/java/com/tasteam/domain/search/repository/executor/nativesql/FtsMvRankedExecutor.java
@@ -6,7 +6,6 @@ import org.springframework.stereotype.Component;
 
 import com.tasteam.domain.search.dto.SearchCursor;
 import com.tasteam.domain.search.dto.SearchRestaurantCursorRow;
-import com.tasteam.domain.search.repository.SearchQueryProperties;
 import com.tasteam.domain.search.repository.SearchQueryStrategy;
 import com.tasteam.domain.search.repository.executor.NativeSearchExecutorSupport;
 import com.tasteam.domain.search.repository.executor.NativeSqlFragments;
@@ -23,12 +22,6 @@ import com.tasteam.domain.search.repository.executor.NativeSqlFragments;
 @Component
 public class FtsMvRankedExecutor extends NativeSearchExecutorSupport {
 
-	private final SearchQueryProperties properties;
-
-	public FtsMvRankedExecutor(SearchQueryProperties properties) {
-		this.properties = properties;
-	}
-
 	@Override
 	public SearchQueryStrategy strategy() {
 		return SearchQueryStrategy.FTS_MV_RANKED;
@@ -40,8 +33,7 @@ public class FtsMvRankedExecutor extends NativeSearchExecutorSupport {
 		boolean withLocation = latitude != null && longitude != null && radiusMeters != null;
 		return runFtsNative(
 			buildSql(withLocation),
-			keyword, cursor, size, latitude, longitude, radiusMeters,
-			properties.getCandidateLimit() * HYBRID_LIMIT_MULTIPLIER);
+			keyword, cursor, size, latitude, longitude, radiusMeters, 0);
 	}
 
 	private String buildSql(boolean withLocation) {
@@ -55,8 +47,8 @@ public class FtsMvRankedExecutor extends NativeSearchExecutorSupport {
 
 		// tsq CTE: plainto_tsquery를 한 번만 평가해 filtered/scored에서 재사용
 		// filtered CTE: 인덱스 조건만으로 후보 추출 + ST_DistanceSphere 1회 계산
-		// scored CTE: 비용 함수(similarity, ts_rank_cd, CASE WHEN)를 각 1회 계산
-		// ranked CTE: 이미 계산된 컬럼으로 total_score 조합 후 LIMIT
+		// scored CTE: 비용 함수(similarity, ts_rank_cd, CASE WHEN) + total_score를 한 번 계산
+		// ranked CTE: 이미 계산된 total_score로 커서 조건 적용 후 LIMIT :size
 		return "WITH tsq AS ("
 			+ " SELECT plainto_tsquery('simple', :kw) AS q"
 			+ " ),"
@@ -92,7 +84,13 @@ public class FtsMvRankedExecutor extends NativeSearchExecutorSupport {
 			+ "         ts_rank_cd(f.search_vector, tsq.q)::double precision                 AS fts_rank,"
 			+ "         f.distance_meters,"
 			+ "         CASE WHEN f.category_names @> ARRAY[:kw]::text[] THEN 1 ELSE 0 END  AS category_match,"
-			+ "         CASE WHEN f.addr_lower LIKE '%' || :kw || '%' THEN 1 ELSE 0 END     AS address_match"
+			+ "         CASE WHEN f.addr_lower LIKE '%' || :kw || '%' THEN 1 ELSE 0 END     AS address_match,"
+			+ "         (CASE WHEN f.name_lower = :kw THEN 1 ELSE 0 END * 100.0"
+			+ "          + similarity(f.name_lower, :kw)::double precision * 30.0"
+			+ "          + ts_rank_cd(f.search_vector, tsq.q)::double precision * 25.0"
+			+ "          + CASE WHEN f.category_names @> ARRAY[:kw]::text[] THEN 1 ELSE 0 END * 15.0"
+			+ "          + CASE WHEN f.addr_lower LIKE '%' || :kw || '%' THEN 1 ELSE 0 END * 5.0"
+			+ "          + " + distanceScore + ")                                            AS total_score"
 			+ "     FROM filtered f, tsq"
 			+ " ),"
 			+ " ranked AS ("
@@ -107,19 +105,20 @@ public class FtsMvRankedExecutor extends NativeSearchExecutorSupport {
 			+ "         distance_meters,"
 			+ "         category_match,"
 			+ "         address_match,"
-			+ "         (name_exact * 100.0"
-			+ "          + name_similarity * 30.0"
-			+ "          + fts_rank * 25.0"
-			+ "          + category_match * 15.0"
-			+ "          + address_match * 5.0"
-			+ "          + " + distanceScore + ") AS total_score"
+			+ "         total_score"
 			+ "     FROM scored"
+			+ "     WHERE ("
+			+ "         CAST(:cursor_score AS double precision) IS NULL"
+			+ "         OR total_score < CAST(:cursor_score AS double precision)"
+			+ "         OR (total_score = CAST(:cursor_score AS double precision) AND updated_at < CAST(:cursor_updated_at AS timestamptz))"
+			+ "         OR (total_score = CAST(:cursor_score AS double precision) AND updated_at = CAST(:cursor_updated_at AS timestamptz) AND restaurant_id < CAST(:cursor_id AS bigint))"
+			+ "     )"
 			+ "     ORDER BY total_score DESC, updated_at DESC, restaurant_id DESC"
-			+ "     LIMIT :text_candidate_limit"
+			+ "     LIMIT :size"
 			+ " )"
 			+ " SELECT restaurant_id, name, full_address, name_exact, name_similarity, fts_rank,"
 			+ "        distance_meters, category_match, address_match, updated_at"
 			+ " FROM ranked"
-			+ " " + CURSOR_WHERE_AND_ORDER;
+			+ " ORDER BY total_score DESC, updated_at DESC, restaurant_id DESC";
 	}
 }

--- a/app-api/src/main/java/com/tasteam/domain/search/repository/executor/nativesql/MvSinglePassExecutor.java
+++ b/app-api/src/main/java/com/tasteam/domain/search/repository/executor/nativesql/MvSinglePassExecutor.java
@@ -6,7 +6,6 @@ import org.springframework.stereotype.Component;
 
 import com.tasteam.domain.search.dto.SearchCursor;
 import com.tasteam.domain.search.dto.SearchRestaurantCursorRow;
-import com.tasteam.domain.search.repository.SearchQueryProperties;
 import com.tasteam.domain.search.repository.SearchQueryStrategy;
 import com.tasteam.domain.search.repository.executor.NativeSearchExecutorSupport;
 import com.tasteam.domain.search.repository.executor.NativeSqlFragments;
@@ -19,12 +18,6 @@ import com.tasteam.domain.search.repository.executor.NativeSqlFragments;
 @Component
 public class MvSinglePassExecutor extends NativeSearchExecutorSupport {
 
-	private final SearchQueryProperties properties;
-
-	public MvSinglePassExecutor(SearchQueryProperties properties) {
-		this.properties = properties;
-	}
-
 	@Override
 	public SearchQueryStrategy strategy() {
 		return SearchQueryStrategy.MV_SINGLE_PASS;
@@ -34,9 +27,8 @@ public class MvSinglePassExecutor extends NativeSearchExecutorSupport {
 	public List<SearchRestaurantCursorRow> execute(String keyword, SearchCursor cursor, int size,
 		Double latitude, Double longitude, Double radiusMeters) {
 		boolean withLocation = latitude != null && longitude != null && radiusMeters != null;
-		int limit = properties.getCandidateLimit() * HYBRID_LIMIT_MULTIPLIER;
 		return runNative(buildSql(withLocation), keyword, cursor, size,
-			latitude, longitude, radiusMeters, limit, limit);
+			latitude, longitude, radiusMeters, 0, 0);
 	}
 
 	private String buildSql(boolean withLocation) {
@@ -44,8 +36,10 @@ public class MvSinglePassExecutor extends NativeSearchExecutorSupport {
 		String distanceExpr = NativeSqlFragments.distanceExprMv(withLocation);
 		String distanceScore = NativeSqlFragments.distanceScoreMv(withLocation);
 
+		// scored CTE: total_score를 한 번만 계산
+		// candidates CTE: 이미 계산된 total_score로 커서 조건 적용 후 LIMIT :size
 		return """
-			WITH candidates AS (
+			WITH scored AS (
 			    SELECT
 			        mv.restaurant_id,
 			        mv.name,
@@ -75,8 +69,27 @@ public class MvSinglePassExecutor extends NativeSearchExecutorSupport {
 				            OR mv.addr_lower LIKE '%' || :kw || '%'
 				            OR mv.category_names @> ARRAY[:kw]::text[]
 				          )
-				    ORDER BY total_score DESC, mv.updated_at DESC, mv.restaurant_id DESC
-				    LIMIT :text_candidate_limit
+				), candidates AS (
+				    SELECT
+				        restaurant_id,
+				        name,
+				        full_address,
+				        name_exact,
+				        name_similarity,
+				        distance_meters,
+				        category_match,
+				        address_match,
+				        updated_at,
+				        total_score
+				    FROM scored
+				    WHERE (
+				        CAST(:cursor_score AS double precision) IS NULL
+				        OR total_score < CAST(:cursor_score AS double precision)
+				        OR (total_score = CAST(:cursor_score AS double precision) AND updated_at < CAST(:cursor_updated_at AS timestamptz))
+				        OR (total_score = CAST(:cursor_score AS double precision) AND updated_at = CAST(:cursor_updated_at AS timestamptz) AND restaurant_id < CAST(:cursor_id AS bigint))
+				    )
+				    ORDER BY total_score DESC, updated_at DESC, restaurant_id DESC
+				    LIMIT :size
 				)
 				SELECT
 				    restaurant_id,
@@ -89,7 +102,7 @@ public class MvSinglePassExecutor extends NativeSearchExecutorSupport {
 				    address_match,
 				    updated_at
 				FROM candidates
-				"""
-			+ CURSOR_WHERE_AND_ORDER;
+				ORDER BY total_score DESC, updated_at DESC, restaurant_id DESC
+				""";
 	}
 }

--- a/app-api/src/main/resources/db/migration/V202603211000__analyze_restaurant_search_mv.sql
+++ b/app-api/src/main/resources/db/migration/V202603211000__analyze_restaurant_search_mv.sql
@@ -1,0 +1,1 @@
+ANALYZE restaurant_search_mv;


### PR DESCRIPTION
- V202603211000: restaurant_search_mv ANALYZE 실행으로 플래너 통계 복구
- FtsMvRankedExecutor: scored CTE에 total_score 미리 계산, ranked CTE에 커서 조건 + LIMIT :size 이동 (중간 LIMIT 600 제거)
- MvSinglePassExecutor: scored → candidates 2단계로 분리, candidates CTE에 커서 조건 + LIMIT :size 이동
- NativeSearchExecutorSupport: runFtsNative의 text_candidate_limit 파라미터 조건부 설정

## 📌 PR 요약

#### Summary
- 

### Issue
- Closes: #

---

## ➕ 추가된 기능
<!--
  새로운 기능을 소개하세요. 무엇이 새롭게 생기는지, 어떤 화면/API가 추가되는지를 기술하고 예시를 덧붙이면 좋습니다.
  예: "관리자 설정에서 `예약 알림` 토글을 추가하여 알림을 켜고 끌 수 있게 함."
-->

1.
2. 

## 🛠️ 수정/변경사항
<!--
  기존 기능 변경, 버그 수정, 리팩토링 등을 나열하세요. 영향 범위도 함께 쓰면 리뷰어가 이해하기 쉽습니다.
  예: "- 예약 API 응답에 `status` 필드를 추가함", "- 기존 실패율 경고 문구 변경"
-->

1.
2.

---

## ✅ 남은 작업

<!--
  아직 완료되지 않은 작업이나 사후에 처리해야 할 항목을 정리하세요. 검토자/다음 작업자에게 힌트가 됩니다.
-->
* [ ] 
