### PR TITLE
🐛 fix: @ConditionalOnBean 순서 의존성 문제 해결

### DIFF
--- a/app-api/src/main/java/com/tasteam/domain/analytics/ingest/ClientActivityDbSink.java
+++ b/app-api/src/main/java/com/tasteam/domain/analytics/ingest/ClientActivityDbSink.java
@@ -1,16 +1,11 @@
 package com.tasteam.domain.analytics.ingest;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.stereotype.Component;
-
 import com.tasteam.domain.analytics.api.ActivityEvent;
 import com.tasteam.domain.analytics.persistence.UserActivityEventStoreService;
 
 import lombok.RequiredArgsConstructor;
 
-@Component
 @RequiredArgsConstructor
-@ConditionalOnProperty(prefix = "tasteam.analytics.ingest", name = "route", havingValue = "db")
 public class ClientActivityDbSink implements ClientActivityIngestSink {
 
 	private final UserActivityEventStoreService userActivityEventStoreService;

--- a/app-api/src/main/java/com/tasteam/domain/analytics/ingest/ClientActivityIngestRouteValidator.java
+++ b/app-api/src/main/java/com/tasteam/domain/analytics/ingest/ClientActivityIngestRouteValidator.java
@@ -1,0 +1,31 @@
+package com.tasteam.domain.analytics.ingest;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import com.tasteam.infra.messagequeue.MessageQueueProperties;
+import com.tasteam.infra.messagequeue.MessageQueueProviderType;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "tasteam.analytics.ingest", name = "enabled", havingValue = "true", matchIfMissing = true)
+public class ClientActivityIngestRouteValidator {
+
+	private final AnalyticsIngestProperties ingestProperties;
+	private final MessageQueueProperties messageQueueProperties;
+
+	@PostConstruct
+	void validate() {
+		if (!"s3".equals(ingestProperties.validatedRoute())) {
+			return;
+		}
+		if (messageQueueProperties.effectiveProviderType() == MessageQueueProviderType.KAFKA) {
+			return;
+		}
+		throw new IllegalStateException(
+			"tasteam.analytics.ingest.route=s3 requires tasteam.message-queue.enabled=true and tasteam.message-queue.provider=kafka");
+	}
+}

--- a/app-api/src/main/java/com/tasteam/domain/analytics/ingest/ClientActivityIngestSinkConfig.java
+++ b/app-api/src/main/java/com/tasteam/domain/analytics/ingest/ClientActivityIngestSinkConfig.java
@@ -1,0 +1,26 @@
+package com.tasteam.domain.analytics.ingest;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.tasteam.domain.analytics.persistence.UserActivityEventStoreService;
+import com.tasteam.infra.messagequeue.UserActivityS3SinkPublisher;
+
+@Configuration
+public class ClientActivityIngestSinkConfig {
+
+	@Bean
+	@ConditionalOnProperty(prefix = "tasteam.analytics.ingest", name = "route", havingValue = "db", matchIfMissing = true)
+	public ClientActivityIngestSink clientActivityDbSink(UserActivityEventStoreService userActivityEventStoreService) {
+		return new ClientActivityDbSink(userActivityEventStoreService);
+	}
+
+	@Bean
+	@ConditionalOnProperty(prefix = "tasteam.analytics.ingest", name = "route", havingValue = "s3")
+	@ConditionalOnProperty(prefix = "tasteam.message-queue", name = "enabled", havingValue = "true")
+	@ConditionalOnProperty(prefix = "tasteam.message-queue", name = "provider", havingValue = "kafka")
+	public ClientActivityIngestSink clientActivityS3Sink(UserActivityS3SinkPublisher userActivityS3SinkPublisher) {
+		return new ClientActivityS3Sink(userActivityS3SinkPublisher);
+	}
+}

--- a/app-api/src/main/java/com/tasteam/domain/analytics/ingest/ClientActivityS3Sink.java
+++ b/app-api/src/main/java/com/tasteam/domain/analytics/ingest/ClientActivityS3Sink.java
@@ -1,18 +1,11 @@
 package com.tasteam.domain.analytics.ingest;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.stereotype.Component;
-
 import com.tasteam.domain.analytics.api.ActivityEvent;
 import com.tasteam.infra.messagequeue.UserActivityS3SinkPublisher;
 
 import lombok.RequiredArgsConstructor;
 
-@Component
 @RequiredArgsConstructor
-@ConditionalOnProperty(prefix = "tasteam.analytics.ingest", name = "route", havingValue = "s3", matchIfMissing = true)
-@ConditionalOnBean(UserActivityS3SinkPublisher.class)
 public class ClientActivityS3Sink implements ClientActivityIngestSink {
 
 	private final UserActivityS3SinkPublisher userActivityS3SinkPublisher;

--- a/app-api/src/main/java/com/tasteam/infra/messagequeue/UserActivityS3SinkPublisher.java
+++ b/app-api/src/main/java/com/tasteam/infra/messagequeue/UserActivityS3SinkPublisher.java
@@ -27,6 +27,7 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 @RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "tasteam.message-queue", name = "enabled", havingValue = "true")
+@ConditionalOnProperty(prefix = "tasteam.message-queue", name = "provider", havingValue = "kafka")
 public class UserActivityS3SinkPublisher implements ActivitySink {
 
 	private final MessageQueueProducer messageQueueProducer;

--- a/app-api/src/main/resources/application.prod.yml
+++ b/app-api/src/main/resources/application.prod.yml
@@ -154,6 +154,9 @@ tasteam:
     bucket: ${ANALYTICS_BUCKET:tasteam-prod-analytics}
     ingest:
       route: s3
+  message-queue:
+    enabled: ${MQ_ENABLED:true}
+    provider: ${MQ_PROVIDER:kafka}
   file:
     cleanup:
       ttl-seconds: ${FILE_CLEANUP_TTL_SECONDS:}

--- a/app-api/src/main/resources/application.stg.yml
+++ b/app-api/src/main/resources/application.stg.yml
@@ -154,6 +154,9 @@ tasteam:
     bucket: ${ANALYTICS_BUCKET:tasteam-stg-analytics}
     ingest:
       route: s3
+  message-queue:
+    enabled: ${MQ_ENABLED:true}
+    provider: ${MQ_PROVIDER:kafka}
   file:
     cleanup:
       ttl-seconds: ${FILE_CLEANUP_TTL_SECONDS:}


### PR DESCRIPTION
## 📌 PR 요약

#### Summary
- @ConditionalOnBean 순서 의존성 문제 해결

### Issue
- Closes: #

---

## ➕ 추가된 기능
<!--
  새로운 기능을 소개하세요. 무엇이 새롭게 생기는지, 어떤 화면/API가 추가되는지를 기술하고 예시를 덧붙이면 좋습니다.
  예: "관리자 설정에서 `예약 알림` 토글을 추가하여 알림을 켜고 끌 수 있게 함."
-->

1.
2. 

## 🛠️ 수정/변경사항
<!--
  기존 기능 변경, 버그 수정, 리팩토링 등을 나열하세요. 영향 범위도 함께 쓰면 리뷰어가 이해하기 쉽습니다.
  예: "- 예약 API 응답에 `status` 필드를 추가함", "- 기존 실패율 경고 문구 변경"
-->

1.
2.

---

## ✅ 남은 작업

<!--
  아직 완료되지 않은 작업이나 사후에 처리해야 할 항목을 정리하세요. 검토자/다음 작업자에게 힌트가 됩니다.
-->
* [ ] 
