### PR TITLE
fix: kustomize newTag YAML number 파싱 방지

### DIFF
--- a/.github/workflows/backend-cd-v3.yml
+++ b/.github/workflows/backend-cd-v3.yml
@@ -102,7 +102,7 @@ jobs:
         run: |
           cd v3-k8s/manifests/app/overlays/prod
 
-          sed -i "/name: SPRING_BOOT_IMAGE/{n;s|newName:.*|newName: ${ECR_REGISTRY}/${ECR_REPO}|;n;s|newTag:.*|newTag: ${NEW_TAG}|}" kustomization.yaml
+          sed -i "/name: SPRING_BOOT_IMAGE/{n;s|newName:.*|newName: ${ECR_REGISTRY}/${ECR_REPO}|;n;s|newTag:.*|newTag: \"${NEW_TAG}\"|}" kustomization.yaml
 
           echo "Updated image tag to: ${NEW_TAG}"
           cat kustomization.yaml


### PR DESCRIPTION
## Summary
- CD 워크플로우에서 kustomization.yaml의 `newTag` 값에 따옴표를 추가
- 커밋 해시가 숫자로만 구성될 경우(예: `7332910`) YAML이 number로 파싱 → `kustomize build` 실패 → ArgoCD sync error 발생하는 문제 수정

## 원인
- `sed`로 `newTag: ${NEW_TAG}`를 따옴표 없이 기록
- SHA 앞 7자리가 `0-9`로만 구성되면 YAML spec상 integer로 해석됨
- Go의 `json.Unmarshal`이 `number → string` 변환을 거부 → kustomize build 실패

## 변경 사항
```diff
- s|newTag:.*|newTag: ${NEW_TAG}|
+ s|newTag:.*|newTag: "${NEW_TAG}"|
```

## Test plan
- [ ] 숫자로만 구성된 태그(예: `1234567`)로 kustomize build 정상 동작 확인
- [ ] 영문자 포함 태그(예: `abc1234`)로 기존 동작 유지 확인