### PR TITLE
✨ feat: 사용자 이벤트 ingest 경로를 DB/S3 라우팅 구조로 분리

### DIFF
--- a/app-api/src/main/java/com/tasteam/domain/analytics/ingest/AnalyticsIngestProperties.java
+++ b/app-api/src/main/java/com/tasteam/domain/analytics/ingest/AnalyticsIngestProperties.java
@@ -17,6 +17,7 @@ import lombok.Setter;
 public class AnalyticsIngestProperties {
 
 	private boolean enabled = true;
+	private String route = "s3";
 	private int maxBatchSize = 50;
 	private List<String> allowlist = List.of(
 		"ui.page.viewed",
@@ -37,6 +38,18 @@ public class AnalyticsIngestProperties {
 
 	public int validatedMaxBatchSize() {
 		return Math.max(1, maxBatchSize);
+	}
+
+	public String validatedRoute() {
+		if (!StringUtils.hasText(route)) {
+			return "s3";
+		}
+
+		String normalized = route.trim().toLowerCase();
+		return switch (normalized) {
+			case "db", "s3" -> normalized;
+			default -> "s3";
+		};
 	}
 
 	public Set<String> allowedEventNames() {

--- a/app-api/src/main/java/com/tasteam/domain/analytics/ingest/ClientActivityDbSink.java
+++ b/app-api/src/main/java/com/tasteam/domain/analytics/ingest/ClientActivityDbSink.java
@@ -1,0 +1,27 @@
+package com.tasteam.domain.analytics.ingest;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import com.tasteam.domain.analytics.api.ActivityEvent;
+import com.tasteam.domain.analytics.persistence.UserActivityEventStoreService;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "tasteam.analytics.ingest", name = "route", havingValue = "db")
+public class ClientActivityDbSink implements ClientActivityIngestSink {
+
+	private final UserActivityEventStoreService userActivityEventStoreService;
+
+	@Override
+	public String sinkType() {
+		return "db";
+	}
+
+	@Override
+	public void ingest(ActivityEvent event) {
+		userActivityEventStoreService.store(event);
+	}
+}

--- a/app-api/src/main/java/com/tasteam/domain/analytics/ingest/ClientActivityIngestService.java
+++ b/app-api/src/main/java/com/tasteam/domain/analytics/ingest/ClientActivityIngestService.java
@@ -9,12 +9,10 @@ import java.util.Set;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import com.tasteam.domain.analytics.api.ActivityEvent;
 import com.tasteam.domain.analytics.ingest.dto.request.ClientActivityEventItemRequest;
-import com.tasteam.domain.analytics.persistence.UserActivityEventStoreService;
 import com.tasteam.global.exception.business.BusinessException;
 import com.tasteam.global.exception.code.AnalyticsErrorCode;
 
@@ -29,10 +27,9 @@ public class ClientActivityIngestService {
 
 	private final AnalyticsIngestProperties ingestProperties;
 	private final ClientActivityIngestRateLimiter rateLimiter;
-	private final UserActivityEventStoreService userActivityEventStoreService;
+	private final ClientActivityIngestSink clientActivityIngestSink;
 	private final Clock clock = Clock.systemUTC();
 
-	@Transactional
 	public int ingest(Long memberId, String anonymousId, List<ClientActivityEventItemRequest> events) {
 		validateBatch(events);
 		String normalizedAnonymousId = normalizeAnonymousId(anonymousId);
@@ -45,7 +42,7 @@ public class ClientActivityIngestService {
 		Set<String> allowedEventNames = ingestProperties.allowedEventNames();
 		for (ClientActivityEventItemRequest eventItem : events) {
 			validateAllowlist(allowedEventNames, eventItem.eventName());
-			userActivityEventStoreService.store(toActivityEvent(memberId, normalizedAnonymousId, eventItem));
+			clientActivityIngestSink.ingest(toActivityEvent(memberId, normalizedAnonymousId, eventItem));
 		}
 		return events.size();
 	}

--- a/app-api/src/main/java/com/tasteam/domain/analytics/ingest/ClientActivityIngestSink.java
+++ b/app-api/src/main/java/com/tasteam/domain/analytics/ingest/ClientActivityIngestSink.java
@@ -1,0 +1,10 @@
+package com.tasteam.domain.analytics.ingest;
+
+import com.tasteam.domain.analytics.api.ActivityEvent;
+
+public interface ClientActivityIngestSink {
+
+	String sinkType();
+
+	void ingest(ActivityEvent event);
+}

--- a/app-api/src/main/java/com/tasteam/domain/analytics/ingest/ClientActivityS3Sink.java
+++ b/app-api/src/main/java/com/tasteam/domain/analytics/ingest/ClientActivityS3Sink.java
@@ -1,0 +1,27 @@
+package com.tasteam.domain.analytics.ingest;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import com.tasteam.domain.analytics.api.ActivityEvent;
+import com.tasteam.infra.messagequeue.UserActivityS3SinkPublisher;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "tasteam.analytics.ingest", name = "route", havingValue = "s3", matchIfMissing = true)
+public class ClientActivityS3Sink implements ClientActivityIngestSink {
+
+	private final UserActivityS3SinkPublisher userActivityS3SinkPublisher;
+
+	@Override
+	public String sinkType() {
+		return "s3";
+	}
+
+	@Override
+	public void ingest(ActivityEvent event) {
+		userActivityS3SinkPublisher.sink(event);
+	}
+}

--- a/app-api/src/main/resources/application.yml
+++ b/app-api/src/main/resources/application.yml
@@ -366,6 +366,7 @@ tasteam:
   analytics:
     ingest:
       enabled: ${ANALYTICS_INGEST_ENABLED:true}
+      route: ${ANALYTICS_INGEST_ROUTE:s3}
       max-batch-size: ${ANALYTICS_INGEST_MAX_BATCH_SIZE:50}
       allowlist: ${ANALYTICS_INGEST_ALLOWLIST:ui.page.viewed,ui.page.dwelled,ui.restaurant.clicked,ui.restaurant.viewed,ui.review.write_started,ui.review.submitted,ui.search.executed,ui.group.clicked,ui.group.viewed,ui.favorite.sheet_opened,ui.favorite.updated,ui.event.clicked,ui.tab.changed}
       rate-limit:


### PR DESCRIPTION
## 📌 PR 요약

#### Summary
- 사용자 이벤트 ingest 경로를 DB/S3 라우팅 구조로 분리
