### PR TITLE
feat(search): 검색 전략을 MV 단일 패스로 전환 (#647)

### DIFF
--- a/app-api/src/main/java/com/tasteam/domain/search/repository/executor/nativesql/MvSinglePassExecutor.java
+++ b/app-api/src/main/java/com/tasteam/domain/search/repository/executor/nativesql/MvSinglePassExecutor.java
@@ -14,6 +14,8 @@ import com.tasteam.domain.search.repository.executor.NativeSqlFragments;
  * MV_SINGLE_PASS 전략 실행기.
  * restaurant_search_mv 뷰를 단일 패스로 스캔해 텍스트 조건·스코어링·정렬을 한 번에 처리한다.
  * 별도의 후보 수집 없이 뷰의 인덱스를 직접 활용하므로 쿼리가 단순하다.
+ * <p>
+ * 점수식: name_exact*100 + name_similarity*30 + category_match*15 + address_match*5 + distance*50
  */
 @Component
 public class MvSinglePassExecutor extends NativeSearchExecutorSupport {
@@ -77,6 +79,8 @@ public class MvSinglePassExecutor extends NativeSearchExecutorSupport {
 				        address_match,
 				        (name_exact * 100.0
 				         + name_similarity * 30.0
+				         + category_match * 15.0
+				         + address_match * 5.0
 				         + """
 			+ distanceScore
 			+ """

--- a/app-api/src/main/resources/application.yml
+++ b/app-api/src/main/resources/application.yml
@@ -108,7 +108,7 @@ tasteam:
     api: ${API_DOMAIN:https://api.tasteam.kr}
   search:
     query:
-      strategy: ${TASTEAM_SEARCH_QUERY_STRATEGY:FTS_MV_RANKED}
+      strategy: ${TASTEAM_SEARCH_QUERY_STRATEGY:MV_SINGLE_PASS}
       fallback-strategy: ${TASTEAM_SEARCH_QUERY_FALLBACK_STRATEGY:ONE_STEP}
       candidate-limit: ${TASTEAM_SEARCH_QUERY_CANDIDATE_LIMIT:200}
     mv-refresh:

--- a/module-infra/persistence/src/main/java/com/tasteam/domain/main/repository/MainRestaurantRepository.java
+++ b/module-infra/persistence/src/main/java/com/tasteam/domain/main/repository/MainRestaurantRepository.java
@@ -177,6 +177,7 @@ public interface MainRestaurantRepository extends Repository<Restaurant, Long> {
 		    ST_X(r.location::geometry) as longitude
 		from restaurant r
 		where r.id in (:ids)
+		  and r.location is not null
 		""", nativeQuery = true)
 	List<RestaurantLocationProjection> findLocationsByIds(
 		@Param("ids")


### PR DESCRIPTION
What changed:

- MV_SINGLE_PASS 실행기 점수식에 category_match, address_match 가중치 항목을 추가해 정렬 반영 범위를 확장

- search 기본 전략 기본값을 FTS_MV_RANKED에서 MV_SINGLE_PASS로 변경

- restaurant 위치 조회 SQL에서 location null 체크 조건 추가

Why:

거리 기반 정렬 품질과 실행 경로 일관성을 높이기 위해

단계별 폴백 전략 전환 전 기준 동작을 안정화하려는 목적

Evidence:

git diff --stat

## 📌 PR 요약

#### Summary
- 

### Issue
- Closes: #

---

## ➕ 추가된 기능
<!--
  새로운 기능을 소개하세요. 무엇이 새롭게 생기는지, 어떤 화면/API가 추가되는지를 기술하고 예시를 덧붙이면 좋습니다.
  예: "관리자 설정에서 `예약 알림` 토글을 추가하여 알림을 켜고 끌 수 있게 함."
-->

1.
2. 

## 🛠️ 수정/변경사항
<!--
  기존 기능 변경, 버그 수정, 리팩토링 등을 나열하세요. 영향 범위도 함께 쓰면 리뷰어가 이해하기 쉽습니다.
  예: "- 예약 API 응답에 `status` 필드를 추가함", "- 기존 실패율 경고 문구 변경"
-->

1.
2.

---

## ✅ 남은 작업

<!--
  아직 완료되지 않은 작업이나 사후에 처리해야 할 항목을 정리하세요. 검토자/다음 작업자에게 힌트가 됩니다.
-->
* [ ] 
