### PR TITLE
revert: HEALTH_RETRIES 변경 원복

### DIFF
--- a/.github/workflows/ci-cd-full.yml
+++ b/.github/workflows/ci-cd-full.yml
@@ -251,7 +251,6 @@ jobs:
           ECR_REGISTRY=${ECR_REGISTRY}
           ECR_REPO_BACKEND=${ECR_REPO_BACKEND}
           IMAGE_TAG=${IMAGE_TAG_SHA}
-          HEALTH_RETRIES=75
           EOF
 
           chmod +x deploy.sh stop.sh health.sh traffic.sh switch.sh rollback.sh

--- a/.github/workflows/manual-codedeploy.yml
+++ b/.github/workflows/manual-codedeploy.yml
@@ -140,7 +140,6 @@ jobs:
           ECR_REGISTRY=${ECR_REGISTRY}
           ECR_REPO_BACKEND=${ECR_REPO_BACKEND}
           IMAGE_TAG=${{ steps.source.outputs.source_sha }}
-          HEALTH_RETRIES=75
           EODEPLOY
 
           chmod +x deploy.sh stop.sh health.sh traffic.sh switch.sh rollback.sh


### PR DESCRIPTION
## Summary
- #659 에서 추가한 HEALTH_RETRIES=75 제거
- 근본 원인은 PR #650의 MV 동기 갱신으로 인한 ReadinessState 블로킹이므로 리트라이 증가는 무의미