### PR TITLE
🐛 fix: 사용자 행동 이벤트 publish 경로를 bounded executor로 격리

### DIFF
--- a/app-api/src/main/java/com/tasteam/domain/analytics/ingest/ClientActivityIngestService.java
+++ b/app-api/src/main/java/com/tasteam/domain/analytics/ingest/ClientActivityIngestService.java
@@ -6,8 +6,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
 
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
@@ -32,6 +35,8 @@ public class ClientActivityIngestService {
 	private final ClientActivityIngestRateLimiter rateLimiter;
 	private final UserActivityEventStoreService userActivityEventStoreService;
 	private final ObjectProvider<UserActivityS3SinkPublisher> userActivityS3SinkPublisherProvider;
+	@Qualifier("clientActivityPublishExecutor")
+	private final Executor clientActivityPublishExecutor;
 	private final Clock clock = Clock.systemUTC();
 
 	public int ingest(Long memberId, String anonymousId, List<ClientActivityEventItemRequest> events) {
@@ -48,8 +53,14 @@ public class ClientActivityIngestService {
 			throw new IllegalStateException("UserActivityS3SinkPublisher 빈이 없어 S3 direct ingest를 처리할 수 없습니다.");
 		}
 		List<ActivityEvent> activityEvents = prepareEvents(memberId, anonymousId, events);
-		for (ActivityEvent activityEvent : activityEvents) {
-			userActivityS3SinkPublisher.sink(activityEvent);
+		try {
+			clientActivityPublishExecutor.execute(() -> {
+				for (ActivityEvent activityEvent : activityEvents) {
+					userActivityS3SinkPublisher.sink(activityEvent);
+				}
+			});
+		} catch (RejectedExecutionException ex) {
+			throw new BusinessException(AnalyticsErrorCode.ANALYTICS_INGEST_RATE_LIMIT_EXCEEDED);
 		}
 		return activityEvents.size();
 	}

--- a/app-api/src/main/java/com/tasteam/global/config/AsyncConfig.java
+++ b/app-api/src/main/java/com/tasteam/global/config/AsyncConfig.java
@@ -118,6 +118,28 @@ public class AsyncConfig implements AsyncConfigurer {
 		return executor;
 	}
 
+	@Bean(name = "clientActivityPublishExecutor")
+	public Executor clientActivityPublishExecutor(
+		@Value("${tasteam.analytics.ingest.executor.core-pool-size:2}")
+		int corePoolSize,
+		@Value("${tasteam.analytics.ingest.executor.max-pool-size:8}")
+		int maxPoolSize,
+		@Value("${tasteam.analytics.ingest.executor.queue-capacity:500}")
+		int queueCapacity,
+		@Nullable
+		MeterRegistry meterRegistry) {
+		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+		executor.setCorePoolSize(Math.max(1, corePoolSize));
+		executor.setMaxPoolSize(Math.max(Math.max(1, corePoolSize), maxPoolSize));
+		executor.setQueueCapacity(Math.max(0, queueCapacity));
+		executor.setThreadNamePrefix("client-activity-publish-");
+		if (meterRegistry != null) {
+			executor
+				.setRejectedExecutionHandler(buildRejectedExecutionHandler(meterRegistry, "client_activity_publish"));
+		}
+		return executor;
+	}
+
 	@Override
 	public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
 		return (ex, method, params) -> log.error("비동기 메서드 {}에서 예외 발생: {}", method.getName(),

--- a/app-api/src/test/java/com/tasteam/domain/analytics/ingest/ClientActivityIngestServiceTest.java
+++ b/app-api/src/test/java/com/tasteam/domain/analytics/ingest/ClientActivityIngestServiceTest.java
@@ -12,6 +12,8 @@ import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -30,10 +32,11 @@ import com.tasteam.infra.messagequeue.UserActivityS3SinkPublisher;
 @DisplayName("[유닛](Client) ClientActivityIngestService 단위 테스트")
 class ClientActivityIngestServiceTest {
 
+	private static final Executor DIRECT_EXECUTOR = Runnable::run;
+
 	@Test
 	@DisplayName("인증 사용자 요청이면 허용 이벤트를 동일 저장 경로로 저장한다")
 	void ingest_storesAllowedEventsForAuthenticatedMember() {
-		// given
 		AnalyticsIngestProperties properties = defaultProperties();
 		ClientActivityIngestRateLimiter rateLimiter = mock(ClientActivityIngestRateLimiter.class);
 		UserActivityEventStoreService storeService = mock(UserActivityEventStoreService.class);
@@ -43,15 +46,14 @@ class ClientActivityIngestServiceTest {
 			properties,
 			rateLimiter,
 			storeService,
-			publisherProvider);
+			publisherProvider,
+			DIRECT_EXECUTOR);
 
 		ClientActivityEventItemRequest first = eventItem("evt-1", "ui.restaurant.viewed", null);
 		ClientActivityEventItemRequest second = eventItem("evt-2", "ui.group.viewed", "v3");
 
-		// when
 		int accepted = service.ingest(10L, null, List.of(first, second));
 
-		// then
 		assertThat(accepted).isEqualTo(2);
 		verify(rateLimiter).tryAcquire("member:10");
 		ArgumentCaptor<ActivityEvent> captor = ArgumentCaptor.forClass(ActivityEvent.class);
@@ -67,7 +69,6 @@ class ClientActivityIngestServiceTest {
 	@Test
 	@DisplayName("익명 요청에서 anonymousId가 없으면 수집을 거부한다")
 	void ingest_rejectsAnonymousRequestWhenAnonymousIdMissing() {
-		// given
 		AnalyticsIngestProperties properties = defaultProperties();
 		ClientActivityIngestRateLimiter rateLimiter = mock(ClientActivityIngestRateLimiter.class);
 		UserActivityEventStoreService storeService = mock(UserActivityEventStoreService.class);
@@ -76,10 +77,10 @@ class ClientActivityIngestServiceTest {
 			properties,
 			rateLimiter,
 			storeService,
-			publisherProvider);
+			publisherProvider,
+			DIRECT_EXECUTOR);
 		ClientActivityEventItemRequest item = eventItem("evt-1", "ui.restaurant.viewed", null);
 
-		// when & then
 		assertThatThrownBy(() -> service.ingest(null, "   ", List.of(item)))
 			.isInstanceOf(BusinessException.class)
 			.extracting(ex -> ((BusinessException)ex).getErrorCode())
@@ -90,7 +91,6 @@ class ClientActivityIngestServiceTest {
 	@Test
 	@DisplayName("allowlist에 없는 이벤트가 포함되면 수집을 거부한다")
 	void ingest_rejectsEventWhenNotAllowlisted() {
-		// given
 		AnalyticsIngestProperties properties = defaultProperties();
 		ClientActivityIngestRateLimiter rateLimiter = mock(ClientActivityIngestRateLimiter.class);
 		UserActivityEventStoreService storeService = mock(UserActivityEventStoreService.class);
@@ -100,10 +100,10 @@ class ClientActivityIngestServiceTest {
 			properties,
 			rateLimiter,
 			storeService,
-			publisherProvider);
+			publisherProvider,
+			DIRECT_EXECUTOR);
 		ClientActivityEventItemRequest item = eventItem("evt-1", "ui.unknown.event", null);
 
-		// when & then
 		assertThatThrownBy(() -> service.ingest(null, "anon-1", List.of(item)))
 			.isInstanceOf(BusinessException.class)
 			.extracting(ex -> ((BusinessException)ex).getErrorCode())
@@ -115,7 +115,6 @@ class ClientActivityIngestServiceTest {
 	@Test
 	@DisplayName("배치 크기가 제한을 초과하면 수집을 거부한다")
 	void ingest_rejectsWhenBatchSizeExceeded() {
-		// given
 		AnalyticsIngestProperties properties = defaultProperties();
 		properties.setMaxBatchSize(1);
 		ClientActivityIngestRateLimiter rateLimiter = mock(ClientActivityIngestRateLimiter.class);
@@ -125,9 +124,9 @@ class ClientActivityIngestServiceTest {
 			properties,
 			rateLimiter,
 			storeService,
-			publisherProvider);
+			publisherProvider,
+			DIRECT_EXECUTOR);
 
-		// when & then
 		assertThatThrownBy(() -> service.ingest(10L, null, List.of(
 			eventItem("evt-1", "ui.restaurant.viewed", null),
 			eventItem("evt-2", "ui.review.submitted", null))))
@@ -140,7 +139,6 @@ class ClientActivityIngestServiceTest {
 	@Test
 	@DisplayName("요청 빈도가 제한을 초과하면 수집을 거부한다")
 	void ingest_rejectsWhenRateLimitExceeded() {
-		// given
 		AnalyticsIngestProperties properties = defaultProperties();
 		ClientActivityIngestRateLimiter rateLimiter = mock(ClientActivityIngestRateLimiter.class);
 		UserActivityEventStoreService storeService = mock(UserActivityEventStoreService.class);
@@ -150,10 +148,10 @@ class ClientActivityIngestServiceTest {
 			properties,
 			rateLimiter,
 			storeService,
-			publisherProvider);
+			publisherProvider,
+			DIRECT_EXECUTOR);
 		ClientActivityEventItemRequest item = eventItem("evt-1", "ui.restaurant.viewed", null);
 
-		// when & then
 		assertThatThrownBy(() -> service.ingest(null, "anon-1", List.of(item)))
 			.isInstanceOf(BusinessException.class)
 			.extracting(ex -> ((BusinessException)ex).getErrorCode())
@@ -164,7 +162,6 @@ class ClientActivityIngestServiceTest {
 	@Test
 	@DisplayName("properties에 null 값이 포함되어도 null-safe 정규화 후 저장한다")
 	void ingest_normalizesNullPropertyEntries() {
-		// given
 		AnalyticsIngestProperties properties = defaultProperties();
 		ClientActivityIngestRateLimiter rateLimiter = mock(ClientActivityIngestRateLimiter.class);
 		UserActivityEventStoreService storeService = mock(UserActivityEventStoreService.class);
@@ -174,7 +171,8 @@ class ClientActivityIngestServiceTest {
 			properties,
 			rateLimiter,
 			storeService,
-			publisherProvider);
+			publisherProvider,
+			DIRECT_EXECUTOR);
 
 		Map<String, Object> rawProperties = new LinkedHashMap<>();
 		rawProperties.put("restaurantId", 1L);
@@ -187,10 +185,8 @@ class ClientActivityIngestServiceTest {
 			Instant.parse("2026-02-19T00:00:00Z"),
 			rawProperties);
 
-		// when
 		int accepted = service.ingest(null, "anon-1", List.of(item));
 
-		// then
 		assertThat(accepted).isEqualTo(1);
 		ArgumentCaptor<ActivityEvent> captor = ArgumentCaptor.forClass(ActivityEvent.class);
 		verify(storeService).store(captor.capture());
@@ -215,7 +211,8 @@ class ClientActivityIngestServiceTest {
 			properties,
 			rateLimiter,
 			storeService,
-			publisherProvider);
+			publisherProvider,
+			DIRECT_EXECUTOR);
 
 		int accepted = service.ingestToS3(10L, null, List.of(
 			eventItem("evt-1", "ui.restaurant.viewed", null),
@@ -224,6 +221,34 @@ class ClientActivityIngestServiceTest {
 		assertThat(accepted).isEqualTo(2);
 		verify(publisher, times(2)).sink(org.mockito.ArgumentMatchers.any(ActivityEvent.class));
 		verifyNoInteractions(storeService);
+	}
+
+	@Test
+	@DisplayName("S3 direct ingest 위임 큐가 포화되면 fast-fail 한다")
+	void ingestToS3_rejectsWhenPublishExecutorIsSaturated() {
+		AnalyticsIngestProperties properties = defaultProperties();
+		ClientActivityIngestRateLimiter rateLimiter = mock(ClientActivityIngestRateLimiter.class);
+		UserActivityEventStoreService storeService = mock(UserActivityEventStoreService.class);
+		UserActivityS3SinkPublisher publisher = mock(UserActivityS3SinkPublisher.class);
+		ObjectProvider<UserActivityS3SinkPublisher> publisherProvider = mock(ObjectProvider.class);
+		Executor rejectingExecutor = command -> {
+			throw new RejectedExecutionException("queue full");
+		};
+		when(rateLimiter.tryAcquire("member:10")).thenReturn(true);
+		when(publisherProvider.getIfAvailable()).thenReturn(publisher);
+		ClientActivityIngestService service = new ClientActivityIngestService(
+			properties,
+			rateLimiter,
+			storeService,
+			publisherProvider,
+			rejectingExecutor);
+
+		assertThatThrownBy(() -> service.ingestToS3(10L, null, List.of(
+			eventItem("evt-1", "ui.restaurant.viewed", null))))
+			.isInstanceOf(BusinessException.class)
+			.extracting(ex -> ((BusinessException)ex).getErrorCode())
+			.isEqualTo(AnalyticsErrorCode.ANALYTICS_INGEST_RATE_LIMIT_EXCEEDED.name());
+		verifyNoInteractions(storeService, publisher);
 	}
 
 	private AnalyticsIngestProperties defaultProperties() {

--- a/app-api/src/test/java/com/tasteam/infra/messagequeue/KafkaMessageQueueProducerTest.java
+++ b/app-api/src/test/java/com/tasteam/infra/messagequeue/KafkaMessageQueueProducerTest.java
@@ -1,0 +1,72 @@
+package com.tasteam.infra.messagequeue;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tasteam.config.annotation.UnitTest;
+import com.tasteam.infra.messagequeue.exception.MessageQueuePublishException;
+import com.tasteam.infra.messagequeue.serialization.QueueMessageSerializer;
+
+@UnitTest
+@DisplayName("[유닛](Message) KafkaMessageQueueProducer 테스트")
+class KafkaMessageQueueProducerTest {
+
+	@Test
+	@DisplayName("Kafka 전송 요청이 접수되면 ack를 기다리지 않고 반환한다")
+	void publish_returnsWithoutWaitingForBrokerAck() throws Exception {
+		@SuppressWarnings("unchecked") KafkaTemplate<String, String> kafkaTemplate = mock(KafkaTemplate.class);
+		QueueMessageSerializer serializer = mock(QueueMessageSerializer.class);
+		QueueMessage message = new QueueMessage(
+			"evt.test",
+			"k1",
+			new ObjectMapper().readTree("{\"ok\":true}"),
+			Map.of("eventType", "TEST"),
+			Instant.now(),
+			"msg-1");
+		CompletableFuture<SendResult<String, String>> pendingFuture = new CompletableFuture<>();
+		when(serializer.serialize(message)).thenReturn("{\"envelope\":true}");
+		when(kafkaTemplate.send("evt.test", "k1", "{\"envelope\":true}")).thenReturn(pendingFuture);
+
+		KafkaMessageQueueProperties properties = new KafkaMessageQueueProperties();
+		KafkaMessageQueueProducer producer = new KafkaMessageQueueProducer(kafkaTemplate, properties, serializer);
+
+		assertThatCode(() -> producer.publish(message)).doesNotThrowAnyException();
+	}
+
+	@Test
+	@DisplayName("Kafka 전송 요청 자체가 실패하면 MessageQueuePublishException으로 래핑한다")
+	void publish_wrapsImmediateSendFailure() throws Exception {
+		@SuppressWarnings("unchecked") KafkaTemplate<String, String> kafkaTemplate = mock(KafkaTemplate.class);
+		QueueMessageSerializer serializer = mock(QueueMessageSerializer.class);
+		QueueMessage message = new QueueMessage(
+			"evt.test",
+			"k1",
+			new ObjectMapper().readTree("{\"ok\":false}"),
+			Map.of(),
+			Instant.now(),
+			"msg-2");
+		when(serializer.serialize(message)).thenReturn("{\"envelope\":false}");
+		when(kafkaTemplate.send("evt.test", "k1", "{\"envelope\":false}"))
+			.thenThrow(new RuntimeException("broker down"));
+
+		KafkaMessageQueueProperties properties = new KafkaMessageQueueProperties();
+		KafkaMessageQueueProducer producer = new KafkaMessageQueueProducer(kafkaTemplate, properties, serializer);
+
+		assertThatThrownBy(() -> producer.publish(message))
+			.isInstanceOf(MessageQueuePublishException.class)
+			.hasMessageContaining("topic=evt.test")
+			.hasMessageContaining("messageId=msg-2");
+	}
+}

--- a/module-infra/messaging/src/main/java/com/tasteam/infra/messagequeue/KafkaMessageQueueProducer.java
+++ b/module-infra/messaging/src/main/java/com/tasteam/infra/messagequeue/KafkaMessageQueueProducer.java
@@ -1,10 +1,7 @@
 package com.tasteam.infra.messagequeue;
 
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
 
 import com.tasteam.infra.messagequeue.exception.MessageQueuePublishException;
 import com.tasteam.infra.messagequeue.serialization.QueueMessageSerializer;
@@ -24,21 +21,28 @@ public class KafkaMessageQueueProducer implements MessageQueueProducer {
 	public void publish(QueueMessage message) {
 		String serialized = serializer.serialize(message);
 		try {
-			kafkaTemplate.executeInTransaction(ops -> {
-				try {
-					return ops.send(message.topic(), message.key(), serialized)
-						.get(kafkaProperties.getProducer().getSendTimeoutMillis(), TimeUnit.MILLISECONDS);
-				} catch (InterruptedException e) {
-					Thread.currentThread().interrupt();
-					throw new RuntimeException(e);
-				} catch (ExecutionException | TimeoutException e) {
-					throw new RuntimeException(e);
-				}
-			});
-			log.debug("Kafka publish 성공. topic={}, messageId={}", message.topic(), message.messageId());
+			kafkaTemplate.send(message.topic(), message.key(), serialized)
+				.whenComplete((result, ex) -> handlePublishResult(message, result, ex));
+			log.debug("Kafka publish 요청 전송. topic={}, messageId={}", message.topic(), message.messageId());
 		} catch (Exception ex) {
 			log.error("Kafka publish 실패. topic={}, messageId={}", message.topic(), message.messageId(), ex);
 			throw new MessageQueuePublishException(message.topic(), message.messageId(), ex);
 		}
+	}
+
+	private void handlePublishResult(QueueMessage message, SendResult<String, String> result, Throwable ex) {
+		if (ex != null) {
+			log.error("Kafka publish 비동기 실패. topic={}, messageId={}", message.topic(), message.messageId(), ex);
+			return;
+		}
+		if (result != null && result.getRecordMetadata() != null) {
+			log.debug("Kafka publish 성공. topic={}, partition={}, offset={}, messageId={}",
+				message.topic(),
+				result.getRecordMetadata().partition(),
+				result.getRecordMetadata().offset(),
+				message.messageId());
+			return;
+		}
+		log.debug("Kafka publish 성공. topic={}, messageId={}", message.topic(), message.messageId());
 	}
 }


### PR DESCRIPTION
## 📌 PR 요약

#### Summary
- 사용자 행동 이벤트 publish 경로를 bounded executor로 격리
